### PR TITLE
Apply `\lectureref` fix

### DIFF
--- a/style/lmu-lecture.sty
+++ b/style/lmu-lecture.sty
@@ -172,7 +172,7 @@
 \setbeamertemplate{items}[ball]
 \setbeamerfont{itemize/enumerate subbody}{size=\normalsize}
 \setbeamerfont{itemize/enumerate subsubbody}{size=\normalsize}
-  
+
 % ------------------------------------------------------------------------
 % Frame title: lecture
 
@@ -206,8 +206,13 @@
   color(0pt)=(black);%
   color(1.0\paperwidth)=(structure!50!black)}
 
+% \@setref sometimes (depending on version) calls \@firstoftwo#1\@empty\@empty\@empty\null, sometimes \@firstoftwo#1\null
+% in the former case, we would prefer to use \@firstoffive
+% We therefore define a macro that returns its first argument and drops all tokens until it finds '\null'.
+\long\def\@eatnull#1#2\null{#1}
+
 % redefine \ref (it has been redefined somewhere by the beamerclass)
-\def\lectureref#1{\expandafter\@setref\csname r@#1\endcsname\@firstoftwo{#1}}
+\def\lectureref#1{\expandafter\@setref\csname r@#1\endcsname\@eatnull{#1}}
 
 % counter for framenumber for current lecture
 \newcounter{lectureframenumber}
@@ -258,7 +263,7 @@
 % Add margin with red talking head section
 % width: 15.8cm
 %\logo{\color{red}\rule{2.7cm}{2.8cm}}
-%\setbeamersize{text margin left=2mm,text margin right=28mm} 
+%\setbeamersize{text margin left=2mm,text margin right=28mm}
 
 
 


### PR DESCRIPTION
Fixes an issue that only appeared in more recent TeX Live versions (e.g. 2023 rather than 2020 or so).

This has previously been fixes in i2ml, see https://github.com/slds-lmu/lecture_i2ml/pull/1108 and fixes were applied to lecture_sl/lecture_advml, but I forgot about iml, sorry 🥴 