### PR TITLE
Moved "A cautionary tale" to the right.

### DIFF
--- a/slides/01_intro/slides02-intro-goals.tex
+++ b/slides/01_intro/slides02-intro-goals.tex
@@ -335,7 +335,7 @@ $\leadsto$ Insights help to identify flaws (in data or model), which can be corr
 	        \includegraphics[width=0.48\textwidth]{figure/landscape_green.jpg}}
 	\end{column}
 	\begin{column}{0.56\textwidth}
-    A cautionary tale (never actually happened):
+    \hspace{0.1cm} A cautionary tale (never actually happened):
 	\begin{itemize}
 	    \item Train a neural network to detect tanks
         \item Good fit on training data


### PR DESCRIPTION
Moved the block starting with "A cautionary tale" a bit to the right so that there is enough space between the figure and the text.