### PR TITLE
iterating on Functional decomposition exercise (06)

### DIFF
--- a/exercises/functional_decompositions_interactions/ex_tex/hw_5_1_h-statistic_categorical.tex
+++ b/exercises/functional_decompositions_interactions/ex_tex/hw_5_1_h-statistic_categorical.tex
@@ -1,7 +1,7 @@
 \aufgabe{Friedman's H-statistic for categorical features}{ \label{ex:h-statistic_categorical}
 
 As in exercise \ref{ex:fANOVA_categorical}, we consider categorical features, and want to calculate the H-statistic for such a case.
-Calculating the H-statistic for categorical features or targets basically works the same as for the fANOVA in exercise \ref{ex:fANOVA_categorical}.
+Calculating the H-statistic for categorical features basically works the same as for the fANOVA in exercise \ref{ex:fANOVA_categorical}.
 
 We are given two independent categorical random variables, which are Bernoulli distributed:
 $$
@@ -19,13 +19,13 @@ Your task is to compute the H-statistic $H_{1,2}$ for measuring the interaction 
     \item Compute all partial dependence (PD) functions:
     \begin{align*}
         \fh_{\emptyset,PD} = \mu
-        & = \E[f(X_1, X_2)], \\
-        \fh_{1,PD}(x_1 )
-        & = \E_{X_2}[\fh(x_1, X_2)] = \tfrac12 \sum_{j=1}^2 f(x_1, x_2^{(j)}), \\
+        & = \E[\fh(X_1, X_2)], \\
+        \fh_{1,PD}(x_1)
+        & = \E_{X_2}[\fh(x_1, X_2)] = \tfrac12 \sum_{j=1}^2 \fh(x_1, x_2^{(j)}), \\
         \fh_{2, PD}(x_2)
         & = \E_{X_1}[\fh(X_1, x_2)].
     \end{align*}
-    (The last PD function is of course $\fh_{12,PD} (x_1,x_2) = f(x_1,x_2)$.)
+    (The last PD function is of course $\fh_{12,PD} (x_1,x_2) = \fh(x_1,x_2)$.)
     
     When computing the PD-functions, you can simply write out the four function values explicitly.
     
@@ -69,9 +69,11 @@ Your task is to compute the H-statistic $H_{1,2}$ for measuring the interaction 
                 \fh( X_1, X_2 )
                 \Bigr]
             }
-        } \\.  
+        }
     \end{aligned}
     \]
+
+    \textit{Note:} The first two formulas (using raw sums) are convenient for computation on finite samples or discrete distributions; the third formula (using variances) is most useful for theoretical analysis and proofs.
 
     \item \textbf{Bonus:} Prove that the three formulas given above for calculating the H-statistic are equivalent in general, that is, for an arbitrary $p$-dimensional function $\fh$ and arbitrary interacting set of features $S$.
     

--- a/exercises/functional_decompositions_interactions/ex_tex/hw_5_2_fANOVA_categorical.tex
+++ b/exercises/functional_decompositions_interactions/ex_tex/hw_5_2_fANOVA_categorical.tex
@@ -1,27 +1,37 @@
 \aufgabe{Functional ANOVA for categorical features}{ \label{ex:fANOVA_categorical}
 
-In this exercise, your task is to calculate the standard fANOVA decomposition (as introduced in the lecture) for an example with categorical features.
+In this exercise, your task is to calculate the standard fANOVA decomposition (as introduced in the lecture) for an example with discrete numerical features that we treat as categorical.
 
 This means that when calculating a PD-function $f_{S,PD}(\xv_S)$ as well as the corresponding fANOVA component $g_S(\xv_S)$, whenever these depend on categorical features contained in $S$, we calculate the value of the PD-function and the components at every category instead of at grid values.
 When integrating over features in the process of computing PD-functions, if some of these features are categorical, we can calculate the average over the data points in the same fashion as for numerical features.
 
-In case of a categorical target that cannot be transformed onto a numerical scale, the average or expected prediction (for computing expected values or marginal expectations) is equal to the mode, i.e. to the category with the highest probability or with the highest number of samples resp.
+\textit{Remark:} In case of a categorical target that cannot be transformed onto a numerical scale, the average or expected prediction (for computing expected values or marginal expectations) is equal to the mode, i.e. to the category with the highest probability or with the highest number of samples resp.
+Note that this remark does not apply to the present exercise, where the target is numerical.
 
-In this exercise, we are given three random variables as features, all of which can take at most 3 different categories as values:
-$$
+In this exercise, we are given three random variables as features, all of which take exactly 3 different values:
+\[
 X_j \in\{-1, 0, 1\},\quad \text{for } j=1,2,3.
-$$
+\]
+Note that the features are discrete numerical (not truly categorical), but since they take finitely many values, we can compute the fANOVA exactly by summing over all values.
+
 We further assume that the features are independent and all uniformly distributed. We then consider the prediction function
 \[
 \fh(x_1,x_2,x_3) = 4x_1 + 2\,x_2x_3 - 4
 \]
+
+Recall the recursive fANOVA algorithm: the components are computed as
+\[
+g_S(\xv_S) = f_{S,PD}(\xv_S) - \sum_{V \subsetneq S} g_V(\xv_V),
+\]
+where $\xv_S = (x_j)_{j \in S}$ denotes the subvector of features indexed by the set $S$.
+
 \begin{enumerate}[a)]
-  \item Compute all fANOVA components using the algorithm from the lecture:
+  \item Compute all fANOVA components using the algorithm above:
         \[
             g_\emptyset, \quad
             g_1, g_2, g_3, \quad
-            g_{12}, g_{13}, g_{23}, \quad
-            g_{123}.
+            g_{1,2}, g_{1,3}, g_{2,3}, \quad
+            g_{1,2,3}.
         \]
   \item Verify the pairwise orthogonality of all the components, i.e., check that
         $$
@@ -31,6 +41,9 @@ We further assume that the features are independent and all uniformly distribute
         whenever $U \neq V$.
 
         \textit{Hint:} Most of the fANOVA components are 0 in this example, which means that you only need to check the orthogonality condition for the remaining nonzero components.
+
+  \item Now consider the same prediction function $\fh(x_1,x_2,x_3) = 4x_1 + 2\,x_2x_3 - 4$, but assume the features are uniformly distributed on $\{0, \tfrac12, 1\}$ instead of $\{-1,0,1\}$.
+        Does the fANOVA decomposition change? If so, compute the new components $g_\emptyset$, $g_1$, $g_2$, $g_3$, and $g_{2,3}$.
 \end{enumerate}
 
 }

--- a/exercises/functional_decompositions_interactions/ex_tex/hw_5_3_fANOVA_implementation_from_scratch.tex
+++ b/exercises/functional_decompositions_interactions/ex_tex/hw_5_3_fANOVA_implementation_from_scratch.tex
@@ -21,7 +21,7 @@ In case you did not finish that other exercise back then, the files \textit{XX.p
     Extend the \texttt{pdp} function to a new function \texttt{pd\_func}, which can compute an arbitrary PD-function of arbitrary dimension.
     This means that the parameters change as follows:
     \begin{itemize}
-        \item Instead of a single feature index \texttt{j}, we know consider an ordered list of indices \texttt{S}, which must be a subset of $\{1, \dots, p\}$, but can also be empty (for the intercept case),
+        \item Instead of a single feature index \texttt{j}, we now consider an ordered list of indices \texttt{S}, which must be a subset of $\{1, \dots, p\}$, but can also be empty (for the intercept case),
         \item the \texttt{grid} is an $\texttt{length(S)} \times g$ matrix, in which the $j$-th row contains all grid values for the $j$-th feature in $S$,
         \item the output of \texttt{pd\_func(model, X, S, grid)} is a $\underbrace{g \times g \times \dots \times g}_{|S| \text{ many dimensions}}$ matrix / tensor, containing the values of the PD-function at all grid points.
     \end{itemize}
@@ -52,7 +52,7 @@ In case you did not finish that other exercise back then, the files \textit{XX.p
     \begin{itemize}
         \item Extend your functions such that if the \texttt{grid} parameter is not given, they can construct a grid from the data (e.g., via quantiles or equidistantly) automatically.
         \item Extend your functions to allow for a different number of grid values for different features.
-        \item Implement a more efficient algorithm for calculating all PD-function of a given model: Each PD-function can be obtained as the one-dimensional integral / expectation of a PD-function one order higher, therefore compute the PD-functions hierarchically starting from the highest order and going to the lowest (using dynamical programming), and then compute the fANOVA components starting from the lowest order, and using the PD-functions computed before.
+        \item Implement a more efficient algorithm for calculating all PD-functions of a given model: Each PD-function can be obtained as the one-dimensional integral / expectation of a PD-function one order higher, therefore compute the PD-functions hierarchically starting from the highest order and going to the lowest (using dynamic programming), and then compute the fANOVA components starting from the lowest order, and using the PD-functions computed before.
     \end{itemize}
     
         

--- a/exercises/functional_decompositions_interactions/ex_tex/hw_5_4_h-statistic_vs_Sobol_index_theory.tex
+++ b/exercises/functional_decompositions_interactions/ex_tex/hw_5_4_h-statistic_vs_Sobol_index_theory.tex
@@ -1,6 +1,7 @@
 \aufgabe{Comparing H-statistic and Sobol indices}{
 \label{ex:H_vs_Sobol_comparison_theory}
 
+Assume that all features are mutually independent.
 What is the (mathematical) relationship between Friedman's H-statistic of a specific interaction and the Sobol index for this interaction?
 You can first look at the cases of two-way and three-way interactions discussed in the lecture, and then at the general case.
 

--- a/exercises/functional_decompositions_interactions/ex_tex/hw_5_5_h-statistic_vs_Sobol_index_example.tex
+++ b/exercises/functional_decompositions_interactions/ex_tex/hw_5_5_h-statistic_vs_Sobol_index_example.tex
@@ -81,7 +81,7 @@ x,y\sim U(0,1)\ \text{independent},
 \]
 we have two measures of interaction strength:
 
-1. Froedman’s $H$‐statistic (see Exercise~\ref{ex:H_param}), which for this model
+1. Friedman’s $H$‐statistic (see Exercise~\ref{ex:H_param}), which for this model
    can be shown to satisfy
    \[
    H(\gamma) = \frac{|\gamma|}{\sqrt{\gamma^2 + 6}}.

--- a/exercises/functional_decompositions_interactions/ex_tex/hw_sol_5_1_h-statistic_categorical.tex
+++ b/exercises/functional_decompositions_interactions/ex_tex/hw_sol_5_1_h-statistic_categorical.tex
@@ -4,7 +4,7 @@
 
 \item
 
-First we evaluate $f$ on all points:
+First we evaluate $\fh$ on all points:
 \[
 \begin{array}{c|cc}
       & x_2=0 & x_2=1 \\ \hline
@@ -30,7 +30,7 @@ The PD-functions have the means
 
 \begin{align*}
 & \E[\fh_{1, PD}(X_1)] = \tfrac{1}{2} (3.5 + 6.5) = 5 = \mu, \\
-& \E[\fh_{2, PD}(X_2)] = \tfrac{1}{2} (3.+ 7) = 5 = \mu,
+& \E[\fh_{2, PD}(X_2)] = \tfrac{1}{2} (3 + 7) = 5 = \mu,
 \end{align*}
 
 as expected.
@@ -55,13 +55,13 @@ H_{1,2}^2
 & =
 \frac{\displaystyle
     \sum_{i,j = 1}^2 \bigl(
-    \hat f_{12,PD}(x_1^{(i)},x_2^{(j)})-
-    \hat f_{1,PD}(x_1^{(i)})-
-    \hat f_{2,PD}(x_2^{(j)})+\mu
+    \fh_{12,PD}(x_1^{(i)},x_2^{(j)})-
+    \fh_{1,PD}(x_1^{(i)})-
+    \fh_{2,PD}(x_2^{(j)})+\mu
     \bigr)^2
 }{\displaystyle
     \sum_{i,j = 1}^2 \bigl(
-    \hat f(x_1^{(i)},x_2^{(j)})-\mu
+    \fh(x_1^{(i)},x_2^{(j)})-\mu
     \bigr)^2
 } \\
 & = 
@@ -146,20 +146,18 @@ For the denominator, we have a very similar, but easier, calculation:
 \end{align*}
 These calculations show that the two versions of the formula, the one with the uncentered PD-functions and the one with the centered PD-functions, are equal.
 
-If we instead have an empirical distribution from an empirical dataset, or a finite probability distribution, we can replace the variance with the empirical variance and obtain the other two formulae given in the exercise.
-For example, for the uncentered version we have in this case
-
-$$
-\var \Bigl[ \fh_{12,PD}(x_1, x_2) - \fh_{1,PD}(x_1) - \fh_{2,PD}(x_2) \Bigr]
-= \sum_{i = 1}^n \bigl(
-    \fh_{12,PD}(x_1^{(i)},x_2^{(i)})-
+If we instead have an empirical distribution from an empirical dataset, or a finite probability distribution, we can replace the variance with the empirical variance. Since the $H^2$-statistic is a ratio of two variances, the $\tfrac{1}{n}$ factor appears in both numerator and denominator and cancels. This yields the raw-sum formulae given in the exercise.
+For example, for the uncentered version we have
+\[
+\var \Bigl[ \fh_{12,PD}(X_1, X_2) - \fh_{1,PD}(X_1) - \fh_{2,PD}(X_2) \Bigr]
+= \frac{1}{n} \sum_{i,j = 1}^n \bigl(
+    \fh_{12,PD}(x_1^{(i)},x_2^{(j)})-
     \fh_{1,PD}(x_1^{(i)})-
-    \fh_{2,PD}(x_2^{(i)})
+    \fh_{2,PD}(x_2^{(j)})
     + \mu
-\bigr)^2
-$$
-
-Analogous for all the other terms.
+\bigr)^2,
+\]
+where we sum over all pairs $(x_1^{(i)}, x_2^{(j)})$ with independent indices $i,j$. Analogous for the denominator.
 
 In the same way, one can prove that the centered and uncentered versions are equivalent for higher interaction orders.
 For example, for interaction order 3, we have

--- a/exercises/functional_decompositions_interactions/ex_tex/hw_sol_5_2_fANOVA_categorical.tex
+++ b/exercises/functional_decompositions_interactions/ex_tex/hw_sol_5_2_fANOVA_categorical.tex
@@ -48,20 +48,22 @@ g_3(x_3)=0.
 \[
 g_{1,2}(x_1, x_2)
 = \E[ \fh(x_1, x_2, X_3) ] - g_1(x_1) - g_2(x_2) - g_\emptyset
-= \E[ 4 x_1 + 2 x_2 X_3 - 4 ] - 4 x_1 + 4
+= \E[ 4 x_1 + 2 x_2 X_3 - 4 ] - 4 x_1 - 0 + 4
 = 4 x_1 + 2 x_2 \underbrace{\E[ X_3 ]}_{=0} - 4 - 4 x_1 +4
-= 0.
+= 0,
 \]
-Again using that $\fh$ is symmetric in $x_2$ and $x_3$, we receive exactly the same result for $S=\{1,3\}$, so $g_{13}(x_1, x_3) = 0$.
+where we used $g_2(x_2) = 0$ from Step~2.
+Again using that $\fh$ is symmetric in $x_2$ and $x_3$, we receive exactly the same result for $S=\{1,3\}$, so $g_{1,3}(x_1, x_3) = 0$.
 
 For $\{2,3\}$, we get:
 \[
 g_{2,3}(x_2,x_3)
 = \E[ \fh(X_1, x_2, x_3) ] - g_2(x_2) - g_3(x_3) - g_\emptyset
-= \E[ 4 X_1 + 2 x_2 x_3 - 4 ] + 4
+= \E[ 4 X_1 + 2 x_2 x_3 - 4 ] - 0 - 0 + 4
 = 4 \underbrace{\E[ X_1 ]}_{=0} + 2 x_2 x_3 - 4 +4
-= 2 x_2 x_3.
+= 2 x_2 x_3,
 \]
+where we used $g_2(x_2) = g_3(x_3) = 0$ from Step~2.
 
 \textbf{Step 4. Third‐order term.}
 \[
@@ -104,6 +106,41 @@ For the remaining components, we have three possibilities we need to check:
     = 8 \ \E [X_1] \ \E [X_2] \ \E [X_3] = 0,
 \end{align*}
 again using independence and centering. This shows the desired orthogonality.
+
+\item
+\textbf{New domain $\{0, \tfrac12, 1\}$.}
+
+Yes, the decomposition changes because $\E[X_j] = \tfrac12 \neq 0$.
+
+\textbf{Step 1.}
+\[
+g_\emptyset = \E[\fh] = 4 \cdot \tfrac12 + 2 \cdot \tfrac12 \cdot \tfrac12 - 4 = 2 + \tfrac12 - 4 = -\tfrac32.
+\]
+
+\textbf{Step 2. First-order terms.}
+\[
+g_1(x_1) = \E[\fh(x_1, X_2, X_3)] - g_\emptyset
+= 4x_1 + 2 \cdot \tfrac12 \cdot \tfrac12 - 4 + \tfrac32
+= 4x_1 - 2.
+\]
+Unlike before, the first-order terms for $x_2$ and $x_3$ are now nonzero:
+\[
+g_2(x_2) = \E[\fh(X_1, x_2, X_3)] - g_\emptyset
+= 2 + x_2 - 4 + \tfrac32
+= x_2 - \tfrac12.
+\]
+By symmetry of $\fh$ in $x_2, x_3$: $g_3(x_3) = x_3 - \tfrac12$.
+
+\textbf{Step 3. Second-order interaction.}
+\begin{align*}
+g_{2,3}(x_2,x_3)
+&= \E[\fh(X_1, x_2, x_3)] - g_2(x_2) - g_3(x_3) - g_\emptyset \\
+&= 2 + 2x_2 x_3 - 4 - (x_2 - \tfrac12) - (x_3 - \tfrac12) + \tfrac32 \\
+&= 2x_2 x_3 - x_2 - x_3 + \tfrac12.
+\end{align*}
+All other second- and third-order terms are still zero (by the same arguments as before).
+
+\textbf{Summary.} Compared to the original decomposition on $\{-1,0,1\}$, the shift in domain causes the nonzero means $\E[X_j] = \tfrac12$ to ``leak'' into the main effects, and the interaction component $g_{2,3}$ now also absorbs additional terms. This illustrates that the fANOVA decomposition depends on the feature distribution, not just on the algebraic form of $\fh$.
 
 \end{enumerate}
 One can also see in this exercise, that

--- a/exercises/functional_decompositions_interactions/ex_tex/hw_sol_5_4_h-statistic_vs_Sobol_index_theory.tex
+++ b/exercises/functional_decompositions_interactions/ex_tex/hw_sol_5_4_h-statistic_vs_Sobol_index_theory.tex
@@ -34,6 +34,7 @@ H_{j,k}^2 = \frac{\var[\fh_{j,k,PD}^c(X_j, X_k) - \fh_{j,PD}^c(X_j) - \fh_{k,PD}
 \fh_{j,PD}^c(X_j) &= g_j(X_j) \\
 \fh_{k,PD}^c(X_k) &= g_k(X_k)
 \end{align*}
+Here, centering removes $g_\emptyset$: since $\fh_{j,PD}^c(x_j) = \fh_{j,PD}(x_j) - \mu$ and $\fh_{j,PD}(x_j) = g_\emptyset + g_j(x_j)$ (all higher-order terms vanish when marginalizing over independent features with the vanishing condition), we get $\fh_{j,PD}^c(x_j) = g_j(x_j)$.
 
 \textbf{Step 2 - Interaction residual simplifies:} The numerator of $H_{j,k}^2$ becomes:
 \begin{align*}


### PR DESCRIPTION

| Description | File(s) Modified |
|-------------|-----------------|
| Removed spurious "or targets" from introductory sentence | `hw_5_1_h-statistic_categorical.tex` |
| Fixed `f` → `\fh` (3 occurrences in PD-function definitions) to use consistent notation | `hw_5_1_h-statistic_categorical.tex` |
| Removed stray `\.` after closing `}}` in the variance formula | `hw_5_1_h-statistic_categorical.tex` |
| Added note explaining when to use each of the three H-statistic formulas (raw sums vs variances) | `hw_5_1_h-statistic_categorical.tex` |
| Changed introductory sentence from "categorical features" to "discrete numerical features that we treat as categorical" | `hw_5_2_fANOVA_categorical.tex` |
| Wrapped remark about categorical targets in `\textit{Remark:}` and added "Note that this remark does not apply to the present exercise" | `hw_5_2_fANOVA_categorical.tex` |
| Changed "at most 3 different categories" → "exactly 3 different values" | `hw_5_2_fANOVA_categorical.tex` |
| Added note that features are discrete numerical (not truly categorical) but fANOVA is exact by summing | `hw_5_2_fANOVA_categorical.tex` |
| Added the recursive fANOVA formula $g_S = f_{S,PD} - \sum_{V \subsetneq S} g_V$ with subvector definition | `hw_5_2_fANOVA_categorical.tex` |
| Changed comma-less subscripts to comma notation: $g_{12}$ → $g_{1,2}$, $g_{13}$ → $g_{1,3}$, etc. | `hw_5_2_fANOVA_categorical.tex` |
| Added new part c): fANOVA on $\{0, \tfrac12, 1\}$ domain instead of $\{-1,0,1\}$ | `hw_5_2_fANOVA_categorical.tex` |
| Changed `$$...$$` to `\[...\]` for display math consistency | `hw_5_2_fANOVA_categorical.tex` |
| Fixed typo "know" → "now" | `hw_5_3_fANOVA_implementation_from_scratch.tex` |
| Fixed "dynamical programming" → "dynamic programming" | `hw_5_3_fANOVA_implementation_from_scratch.tex` |
| Fixed "PD-function" → "PD-functions" (plural) | `hw_5_3_fANOVA_implementation_from_scratch.tex` |
| Added "Assume that all features are mutually independent." before the question | `hw_5_4_h-statistic_vs_Sobol_index_theory.tex` |
| Fixed typo "Froedman" → "Friedman" | `hw_5_5_h-statistic_vs_Sobol_index_example.tex` |
| Fixed "First we evaluate $f$" → "$\fh$" for consistent notation | `hw_sol_5_1_h-statistic_categorical.tex` |
| Fixed "3.+" → "3 +" (removed stray period in arithmetic) | `hw_sol_5_1_h-statistic_categorical.tex` |
| Replaced `\hat f` with `\fh` macro (4 occurrences in the H-statistic formula) | `hw_sol_5_1_h-statistic_categorical.tex` |
| Fixed empirical variance formula: added `\frac{1}{n}` factor, changed single index to double index $(i,j)$, fixed $x_2^{(i)}$ → $x_2^{(j)}$ | `hw_sol_5_1_h-statistic_categorical.tex` |
| Added explanation that $\frac{1}{n}$ cancels in the H-statistic ratio | `hw_sol_5_1_h-statistic_categorical.tex` |
| Added "where we used $g_2(x_2) = 0$" notes after zero-component substitutions | `hw_sol_5_2_fANOVA_categorical.tex` |
| Fixed $g_{13}$ → $g_{1,3}$ in solution text | `hw_sol_5_2_fANOVA_categorical.tex` |
| Added full solution for new part c): fANOVA on $\{0, \tfrac12, 1\}$ with all components computed | `hw_sol_5_2_fANOVA_categorical.tex` |
| Added explanation of why centering removes $g_\emptyset$ in Step 1 (vanishing condition under independence) | `hw_sol_5_4_h-statistic_vs_Sobol_index_theory.tex` |
