### PR TITLE
refactor(slides): clean up local explanations counterfactual slides

### DIFF
--- a/slides/local-explanations-counterfactual/slides02-le-adversarial.tex
+++ b/slides/local-explanations-counterfactual/slides02-le-adversarial.tex
@@ -4,23 +4,21 @@
 \input{../../latex-math/basic-math}
 \input{../../latex-math/basic-ml}
 % Defines macros and environments
- 
+
 % not sure how was \thetab supposed to be defined, treat this as a temporary placeholder
 \newcommand{\thetab}{\theta}
 
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
 
 % Set style/preamble.Rnw as parent.
-\newcommand{\vertiii}[1]{{\left\vert\kern-0.25ex\left\vert\kern-0.25ex\left\vert #1 
-    \right\vert\kern-0.25ex\right\vert\kern-0.25ex\right\vert}}
+\newcommand{\vertiii}[1]{{\left\vert\kern-0.25ex\left\vert\kern-0.25ex\left\vert #1 \right\vert\kern-0.25ex\right\vert\kern-0.25ex\right\vert}}
 % Load all R packages and set up knitr
 
-% This file loads R packages, configures knitr options and sets preamble.Rnw as 
+% This file loads R packages, configures knitr options and sets preamble.Rnw as
 % parent file
 % IF YOU MODIFY THIS, PLZ ALSO MODIFY setup.Rmd ACCORDINGLY...
 
@@ -33,144 +31,107 @@ Adversarial Examples
 }{
 figure/AEturtle.jpg
 }{
-\item Understand the definition of ADEs 
+\item Understand the definition of ADEs
 \item Understand first methods that generate ADEs
 \item Discuss potential causes of ADEs and standard defenses against them
 }
 
 % ------------------------------------------------------------------------------
 
-\begin{frame}[c]{Adversarial Machine Learning}
-\begin{itemize}
-    \item What happens if a computer system gets an erroneous input?
-    \item Even worse:\\ What happens if someone feeds in a malicious input on purpose to attack a system?
-    \item[$\leadsto$] \textbf{Robustness} is important to ensure a safe service!
-    \medskip
-    \item \textbf{Adversarial ML} studies the robustness of machine learning (ML) algorithms to malicious input
-    \item Two different kinds of attacks:
-    \begin{itemize}
-        \item \textbf{Evasion attacks} mislead an employed ML model with manipulated inputs (our focus)
-        \item \textbf{Data Poisoning}: Malicious inputs to the training dataset
-    \end{itemize}
-    \end{itemize}
-\end{frame}
+\begin{framei}[align=top]{Adversarial Machine Learning}
+\item What happens if a computer system gets an erroneous input?
+\item Even worse:\\ What happens if someone feeds in a malicious input on purpose to attack a system?
+\item[$\leadsto$] \textbf{Robustness} is important to ensure a safe service!
+\item \textbf{Adversarial ML} studies the robustness of machine learning (ML) algorithms to malicious input
+\item Two different kinds of attacks:
+\begin{itemizeS}
+\item \textbf{Evasion attacks} mislead an employed ML model with manipulated inputs (our focus)
+\item \textbf{Data Poisoning}: Malicious inputs to the training dataset
+\end{itemizeS}
+\end{framei}
 
-\begin{frame}[c]{Adversarial Examples}
+
+\begin{framei}[align=top]{Adversarial Examples}
 %The inputs by which evasion attacks can be conducted are called \textbf{Adversarial Examples (ADEs)}
-\begin{itemize}
-    \item \textbf{Informal Definition}: An ADE is an input to a model that is deliberately designed to "fool" the model into misclassifying it
-    \item Even possible with low generalization error
-    \item Both deep learning models (e.g., CNNs) and classical ML can be vulnerable to such attacks
-    \item ADEs created from a real data observation $\xv$ can be indistinguishable from $\xv$ by a human observer 
-    \item Since the model misclassifies this input, it does not seem to have a real understanding of the underlying concepts of the provided inputs
-\end{itemize}
-\end{frame}
-
-\begin{frame}[c]{Examples: Model-Attacks \furtherreading{POELLABAUER2018}}
-
-\begin{columns}[totalwidth=\textwidth]
-
-\begin{column}{0.6\textwidth}
-
-\begin{figure}[h]
-\centering
-  \includegraphics[width=1\linewidth]{figure/AEduckSound.png}
-  \label{fig:mnist}
-\end{figure} 
-
-\end{column}
-
-\begin{column}{0.4\textwidth}
-
-    \vspace{3em}
-    \begin{itemize}
-        \item Is this a duck or a horse?
-        \item Small (hard-to-see) noise can change the prediction
-    \end{itemize}
-
-\end{column}
-
-\end{columns}
-
-\end{frame}
-
-\begin{frame}[c]{Examples: Image Data \furtherreading{EYKHOLT2018}  \furtherreading{ATHALYE2018}}
-\begin{figure}[h]
-\centering
-\includegraphics[width=0.46\linewidth]{figure/AEstop.png}\quad \includegraphics[width=0.45\linewidth]{figure/AEturtle.jpg}
-  \label{fig:mnist}
-\end{figure} 
-
-\begin{columns}[totalwidth=\textwidth]
-
-\begin{column}{0.5\textwidth}
-
-\begin{itemize}
-    \item Stop signs can be missclassified\\ e.g., because of graffiti
-    \item With some well-placed patches, the model identifies it as a ``right of way'' sign
-\end{itemize}
-
-\end{column}
-
-\begin{column}{0.5\textwidth}
-
-\begin{itemize}
-    \item 3D-print of a turtle
-    \item Misclassified as a rifle\\(from every angle)
-    \item Video: 
-    \furtherreading{MITCSAIL2017}
-\end{itemize}
-
-\end{column}
-
-\end{columns}
+\item \textbf{Informal Definition}: An ADE is an input to a model that is deliberately designed to ``fool'' the model into misclassifying it
+\item Even possible with low generalization error
+\item Both deep learning models (e.g., CNNs) and classical ML can be vulnerable to such attacks
+\item ADEs created from a real data observation $\xv$ can be indistinguishable from $\xv$ by a human observer
+\item Since the model misclassifies this input, it does not seem to have a real understanding of the underlying concepts of the provided inputs
+\end{framei}
 
 
-\end{frame}
+\begin{framev}[align=top]{Examples: Model-Attacks \furtherreading{POELLABAUER2018}}
+\splitVCC[0.6]{
+\image{figure/AEduckSound.png}
+}{
+\begin{itemizeM}
+\item Is this a duck or a horse?
+\item Small (hard-to-see) noise can change the prediction
+\end{itemizeM}
+}
+\end{framev}
 
-\begin{frame}[c]{Example: Tabular Data \furtherreading{BALLET2019}}
+
+\begin{framev}[align=top]{Examples: Image Data \furtherreading{EYKHOLT2018} \furtherreading{ATHALYE2018}}
+\splitVCompact{0.46}{0.45}{
+\image{figure/AEstop.png}
+}{
+\image{figure/AEturtle.jpg}
+}
+\spacer[0.25]
+\splitVCC[0.5]{
+\begin{itemizeM}
+\item Stop signs can be misclassified\\ e.g., because of graffiti
+\item With some well-placed patches, the model identifies it as a ``right of way'' sign
+\end{itemizeM}
+}{
+\begin{itemizeM}
+\item 3D-print of a turtle
+\item Misclassified as a rifle\\ (from every angle)
+\item Video: \furtherreading{MITCSAIL2017}
+\end{itemizeM}
+}
+\end{framev}
+
+
+\begin{framev}[align=top]{Example: Tabular Data \furtherreading{BALLET2019}}
 What is imperceptibility on tabular data?
-\begin{itemize}
-    \item Idea: experts focus on the most important features in their judgment
-    \item An ADE arises from manipulating features the model deems important but experts do not
-\end{itemize}
-\begin{figure}[h]
-\centering
-\includegraphics[width=0.6\linewidth]{figure/AEloanApplication.png}\\
-   \centering
-  {Decision boundary of a classifier deciding loan applications. ADE via ``number of pets''}
-  \label{fig:mnist}
-\end{figure} 
+\begin{itemizeM}
+\item Idea: experts focus on the most important features in their judgment
+\item An ADE arises from manipulating features the model deems important but experts do not
+\end{itemizeM}
+\imageC[0.6]{figure/AEloanApplication.png}
+{\centering Decision boundary of a classifier deciding loan applications. ADE via ``number of pets''\par}
+\end{framev}
 
-\end{frame}
 
-\begin{frame}[c]{ADE and Interpretability}
-
+\begin{framev}[align=top]{ADE and Interpretability}
 \begin{enumerate}
-    \item ADEs show where models fail $\leadsto$ improved model understanding
-    \item Because of ADEs, we need more interpretability
-    \item Interpretation can lead to robustness against ADEs
-    \medskip
-    \item Explanations can be used to construct ADEs (e.g., see numer of pets on previous slide)
+\item ADEs show where models fail $\leadsto$ improved model understanding
+\item Because of ADEs, we need more interpretability
+\item Interpretation can lead to robustness against ADEs
+\item Explanations can be used to construct ADEs (e.g., see number of pets on previous slide)
 \end{enumerate}
+\end{framev}
 
-\end{frame}
 
-\begin{frame}[c]{Formal Definition}
+\begin{framev}[align=top]{Formal Definition}
 \begin{block}{Adversarial Input}
-Let $\epsilon>0$, $f:\Xspace \rightarrow \Yspace$ be an ML model and $\xv \in \Xspace$ be a real data point that is correctly classified: $f(\xv)=y_{\xv,true}$. \\\medskip
- We call $\mathbf{a}_{\xv}$ an \textbf{adversarial input} to $\xv$ if:
+Let $\epsilon > 0$, $f:\Xspace \rightarrow \Yspace$ be an ML model and $\xv \in \Xspace$ be a real data point that is correctly classified: $f(\xv)=y_{\xv,true}$.\\
+\spacer[0.25]
+We call $\mathbf{a}_{\xv}$ an \textbf{adversarial input} to $\xv$ if:
 \begin{equation*}
-    \| \mathbf{a}_{\xv}- \xv\|<\epsilon\text{ and } f(\mathbf{a}_{\xv})\neq y_{\mathbf{a}_{\xv},true}=f(\xv)
+\|\mathbf{a}_{\xv} - \xv\| < \epsilon \text{ and } f(\mathbf{a}_{\xv}) \neq y_{\mathbf{a}_{\xv},true} = f(\xv)
 \end{equation*}
 \end{block}
-\begin{itemize}
-    \item $\mathbf{a}_{\xv}$ is a nearby point to a real, correctly classified input that is misclassified
-    \item $\mathbf{a}_{\xv}$ is called \textbf{targeted} if the class it is assigned to is determined\\
-    $f(\mathbf{a}_{\xv})=y'$ with $y'$ being a desired prediction
-    \item Can be generalized to regression problems
-\end{itemize}
-\end{frame}
+\begin{itemizeM}
+\item $\mathbf{a}_{\xv}$ is a nearby point to a real, correctly classified input that is misclassified
+\item $\mathbf{a}_{\xv}$ is called \textbf{targeted} if the class it is assigned to is determined\\
+$f(\mathbf{a}_{\xv})=y'$ with $y'$ being a desired prediction
+\item Can be generalized to regression problems
+\end{itemizeM}
+\end{framev}
 
 
 % \begin{vbframe}{ADE and Counterfactual Explanations}
@@ -185,144 +146,115 @@ Let $\epsilon>0$, $f:\Xspace \rightarrow \Yspace$ be an ML model and $\xv \in \X
 % \end{itemize}
 % \end{vbframe}
 
-
-\begin{frame}[c]{Why Do ADE Exist?}
-Non-exhaustive list of hypotheses: \\[0.5cm]
-    
+\begin{framev}[align=top]{Why Do ADE Exist?}
+Non-exhaustive list of hypotheses:\\
+\spacer[0.25]
 \only<1>{
-    \textbf{1. Low-probability spaces hypotheses:} ADEs live in low-probability yet dense spaces in the data manifold that are not well represented in the training samples \furtherreading{SZEGEDY2013}
-        
-    \begin{figure}
-        \centering
-        \includegraphics[width = .5\textwidth]{figure/adversarial examples.png}
-        \caption{Binary classification example (dark blue vs. green dots). Dotted line represents the true decision boundary, bold line the trained one. Low probability space close to decision boundary allow for adversarial examples (turquoise dot).}
-    \end{figure}
+\textbf{1. Low-probability spaces hypotheses:} ADEs live in low-probability yet dense spaces in the data manifold that are not well represented in the training samples \furtherreading{SZEGEDY2013}\\
+\spacer[0.25]
+\imageC[0.5]{figure/adversarial examples.png}
+{\centering Binary classification example (dark blue vs.\ green dots). Dotted line represents the true decision boundary, bold line the trained one. Low probability space close to decision boundary allow for adversarial examples (turquoise dot).\par}
 }
-    
 \only<2>{
-    \textbf{2. Linearity hypotheses (most popular):}\\ Adversarial examples are omnipresent in the data manifold\\
-    $\leadsto$ occur, because commonly used models often show linear behavior\\
-    $\leadsto$ small changes of $\epsilon$ in every feature cause a change of $\epsilon\|\thetab\|_1$ in prediction \furtherreading{GOODFELLOW2014}
-
-    \vspace{.5cm}
-    
-    \textbf{Example:} linear model
-    
-    Original: $f(\xv) = \xv^T \thetab$ 
-    
-    Small changes: $f(\xv + \epsilon) = (\xv + \epsilon)^T \thetab$
-    
-    Difference: $f(\xv + \epsilon) - f(\xv) = \epsilon \cdot \thetab$
+\textbf{2. Linearity hypotheses (most popular):}\\
+Adversarial examples are omnipresent in the data manifold\\
+$\leadsto$ occur, because commonly used models often show linear behavior\\
+$\leadsto$ small changes of $\epsilon$ in every feature cause a change of $\epsilon\|\thetab\|_1$ in prediction \furtherreading{GOODFELLOW2014}\\
+\spacer[0.25]
+\textbf{Example:} linear model\\
+Original: $f(\xv) = \xv^T \thetab$\\
+Small changes: $f(\xv + \epsilon) = (\xv + \epsilon)^T \thetab$\\
+Difference: $f(\xv + \epsilon) - f(\xv) = \epsilon \cdot \thetab$
 }
-    
 \only<3>{
-    \textbf{3. The boundary tilting hypothesis:} Linearity is neither necessary nor sufficient to explain ADEs\\
-    $\leadsto$ ADEs mostly result from overfitting the sampled manifold \furtherreading{GRIFFIN2016}
-    
-    \begin{figure}
-        \centering
-        \includegraphics[width = .35\textwidth]{figure/tilting_ae.png}
-        \caption{Linear binary classification example. Due to overfitting the decision boundary (red) is close to the manifold of the training data. Techniques like regularization could help to make the decision boundary more robust (green). \furtherreading{KIM2019}
+\textbf{3. The boundary tilting hypothesis:} Linearity is neither necessary nor sufficient to explain ADEs\\
+$\leadsto$ ADEs mostly result from overfitting the sampled manifold \furtherreading{GRIFFIN2016}\\
+\spacer[0.25]
+\imageC[0.35]{figure/tilting_ae.png}
+{\centering Linear binary classification example. Due to overfitting the decision boundary (red) is close to the manifold of the training data. Techniques like regularization could help to make the decision boundary more robust (green). \furtherreading{KIM2019}\par}
 }
-    \end{figure}
-}
-    
 \only<4>{
-    \textbf{4. Human-centric hypotheses:} ML models make use of predictive but non-robust features -- meaning they are highly correlated with the prediction target, but not used by humans \furtherreading{ILYAS2019}
+\textbf{4. Human-centric hypotheses:} ML models make use of predictive but non-robust features -- meaning they are highly correlated with the prediction target, but not used by humans \furtherreading{ILYAS2019}
 }
-    
-\end{frame}
+\end{framev}
 
 
-\begin{frame}[c]{Ways to Generate ADE}
-Different ways for constructing ADEs:
-There exist various ways in the literature to generate ADEs for a given model in feasible time
-\begin{itemize}
-    \item Formulate the search for ADEs as an \textbf{optimization problem}, e.g. 
-    \begin{equation*}
-        \label{eq:optimization}
-        \underset{\xv'\in \Xspace}{\text{argmin}}\; \underbrace{\| \xv-\xv' \|_{\Xspace}}_{\text{minmize}} - \lambda\;   \underbrace{ \|f(\xv')-y'\|_{\Yspace}}_{\text{maximize}}
-    \end{equation*}
-    \item Use \textbf{sensitivity analysis} to identify feats that influence the target class
-    \item Train a generative adversarial network (GAN) \furtherreading{GOODFELLOW2014}
-\end{itemize}
+\begin{framev}[align=top]{Ways to Generate ADE}
+Different ways for constructing ADEs:\\
+There exist various ways in the literature to generate ADEs for a given model in feasible time.
+\begin{itemizeM}
+\item Formulate the search for ADEs as an \textbf{optimization problem}, e.g.
+\begin{equation*}
+\label{eq:optimization}
+\underset{\xv' \in \Xspace}{\text{argmin}}\; \underbrace{\|\xv - \xv'\|_{\Xspace}}_{\text{minimize}} - \lambda\; \underbrace{\|f(\xv') - y'\|_{\Yspace}}_{\text{maximize}}
+\end{equation*}
+\item Use \textbf{sensitivity analysis} to identify feats that influence the target class
+\item Train a generative adversarial network (GAN) \furtherreading{GOODFELLOW2014}
+\end{itemizeM}
 Moreover, based on the attacker's model access, we can distinguish between
-\begin{itemize}
-    \item \textbf{Full-access attacks}: attacker has full access to internals of the model
-    \item \textbf{Black-box attacks}: the attacker can only query the model on some inputs and receives the model's outputs
-\end{itemize}
-\end{frame}
+\begin{itemizeM}
+\item \textbf{Full-access attacks}: attacker has full access to internals of the model
+\item \textbf{Black-box attacks}: the attacker can only query the model on some inputs and receives the model's outputs
+\end{itemizeM}
+\end{framev}
 
-\begin{frame}[c]{Fast-Gradient-Sign-Method (FGSM)
-\furtherreading{GOODFELLOW2015}}
+
+\begin{framev}[align=top]{Fast-Gradient-Sign-Method (FGSM) \furtherreading{GOODFELLOW2015}}
 % Since we have seen optimization methods for CEs, we focus on a method using sensitivity analysis, namely FGSM.
 % Source of (modified) figure: https://docs.google.com/presentation/d/1l-ng618qrisSorutii9I30qL8VhZGYD9aRBuwvvBbSY/edit?usp=sharing
-\begin{itemize}
-    \item FGSM is based on the linearity hypothesis
-    \item FGSM finds ADEs from:
-    \begin{equation*}
-        a_{\xv}=\xv+\epsilon\cdot\text{sign}(\nabla_{\xv} J(\theta,\xv,y_{\xv,true}))
-    \end{equation*}
-    where $\text{sign}(\nabla_{\xv} J(\theta,x,y_{\xv,true}))$ describes the component-wise signum of the gradient of cost function $J$ in $\xv$ with true label $y_{\xv,true}$
-\end{itemize}
-\begin{figure}[h]
-\centering
-\includegraphics[width=0.7\linewidth]{figure/AEpanda.png}
-  \label{fig:mnist}
-\end{figure} 
-
-\end{frame}
-
-\begin{frame}[c]{Notes on FGSM \furtherreading{GOODFELLOW2015} \furtherreading{LYU2015}}
-\begin{itemize}
-    \item FGSM works particularly well for linear(-like) models in high-dim. spaces,\\ e.g., LSTMs, logistic regressions or CNNs with ReLU activations
-    \item Not every $\mathbf{a}_{\xv}$ generated by FGSM is an ADE, especially if $\epsilon$ is too small
-    \item FGSM attacks can be also generated without model access by approximating the gradient,\\ e.g. with finite difference methods
-    \item The notion of similarity in FGSM is based on $\|\cdot\|_{\infty}$ $\leadsto$ there are generalizations of FGSM to other norms
-\end{itemize}
-\end{frame}
+\begin{itemizeM}
+\item FGSM is based on the linearity hypothesis
+\item FGSM finds ADEs from:
+\begin{equation*}
+a_{\xv} = \xv + \epsilon \cdot \text{sign}(\nabla_{\xv} J(\theta,\xv,y_{\xv,true}))
+\end{equation*}
+where $\text{sign}(\nabla_{\xv} J(\theta,x,y_{\xv,true}))$ describes the component-wise signum of the gradient of cost function $J$ in $\xv$ with true label $y_{\xv,true}$
+\end{itemizeM}
+\imageC[0.7]{figure/AEpanda.png}
+\end{framev}
 
 
-\begin{frame}[c]{Black-Box Attacks with Surrogates \furtherreading{PAPERNOT2016}}
+\begin{framei}[align=top]{Notes on FGSM \furtherreading{GOODFELLOW2015} \furtherreading{LYU2015}}
+\item FGSM works particularly well for linear(-like) models in high-dim.\ spaces,\\ e.g., LSTMs, logistic regressions or CNNs with ReLU activations
+\item Not every $\mathbf{a}_{\xv}$ generated by FGSM is an ADE, especially if $\epsilon$ is too small
+\item FGSM attacks can be also generated without model access by approximating the gradient,\\ e.g.\ with finite difference methods
+\item The notion of similarity in FGSM is based on $\|\cdot\|_{\infty}$ $\leadsto$ there are generalizations of FGSM to other norms
+\end{framei}
 
-\begin{itemize}
-    \item So far, we assumed full access to the predictive model
-    \item Black-box attacks only assume query-access
-    \item High attack risk since often one can query predictive models many times
-\end{itemize}
 
-\medskip
+\begin{framev}[align=top]{Black-Box Attacks with Surrogates \furtherreading{PAPERNOT2016}}
+\begin{itemizeM}
+\item So far, we assumed full access to the predictive model
+\item Black-box attacks only assume query-access
+\item High attack risk since often one can query predictive models many times
+\end{itemizeM}
+\spacer[0.25]
 \begin{enumerate}
-    \item Query the model you aim to attack as often as allowed on data similar to the training data
-    \item Use the labeled data you received to train a surrogate model
-    \item Generate ADEs for the surrogate model
-    \item Use these ADEs to attack the original model
+\item Query the model you aim to attack as often as allowed on data similar to the training data
+\item Use the labeled data you received to train a surrogate model
+\item Generate ADEs for the surrogate model
+\item Use these ADEs to attack the original model
 \end{enumerate}
+\spacer[0.25]
+\begin{itemizeM}
+\item[$\leadsto$] Known as the \textbf{transferability} of ADEs.
+\end{itemizeM}
+\end{framev}
 
-\medskip
-\begin{itemize}
-    \item[$\leadsto$] Known as the \textbf{transferability} of ADEs.
-\end{itemize}
 
-
-
-\end{frame}
-
-\begin{frame}[c]{Defenses Against ADE}
-There are several ways to protect your network against such attacks -- we distinguish between two broad types of defenses, differing in the position in which they act
-\begin{itemize}
-    \item \textbf{Guards} act on the inputs a model receives
-    \begin{itemize}
-        \item \textbf{Detect anomalies:} e.g., statistical testing, or discriminator networks from GANs
-        \item \textbf{Conduct transformations} on inputs (e.g. PCA)
-    \end{itemize}
-    \item \textbf{Defense by design} act on the model itself
-    \begin{itemize}
-        \item \textbf{Adversarial training}: train model on adversarials
-        \item \textbf{Architectural defenses}: e.g., removing low predictive features from the model
-    \end{itemize}
-\end{itemize}
-\end{frame}
+\begin{framei}[align=top]{Defenses Against ADE}
+\item There are several ways to protect your network against such attacks -- we distinguish between two broad types of defenses, differing in the position in which they act
+\item \textbf{Guards} act on the inputs a model receives
+\begin{itemizeS}
+\item \textbf{Detect anomalies:} e.g., statistical testing, or discriminator networks from GANs
+\item \textbf{Conduct transformations} on inputs (e.g.\ PCA)
+\end{itemizeS}
+\item \textbf{Defense by design} act on the model itself
+\begin{itemizeS}
+\item \textbf{Adversarial training}: train model on adversarials
+\item \textbf{Architectural defenses}: e.g., removing low predictive features from the model
+\end{itemizeS}
+\end{framei}
 
 %\begin{vbframe}{Regularization Against ADEs}
 %The use of regularization techniques against ADEs is motivated by most hypotheses that explain ADEs. As an example we look at a technique based on the FGSM and the linearity hypotheses.
@@ -338,18 +270,16 @@ There are several ways to protect your network against such attacks -- we distin
 %\end{itemize}
 %\end{vbframe}
 
-\begin{frame}[c]{Summary}
-\begin{itemize}
-    \item ADEs are not explanations themselves, but conceptually related to them
-    \item ADEs can be generated in diverse settings $\leadsto$ crucial modeling decisions are the distance measure, the local environment, and the target level (model or process)
-    \item There are various hypotheses on the existence of ADEs which also motivate different defense strategies
-\end{itemize}
-\begin{center}
-    \includegraphics[width = .6\textwidth]{figure/AEpanda_simple.png}
-    
-    {\furtherreading{GOODFELLOW2017}}
-\end{center}
-\end{frame}
+\begin{framev}[align=top]{Summary}
+\begin{itemizeM}
+\item ADEs are not explanations themselves, but conceptually related to them
+\item ADEs can be generated in diverse settings $\leadsto$ crucial modeling decisions are the distance measure, the local environment, and the target level (model or process)
+\item There are various hypotheses on the existence of ADEs which also motivate different defense strategies
+\end{itemizeM}
+\spacer[0.25]
+\imageC[0.6]{figure/AEpanda_simple.png}
+{\centering \furtherreading{GOODFELLOW2017}\par}
+\end{framev}
 
 %\begin{vbframe}{Outlook}
 %\begin{itemize}
@@ -358,7 +288,7 @@ There are several ways to protect your network against such attacks -- we distin
 %    \item Recent work considered ADEs that fool both, humans and ML models. ADEs may be a case where research on human and machine perception can profit from each other.
 %\end{itemize}
 %@misc{rozsa2016adversarial,
-%      title={Adversarial Diversity and Hard Positive Generation}, 
+%      title={Adversarial Diversity and Hard Positive Generation},
 %      author={Andras Rozsa and Ethan M. Rudd and Terrance E. Boult},
 %      year={2016},
 %      eprint={1605.01775},

--- a/slides/local-explanations-counterfactual/slides03-le-adversarial-counterfactuals.tex
+++ b/slides/local-explanations-counterfactual/slides03-le-adversarial-counterfactuals.tex
@@ -8,13 +8,11 @@
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
 
 % Set style/preamble.Rnw as parent.
-\newcommand{\vertiii}[1]{{\left\vert\kern-0.25ex\left\vert\kern-0.25ex\left\vert #1 
-    \right\vert\kern-0.25ex\right\vert\kern-0.25ex\right\vert}}
+\newcommand{\vertiii}[1]{{\left\vert\kern-0.25ex\left\vert\kern-0.25ex\left\vert #1 \right\vert\kern-0.25ex\right\vert\kern-0.25ex\right\vert}}
 % Load all R packages and set up knitr
 
 % This file loads R packages, configures knitr options and sets preamble.Rnw as 
@@ -24,43 +22,40 @@
 % Defines macros and environments
 
 \titlemeta{
-Local explanations
+Local Explanations
 }{
 Adversarial Examples and Counterfactual Explanations
 }{
 figure/AEloanApplication.png
 }{
 \item Compare adversarial examples to counterfactual explanations
-\item See an example where both coincident
+\item See an example where both coincide
 }
 
 
 % ------------------------------------------------------------------------------
 
-\begin{frame}{ADE and Counterfactual Explanations}
-It seems as if ADEs and counterfactual explanations (CEs) are defined similarly. Both ADEs and CEs describe inputs close to a given input $\xv$ that gets a different assignment. What are their differences?
-\begin{itemize}
-    \item Counterfactuals do not have to be misclassified.
+\begin{framev}[align=top]{ADE and Counterfactual Explanations}
+It seems as if ADEs and counterfactual explanations (CEs) are defined similarly.
+Both ADEs and CEs describe inputs close to a given input $\xv$ that gets a different assignment.
+What are their differences?
+\begin{itemizeM}
+\item Counterfactuals do not have to be misclassified.
 %    \item Counterfactuals should be maximally close to $\xv$.
-    \item Different notions of distance $\|\cdot\|$ are applied, e.g., $p_{2,\infty}$-norm for ADEs or $p_{0,1}$-norm for CEs.
-    \item Informal difference I: ADEs are mostly considered for high-dimensional data, while CEs are mostly considered in the context of low-dim. data.
-    \item Informal difference II: ADEs hide changes while CEs highlight them.
-\end{itemize}
-\end{frame}
+\item Different notions of distance $\|\cdot\|$ are applied, e.g., $p_{2,\infty}$-norm for ADEs or $p_{0,1}$-norm for CEs.
+\item Informal difference I: ADEs are mostly considered for high-dimensional data, while CEs are mostly considered in the context of low-dimensional data.
+\item Informal difference II: ADEs hide changes while CEs highlight them.
+\end{itemizeM}
+\end{framev}
 
-\begin{frame}{Shared Example \furtherreading{BALLET2019}}
-\begin{itemize}
-\item \textbf``If you had two more pets, your loan application would have been granted" is an example of both ADEs and CEs.
-\end{itemize}
-\begin{figure}[h]
-\centering
-\includegraphics[width=0.6\linewidth]{figure/AEloanApplication.png}\\
-   \centering
-  {Decision boundary of a classifier deciding loan applications. ADE via ``number of pets''}
-  \label{fig:mnist}
-\end{figure} 
-\end{frame}
+
+\begin{framev}[align=top]{Shared Example \furtherreading{BALLET2019}}
+\begin{itemizeM}
+\item ``If you had two more pets, your loan application would have been granted'' is an example of both ADEs and CEs.
+\end{itemizeM}
+\imageC[0.6]{figure/AEloanApplication.png}
+{\centering Decision boundary of a classifier deciding loan applications. ADE via ``number of pets''\par}
+\end{framev}
 
 \endlecture
 \end{document}
-

--- a/slides/local-explanations-counterfactual/slides06-le-counterfactuals-intro.tex
+++ b/slides/local-explanations-counterfactual/slides06-le-counterfactuals-intro.tex
@@ -4,11 +4,10 @@
 \input{../../latex-math/basic-math}
 \input{../../latex-math/basic-ml}
 % Defines macros and environments
- 
+
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
 
@@ -30,7 +29,6 @@ Motivation
 }{
 figure/counterfactuals_obj
 }{
-
 \item Understand the motivation behind CEs
 \item Know why and how CEs are used
 \item Recognize the philosophical foundations of counterfactual reasoning
@@ -39,29 +37,27 @@ figure/counterfactuals_obj
 
 % ------------------------------------------------------------------------------
 
-\begin{frame}{Motivating Example: Credit Risk \& CE}
-        %\begin{center}
-            $\textbf{x}$: customer and credit information \hfill $y$: grant or reject credit \
-        \includegraphics[width=\linewidth, page=1]{figure/counterfactuals_credit.pdf} 
-        %\end{center}
+\begin{framev}[align=top]{Motivating Example: Credit Risk \& CE}
+% \begin{center}
+$\mathbf{x}$: customer and credit information \hfill $y$: grant or reject credit\\
+\includegraphics[width=\textwidth, page=1]{figure/counterfactuals_credit.pdf}
+% \end{center}
+Potential questions:
+\begin{itemizeM}
+\item Why was the credit rejected?
+\item Is this decision fair compared with similar applicants?
+\item \textbf{How should $\xv$ be changed so that the credit is accepted?}
+\end{itemizeM}
+\end{framev}
 
-	Potential questions:
-	\begin{itemize}
-		\item Why was the credit rejected?
-		\item Is this decision fair compared with similar applicants?
-		\item \textbf{How should $\xv$ be changed so that the credit is accepted?}
-	\end{itemize}
-\end{frame}
 
-
-\begin{frame}{Motivating Example: Credit Risk \& CE}
-    CEs provide answers in the form of "What-If"-scenarios.
-	
-    \includegraphics[width=\linewidth, page=2]{figure/counterfactuals_credit.pdf}
-
-    ``If the applicant had higher skills and the credit amount had been reduced to \$8.000, the loan would have been granted."  \\[0.2cm]
-
-\end{frame}
+\begin{framev}[align=top]{Motivating Example: Credit Risk \& CE}
+CEs provide answers in the form of ``What-If''-scenarios.\\
+\spacer[0.25]
+\includegraphics[width=\textwidth, page=2]{figure/counterfactuals_credit.pdf}\\
+\spacer[0.25]
+``If the applicant had higher skills and the credit amount had been reduced to \$8.000, the loan would have been granted.''
+\end{framev}
 
 
 % \begin{frame}{Counterfactual Explanations: Main Idea}
@@ -76,89 +72,74 @@ figure/counterfactuals_obj
 % \end{frame}
 
 
-\begin{frame}{Core Definition and Purpose of CE}
-  \begin{itemize}
-    \item<1-> \textbf{Counterfactual explanation (CE):} Hypothetical input \(\mathbf{x}'\) close to the data point of interest $\mathbf{x}$ whose prediction equals a user-defined desired outcome \(y'\)
-    \item<2-> \textbf{Proximity constraint:} %Find \(\mathbf{x}' \approx \mathbf{x}\) such that
-      \[
-      \text{Find} \quad \mathbf{x}' \approx \mathbf{x} \quad\text{such that} \quad f(\mathbf{x}') = y' \quad\text{and distance}\quad 
-        d(\mathbf{x},\mathbf{x}') \quad \text{is minimal}
-      \]
-    \item<3-> \textbf{Minimal actionable changes:} Difference \(\mathbf{x}'-\mathbf{x}\) shows the smallest feature change a user could realize in practice
-    \item<4-> \textbf{Primary audience:} 
-    \begin{itemize}
-        \item Individuals aiming to alter model predictions 
-        \item ML engineers exploring model behavior under adversarial conditions\\
-        $\leadsto$ how small text changes in an email flip the prediction from "spam" to "no spam"
-    \end{itemize}
-  \end{itemize}
-\end{frame}
+\begin{framev}[align=top]{Core Definition and Purpose of CE}
+\begin{itemizeM}
+\item<1-> \textbf{Counterfactual explanation (CE):} Hypothetical input $\mathbf{x}'$ close to the data point of interest $\mathbf{x}$ whose prediction equals a user-defined desired outcome $y'$
+\item<2-> \textbf{Proximity constraint:} %Find \(\mathbf{x}' \approx \mathbf{x}\) such that
+$$
+\text{Find} \quad \mathbf{x}' \approx \mathbf{x} \quad \text{such that} \quad f(\mathbf{x}') = y' \quad \text{and distance} \quad d(\mathbf{x},\mathbf{x}') \quad \text{is minimal}
+$$
+\item<3-> \textbf{Minimal actionable changes:} Difference $\mathbf{x}' - \mathbf{x}$ shows the smallest feature change a user could realize in practice
+\item<4-> \textbf{Primary audience:}
+\begin{itemizeS}
+\item Individuals aiming to alter model predictions
+\item ML engineers exploring model behavior under adversarial conditions\\
+$\leadsto$ how small text changes in an email flip the prediction from ``spam'' to ``no spam''
+\end{itemizeS}
+\end{itemizeM}
+\end{framev}
 
 
-\begin{frame}{Interpretive Aims \& Roles}
-	CEs can serve various purposes; the user can decide what to learn from them, e.g.:  \\[0.2cm]
-	``If the person had been \textbf{one year older} and the \textbf{credit amount had been increased} to \$12.000, the credit would have been granted."  \\[0.2cm]
-	\pause
-	\begin{itemize}[<+->]
-		\itemsep1.2em
-		\item \textbf{Guidance for future actions:}\\ \textit{Ok, I will apply again next year for the higher amount.}
-		\item \textbf{Provide reasons:}\\ \textit{Interesting, I did not know that age plays a role in loan applications.}
-		\item \textbf{Provide grounds to contest the decision:}\\ \textit{How dare you, I won’t accept age-based discrimination in my application.}
-		\item \textbf{Detect model biases:}\\ \textit{There is a bug, an increase in amount should not increase approval rates.}
-	\end{itemize}
-\end{frame}
+\begin{framev}[align=top]{Interpretive Aims \& Roles}
+CEs can serve various purposes; the user can decide what to learn from them, e.g.:\\
+\spacer[0.25]
+``If the person had been \textbf{one year older} and the \textbf{credit amount had been increased} to \$12.000, the credit would have been granted.''\\
+\spacer[0.25]
+\pause
+\begin{itemizeM}
+\item<+-> \textbf{Guidance for future actions:}\\
+\textit{Ok, I will apply again next year for the higher amount.}
+\item<+-> \textbf{Provide reasons:}\\
+\textit{Interesting, I did not know that age plays a role in loan applications.}
+\item<+-> \textbf{Provide grounds to contest the decision:}\\
+\textit{How dare you, I won’t accept age-based discrimination in my application.}
+\item<+-> \textbf{Detect model biases:}\\
+\textit{There is a bug, an increase in amount should not increase approval rates.}
+\end{itemizeM}
+\end{framev}
 
 
 %------------------------------------------------------------
-\begin{frame}{Philosophical Foundations \furtherreading{LEWIS1973}}
-
+\begin{framev}[align=top]{Philosophical Foundations \furtherreading{LEWIS1973}}
 Counterfactuals have a long tradition in analytic philosophy\\
 $\leadsto$ A \textbf{counterfactual conditional} takes the form:
-
 \begin{center}
-  \emph{"If $S$ had occurred, $Q$ would have occurred."}
+\emph{``If $S$ had occurred, $Q$ would have occurred.''}
 \end{center}
-
-  \begin{itemize}%[<+->]
-    \item $S$: past event that never happened 
-    $\leadsto$ CE run contrary to fact
-    \item Statement is true iff $Q$ holds in all \textbf{closest} worlds where $S$ is true
-    \item Closest worlds preserve laws and change as few facts as possible (related to $S$)
-    %\item \alert{Debate}: what counts as "closest" is controversial in philosophy
-  \end{itemize}
-\end{frame}
+\begin{itemizeM}
+\item $S$: past event that never happened\\
+$\leadsto$ CE run contrary to fact
+\item Statement is true iff $Q$ holds in all \textbf{closest} worlds where $S$ is true
+\item Closest worlds preserve laws and alter as few facts as possible (related to $S$)
+%\item \alert{Debate}: what counts as "closest" is controversial in philosophy
+\end{itemizeM}
+\end{framev}
 
 %------------------------------------------------------------
-\begin{frame}{Philosophical Foundations}
-  \begin{itemize}%[<+->]
-    \item<1-> CEs have largely been studied to explain causal dependence
-    \item<1-> \textbf{Causal dependence}: $Q$ depends on $S$   $\Leftrightarrow$ without $S$, no $Q$\\
-    $\leadsto$ Good CEs reveal critical causal factors that drove algorithmic decision\\
-    $\leadsto$ \textbf{CE objective}: find $\mathbf{x}' \!\approx\! \mathbf{x}$ with $f(\mathbf{x}')=y'$ to expose causal features
-    \item<2-> Relaxing closeness may add causally irrelevant edits to the explanation\\
+\begin{framev}[align=top]{Philosophical Foundations}
+\begin{itemizeM}
+\item<1-> CEs have largely been studied to explain causal dependence
+\item<1-> \textbf{Causal dependence}: $Q$ depends on $S$ $\Leftrightarrow$ without $S$, no $Q$\\
+$\leadsto$ Good CEs reveal critical causal factors that drove algorithmic decision\\
+$\leadsto$ \textbf{CE objective}: find $\mathbf{x}' \!\approx\! \mathbf{x}$ with $f(\mathbf{x}') = y'$ to expose causal features
+\item<2-> Relaxing closeness may add causally irrelevant edits to the explanation\\
 $\leadsto$ e.g., suggest to lower loan \emph{and} increase age (but only loan matters)
-
 \item<3-> CEs are contrastive: Explain a decision by comparing it to a different case\\
 $\leadsto$ If age were 30 (not 60), loan would have been \$9k (not rejected)\\%\$40k\\
 $\leadsto$ Answers contrastive question: \\``Why Q' instead of Q?'' (preferred by humans)
-
-    % \item \textbf{Alternative view}: Pearl (2009) models causality via graphs, then derives counterfactuals from the graph
-  \end{itemize}
-\end{frame}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+% \item \textbf{Alternative view}: Pearl (2009) models causality via graphs, then derives counterfactuals from the graph
+\end{itemizeM}
+\end{framev}
 
 % \begin{frame}{Philosophical Basis}
 % %Interestingly, counterfactuals have a long-standing tradition in philosophy and, in fact the IML discussion of CEs is based on the work of Lewis (1973).

--- a/slides/local-explanations-counterfactual/slides07-le-counterfactuals-optim.tex
+++ b/slides/local-explanations-counterfactual/slides07-le-counterfactuals-optim.tex
@@ -5,17 +5,12 @@
 \input{../../latex-math/basic-ml}
 \input{../../latex-math/ml-interpretable.tex}
 % Defines macros and environments
- 
 \usepackage[dvipsnames]{xcolor}
-
 
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
-
 \begin{document}
-
 
 % Set style/preamble.Rnw as parent.
 
@@ -27,7 +22,7 @@
 
 % Defines macros and environments
 
- \titlemeta{
+\titlemeta{
 Counterfactual Explanations (CEs)
 }{
 Optimization Problem and Objectives
@@ -40,78 +35,72 @@ figure/counterfactuals_obj
 }
 
 
-
-\begin{frame}{Mathematical Perspective}
-    Terminology:
-    \begin{itemize}
-        \item $\xv$: original/factual data point whose prediction we want to explain
-        \item $y' \subset \R^g$: desired predi. ($y' =$ ``grant credit") or interval ($y' = [1000, \infty[$)
-    \end{itemize}
-    \lz\pause
-    A \textbf{valid} counterfactual $\xv'$ satisfies two criteria:
-    \begin{enumerate}
-    \item \textbf{Prediction validity:} CE's prediction $\fh(\xv')$ is equal to the desired pred. $y'$ 
-\item \textbf{Proximity:} CE $\xv'$ is as close as possible to the original input $\xv$
-		% \item whose prediction $\fh(\xv')$ is equal to the desired prediction $y'$ (prediction validity)
-		% \item maximally close to the original datapoint $\xv$ (proximity)
-	\end{enumerate}
-	\lz\pause
-	Reformulate these two objectives as optimization problem: %(denoted by $o_1$ and $o_2$)
-	
-$$\argmin_{\xv'} \lambda_1 o_{target}(\fh(\xv'), y') + \lambda_2 o_{proximity}(\xv', \xv)$$
-
-	\begin{itemize}
-		\item $\lambda_1$ and $\lambda_2$ balance the two objectives
-          \item $o_{target}$: distance in target space %(e.g., cross-entropy, margin loss)
-          \item $o_{proximity}$: distance in feature space % (e.g., $\ell_1$, Mahalanobis, cost-aware)
-		%\item Choice of $o_{target}$ (distance on target space) and of $o_{proximity}$ (distance on feature space) is crucial
-	\end{itemize}
-\end{frame}
-
-
-
-\begin{frame}{Objective Functions \furtherreading{DANDL2020}}
-
-\textbf{Distance in target space $o_{target}$:}
-
-\begin{itemize}
-  \item \textbf{Regression:} L$_1$ distance   
-  $o_{target}(\fh(\xv'), y') = | \fh(\xv') - y'|$
-  
-  \item \textbf{Classification:}  
-  \begin{itemize}
-    \item For predicted probabilities: $o_{target} = | \fh(\xv') - y'|$
-    \item For predicted hard labels: $o_{target} = \mathbb{I} \{ \fh(\xv') \ne y'\}$
-  \end{itemize}
-\end{itemize}
-
+\begin{framev}[align=top]{Mathematical Perspective}
+Terminology:
+\begin{itemizeM}
+\item $\xv$: original/factual data point whose prediction we want to explain
+\item $y' \subset \R^g$: desired prediction ($y' =$ ``grant credit'') or interval ($y' = [1000, \infty[$)
+\end{itemizeM}
 \pause
+\spacer[0.25]
+A \textbf{valid} counterfactual $\xv'$ satisfies two criteria:
+\begin{enumerate}
+\item \textbf{Prediction validity:} CE's prediction $\fh(\xv')$ is equal to the desired prediction $y'$
+\item \textbf{Proximity:} CE $\xv'$ is as close as possible to the original input $\xv$
+% \item whose prediction $\fh(\xv')$ is equal to the desired prediction $y'$ (prediction validity)
+% \item maximally close to the original datapoint $\xv$ (proximity)
+\end{enumerate}
+\pause
+\spacer[0.25]
+Reformulate these two objectives as optimization problem:\\
+\spacer[0.25]
+$$
+\argmin_{\xv'} \lambda_1 o_{target}(\fh(\xv'), y') + \lambda_2 o_{proximity}(\xv', \xv)
+$$
+\begin{itemizeM}
+\item $\lambda_1$ and $\lambda_2$ balance the two objectives
+\item $o_{target}$: distance in target space
+\item $o_{proximity}$: distance in feature space
+%\item Choice of $o_{target}$ (distance on target space) and of $o_{proximity}$ (distance on feature space) is crucial
+\end{itemizeM}
+\end{framev}
 
-\textbf{Distance in input space $o_{proximity}$: Gower distance (mixed feature types)}
 
-\[
-o_{proximity}(\xv', \xv) = \Gower(\xv', \xv) = \frac{1}{p} \sum_{j = 1}^{p} \delta_G(x'_j, x_j) \in [0, 1], \text{ where}
-\]
-
+\begin{framev}[align=top]{Objective Functions \furtherreading{DANDL2020}}
+\textbf{Distance in target space $o_{target}$:}
+\begin{itemizeM}
+\item \textbf{Regression:} L$_1$ distance\\
+$o_{target}(\fh(\xv'), y') = |\fh(\xv') - y'|$
+\item \textbf{Classification:}
+\begin{itemizeS}
+\item For predicted probabilities: $o_{target} = |\fh(\xv') - y'|$
+\item For predicted hard labels: $o_{target} = \mathbb{I}\{\fh(\xv') \ne y'\}$
+\end{itemizeS}
+\end{itemizeM}
+\pause
+\spacer[0.25]
+\textbf{Distance in input space $o_{proximity}$:} Gower distance (mixed feature types)
+$$
+o_{proximity}(\xv', \xv) = \Gower(\xv', \xv) = \frac{1}{p} \sum_{j = 1}^{p} \delta_G(x'_j, x_j) \in [0, 1]
+$$
+where
 % \begin{equation*}
-% \delta_G(x'_j, x_j) = 
+% \delta_G(x'_j, x_j) =
 % \begin{cases}
 % \frac{1}{\widehat{R}_j} \, |x'_j - x_j| & \text{if $x_j$ is numerical} \\
 % \mathbb{I} \left\{ x'_j \ne x_j \right\} & \text{if $x_j$ is categorical}
 % \end{cases}
 % \end{equation*}
-
-\begin{itemize}
-  \item $\delta_G(x'_j, x_j) = \mathbb{I} \left\{ x'_j \ne x_j \right\}$ if $x_j$ is categorical
-  \item $\delta_G(x'_j, x_j) = \frac{1}{\widehat{R}_j} \, |x'_j - x_j| $ if $x_j$ is numerical\\
-  $\leadsto \widehat{R}_j$: range of feature $j$ in the training set to ensure $\delta_G(x'_j, x_j) \in [0, 1]$
-\end{itemize}
-
-\end{frame}
+\begin{itemizeM}
+\item $\delta_G(x'_j, x_j) = \mathbb{I}\{x'_j \ne x_j\}$ if $x_j$ is categorical
+\item $\delta_G(x'_j, x_j) = \frac{1}{\widehat{R}_j} |x'_j - x_j|$ if $x_j$ is numerical\\
+$\leadsto \widehat{R}_j$: range of feature $j$ in the training set to ensure $\delta_G(x'_j, x_j) \in [0, 1]$
+\end{itemizeM}
+\end{framev}
 
 
 % \begin{frame}{Mathematical Perspective \furtherreading{DANDL2020}}
-	
+
 % 	\begin{itemize}
 % 		\item Regression: $o_{target}$ could be the L$_1$-distance $o_{target}(\fh(\xv'), y') = |\fh(\xv')-y'|$
 % 		\item Classification:
@@ -133,163 +122,149 @@ o_{proximity}(\xv', \xv) = \Gower(\xv', \xv) = \frac{1}{p} \sum_{j = 1}^{p} \del
 % %\footnote[frame]{Verma et al. (2020). \href{https://arxiv.org/pdf/2010.10596.pdf}{Counterfactual Explanations for Machine Learning: A Review.}}
 % \end{frame}
 
-\begin{frame}{Further Objectives: Sparsity}
-	%While validity is a necessary condition for counterfactuals,
-	Additional constraints can improve the explanation quality of the corresponding CEs\\
-	$\leadsto$ popular constraints include \textbf{sparsity} and \textbf{plausibility}
-	
-	\lz
-
-	\textbf{Sparsity} Favor explanations that change few features
-	\begin{itemize}[<+->]
-		\item End-users often prefer short over long explanations%\\
-        \item Sparsity could be integrated into $o_{proximity}$ \\
-        e.g., using L$_0$-norm (number of changed features) or L$_1$-norm (LASSO)
-		%$\leadsto$ %changes made to obtain
-		%counterfactuals should be \textbf{sparse} %(i.e., only few feature values should change)
-		%\item Objective $o_{proximity}$ can take the number of changed features into account (but does not have to)\\
-		%$\leadsto$ e.g., the L$_0$- and the L$_1$-norm (similar to LASSO) can do this
+\begin{framev}[align=top]{Further Objectives: Sparsity}
+%While validity is a necessary condition for counterfactuals,
+Additional constraints can improve the explanation quality of the corresponding CEs\\
+$\leadsto$ popular constraints include \textbf{sparsity} and \textbf{plausibility}\\
+\spacer[0.25]
+\textbf{Sparsity} Favor explanations that change few features
+\begin{itemizeM}
+\item<+-> End-users often prefer short over long explanations
+\item<+-> Sparsity could be integrated into $o_{proximity}$\\
+e.g., using L$_0$-norm (number of changed features) or L$_1$-norm (LASSO)
+%$\leadsto$ %changes made to obtain
+%counterfactuals should be \textbf{sparse} %(i.e., only few feature values should change)
+%\item Objective $o_{proximity}$ can take the number of changed features into account (but does not have to)\\
+%$\leadsto$ e.g., the L$_0$- and the L$_1$-norm (similar to LASSO) can do this
 %		\item There could be a trade-off between the number of features changed and the total amount of change made to obtain a certain prediction.
-        \item Alternative: Include separate objective measuring sparsity, e.g., via L$_0$-norm
-        %we can also account for sparsity by adding an extra term to our objective that counts the number of changed features via the L0-norm
-        $$o_{sparse}(\xv', \xv) = \sum_{j = 1}^p {\ind}_{\{ x'_j \neq x_j \}}$$
-	\end{itemize}
-\end{frame}
+\item<+-> Alternative: Include separate objective measuring sparsity, e.g., via L$_0$-norm
+%we can also account for sparsity by adding an extra term to our objective that counts the number of changed features via the L0-norm
+$$
+o_{sparse}(\xv', \xv) = \sum_{j = 1}^p \ind_{\{x'_j \neq x_j\}}
+$$
+\end{itemizeM}
+\end{framev}
 
-\begin{frame}{Further Objectives: Plausibility}
-		\textbf{Plausibility:}
-		\begin{itemize}
-			%\item CEs should suggest alternatives that are plausible -- e.g, it is a bad idea to suggest a loan applicant to raise her income and get unemployed at the same time
-			\item<1-> CEs should suggest realistic (i.e., plausible) alternatives\\
-			$\leadsto$ Implausible: increase income \emph{and} become unemployed
-            %e.g., not plausible to suggest to raise your income and get unemployed at the same time
-			\item<2-> CEs should adhere to data manifold or originate from distribution of $\Xspace$\\
-			$\leadsto$ Avoid unrealistic combinations of feature values
-			%We desire realistic CEs in the sense that they originate from the distribution of $\Xspace$ or adhere to the data manifold
-			\item<3-> Estimating joint distribution is hard, especially for mixed feature spaces\\
-			$\leadsto$ Common proxy: ensure that $\xv'$ is close to training data $\Xmat$
-		\end{itemize}	
-	\only<4>{
-	\begin{columns}[c, totalwidth=\textwidth]
-	\begin{column}{0.43\textwidth}
-	\includegraphics[width=1\textwidth]{figure/counterfactuals_obj}			
-	\end{column}
-    
-\begin{column}{0.6\textwidth}
-    \textbf{Example from \furtherreading{VERMA2020}} 
-    \begin{itemize}
-        \item Input \textcolor{blue}{$\xv$} originally classified as $\pmb{\circleddash}$ 
-        \item Two valid CEs in class $\pmb\oplus$: {\color{Red} CF1} and {\color{Green} CF2}
-        \item {\color{Red} Path \textbf{A} (CF1)} is shorter (but unrealistic)
-        \item {\color{Green} Path \textbf{B} (CF2)} is longer but in data manifold
-    \end{itemize}
-    %Two possible paths for \textcolor{blue}{$\xv$},			originally classified in the negative class. The two counterfactuals (\textcolor{red}{CF1} and \textcolor{green}{CF2}) are valid. Note that the red path $A$ for CF1 is the shortest, whereas the green path $B$ for CF2 adheres closely to the manifold of the training data, but is longer.
-\end{column}
-\end{columns}
+
+\begin{framev}[align=top]{Further Objectives: Plausibility}
+\textbf{Plausibility:}
+\begin{itemizeM}
+%\item CEs should suggest alternatives that are plausible -- e.g, it is a bad idea to suggest a loan applicant to raise her income and get unemployed at the same time
+\item<1-> CEs should suggest realistic (i.e., plausible) alternatives\\
+$\leadsto$ Implausible: increase income \emph{and} become unemployed
+%e.g., not plausible to suggest to raise your income and get unemployed at the same time
+\item<2-> CEs should adhere to data manifold or originate from distribution of $\Xspace$\\
+$\leadsto$ Avoid unrealistic combinations of feature values
+%We desire realistic CEs in the sense that they originate from the distribution of $\Xspace$ or adhere to the data manifold
+\item<3-> Estimating joint distribution is hard, especially for mixed feature spaces\\
+$\leadsto$ Common proxy: ensure that $\xv'$ is close to training data $\Xmat$
+\end{itemizeM}
+\only<4>{
+\splitVCC[0.43]{
+\image[1]{figure/counterfactuals_obj}
+}{
+\textbf{Example from \furtherreading{VERMA2020}}
+\begin{itemizeM}
+\item Input \textcolor{blue}{$\xv$} originally classified as $\pmb{\circleddash}$
+\item Two valid CEs in class $\pmb\oplus$: {\color{Red} CF1} and {\color{Green} CF2}
+\item {\color{Red} Path \textbf{A} (CF1)} is shorter (but unrealistic)
+\item {\color{Green} Path \textbf{B} (CF2)} is longer but in data manifold
+\end{itemizeM}
+%Two possible paths for \textcolor{blue}{$\xv$},			originally classified in the negative class. The two counterfactuals (\textcolor{red}{CF1} and \textcolor{green}{CF2}) are valid. Note that the red path $A$ for CF1 is the shortest, whereas the green path $B$ for CF2 adheres closely to the manifold of the training data, but is longer.
+}
 }
 %\footnote[frame]{Verma et al. (2020). \href{https://arxiv.org/pdf/2010.10596.pdf}{Counterfactual Explanations for Machine Learning: A Review.}}
+\end{framev}
 
-\end{frame}
 
-
-\begin{frame}{Further Objectives}
-	%\begin{itemize}
-	%\item 
+\begin{framev}[align=top]{Further Objectives}
+%\begin{itemize}
+%\item
 %For example, $o_{plausible}$ could then be the Gower distance of $\xv'$ to the nearest data point of the training dataset $\xv^{[1]}$
-
 % To ensure plausibility, $o_{plausible}$ could, e.g., be the Gower distance of $\xv'$ to its nearest data point of the training dataset which we denote $\xv^{[1]}$:
 \textbf{Plausibility term:} Encourage counterfactuals close to observed data.
-
-\begin{itemize}
-  \item Define $\xv^{[1]}$ as the nearest neighbor of $\xv'$ in the training set $\Xmat$
-  \item Use Gower distance between $\xv'$ and $\xv^{[1]}$ to define plausibility objective: 
-$$o_{plausible}(\xv', \Xmat) = \Gower(\xv', \xv^{[1]}) = \frac{1}{p} \sum_{j = 1}^{p}  \delta_G(x_j', x^{[1]}_j)$$
-\end{itemize}
-
-
+\begin{itemizeM}
+\item Define $\xv^{[1]}$ as the nearest neighbor of $\xv'$ in the training set $\Xmat$
+\item Use Gower distance between $\xv'$ and $\xv^{[1]}$ to define plausibility objective:
+$$
+o_{plausible}(\xv', \Xmat) = \Gower(\xv', \xv^{[1]}) = \frac{1}{p} \sum_{j = 1}^{p} \delta_G(x_j', x^{[1]}_j)
+$$
+\end{itemizeM}
 \pause
-
+\spacer[0.25]
 \textbf{Extended optimization:} Add sparsity and plausibility terms to the objective
-
-\[
-\argmin_{\xv'} \lambda_1 o_{\text{target}}(\fh(\xv'), y') 
-+ \lambda_2 o_{\text{proximity}}(\xv', \xv)
-+ \lambda_3 o_{\text{sparse}}(\xv', \xv) 
-+ \lambda_4 o_{\text{plausible}}(\xv', \Xmat)
-\]
+$$
+\argmin_{\xv'} \lambda_1 o_{target}(\fh(\xv'), y')
++ \lambda_2 o_{proximity}(\xv', \xv)
++ \lambda_3 o_{sparse}(\xv', \xv)
++ \lambda_4 o_{plausible}(\xv', \Xmat)
+$$
 %\end{itemize}
-
 % We can extend the previous optimization problem by adding $o_{sparse}$ (for sparsity) and $o_{plausible}$ (for plausibility):
-
 % $$\argmin_{\xv'} \lambda_1 o_{target}(\fh(\xv'), y') + \lambda_2 o_{proximity}(\xv', \xv) + \lambda_3 o_{sparse}(\xv', \xv) + \lambda_4 o_{plausible}(\xv', \Xmat)$$
+\end{framev}
 
-\end{frame}
 
-
-\begin{frame}{Remarks: The Rashomon Effect}
+\begin{framev}[align=top]{Remarks: The Rashomon Effect}
 %The solution to the optimization problem might not be unique, there can be many equally close inputs that obtain the desired classification. Correspondingly, there can be many different equally good explanations for the same decision. This is called the \textbf{Rashomon effect}.
-
 \textbf{Issue (\textbf{Rashomon effect}):}
-\begin{itemize}
-    \item Solution to the optimization problem might not be unique
-    \item Many equally close CE might exist that obtain the desired prediction\\
-    $\Rightarrow$ Many different equally good explanations for the same decision exist
-\end{itemize}
-
-\lz\pause
-
+\begin{itemizeM}
+\item Solution to the optimization problem might not be unique
+\item Many equally close CEs might exist that obtain the desired prediction\\
+$\Rightarrow$ Many different equally good explanations for the same decision exist
+\end{itemizeM}
+\pause
+\spacer[0.25]
 \textbf{Possible solutions:}
-	\begin{itemize}
-	\item Present all CEs for $\xv$ (but: time and human processing capacity is limited)
-		%\item We could present all CEs for a given case; however, time is limited and so is the human processing capacity
-		%\item Another solution is to focus on one or few CEs; however, by which criterion should they be selected?
-		\item Focus on one/few CEs (but: by which criterion should guide this choice?)
-	\end{itemize}
-	
-\lz\pause
-
+\begin{itemizeM}
+\item Present all CEs for $\xv$ (but: time and human processing capacity is limited)
+%\item We could present all CEs for a given case; however, time is limited and so is the human processing capacity
+%\item Another solution is to focus on one or few CEs; however, by which criterion should they be selected?
+\item Focus on one/few CEs (but: by which criterion should guide this choice?)
+\end{itemizeM}
+\pause
+\spacer[0.25]
 \textbf{Note:}
-	\begin{itemize}
-      \item Nonlinear models can produce diverse and inconsistent CEs\\
-  $\leadsto$ suggest both increasing and decreasing credit duration\\ (confusing for users)
-  \item Handling this \textbf{Rashomon effect} remains an open problem in interpretable ML
-  %       \item As the model is generally non-linear, inconsistent and diverse CEs can arise\\
-  %       e.g. suggesting either an increase or decrease in credit duration (confuses the explainee)
-		% \item How to deal with the Rashomon effect is considered an open problem in IML
-	\end{itemize}
-\end{frame}
+\begin{itemizeM}
+\item Nonlinear models can produce diverse and inconsistent CEs\\
+$\leadsto$ suggest both increasing and decreasing credit duration\\
+(confusing for users)
+\item Handling this \textbf{Rashomon effect} remains an open problem in interpretable ML
+%       \item As the model is generally non-linear, inconsistent and diverse CEs can arise\\
+%       e.g. suggesting either an increase or decrease in credit duration (confuses the explainee)
+% \item How to deal with the Rashomon effect is considered an open problem in IML
+\end{itemizeM}
+\end{framev}
 
-\begin{frame}{Remarks: Model or Real-World}
 
-	\begin{itemize}
-	\item CEs explain model predictions, but may seem to explain real-world users\\
-$\leadsto$ Transfer of model explanations to explain real-world is generally not permitted
-  \item \textbf{Example:} CE suggests increasing age by 5 to receive a loan\\
-  $\leadsto$ The applicant waits 5 years and reapplies
-  \pause
-  \item \textbf{Problem:} Other features may change in the meantime (e.g., job status, income)  
-  %$\leadsto$ Age is causally linked to other variables\\
-  $\leadsto$ \furtherreading{KARIMI2020} propose CEs that respect causal structure
-  \item \textbf{Model drift:} Bank's algorithm itself may change over time\\
-  $\leadsto$ Past CEs may become invalid
-	% \item Consider a CE that proposes to increase the feature age by 5 to obtain the loan\\
-	% $\leadsto$ a loan applicant takes this information and applies 5 years later for the loan
-	% \item However, by then, many 
-	% %of their 
-	% other feature values 
-	% %properties 
-	% might have changed\\
-	% $\leadsto$ not only age, also other causally dependent features e.g. job status might have changed \\%after 5 years% since they are causally dependent on age like income or the job status
-	% $\leadsto$ \furtherreading{KARIMI2020} avoid this by considering causal dependencies between features
-	% \item Also, the bank's algorithm might change and previous CEs are not applicable anymore
-	%\item Even worse, the user might have typos in the application and in fact no changes are necessary to obtain the loan.
+\begin{framev}[align=top]{Remarks: Model or Real-World}
+\begin{itemizeM}
+\item CEs explain model predictions, but may seem to explain real-world users\\
+$\leadsto$ Transfer of model explanations to explain real-world is generally not allowed
+\item \textbf{Example:} CE suggests increasing age by 5 to receive a loan\\
+$\leadsto$ The applicant waits 5 years and reapplies
+\pause
+\item \textbf{Problem:} Other features may change till then (e.g., job status, income)\\
+%$\leadsto$ Age is causally linked to other variables\\
+$\leadsto$ \furtherreading{KARIMI2020} propose CEs that respect causal structure
+\item \textbf{Model drift:} Bank's algorithm itself may change over time\\
+$\leadsto$ Past CEs may become invalid
+% \item Consider a CE that proposes to increase the feature age by 5 to obtain the loan\\
+% $\leadsto$ a loan applicant takes this information and applies 5 years later for the loan
+% \item However, by then, many
+% %of their
+% other feature values
+% %properties
+% might have changed\\
+% $\leadsto$ not only age, also other causally dependent features e.g. job status might have changed \\%after 5 years% since they are causally dependent on age like income or the job status
+% $\leadsto$ \furtherreading{KARIMI2020} avoid this by considering causal dependencies between features
+% \item Also, the bank's algorithm might change and previous CEs are not applicable anymore
+%\item Even worse, the user might have typos in the application and in fact no changes are necessary to obtain the loan.
 %		\item Actionability: We could further strengthen above's plausibility criterion by requiring counterfactuals that do not change immutable features (e.g., race, city of birth, sex). Therefore, we could  search for counterfactuals only among a defined feasible set of counterfactuals $\mathcal{A}$.
 %		\item Causality: We could also restrict the search to counterfactuals that maintain any known causal relations. In the real world, if one feature is changed it affects also other features. E.g., better skills lead to better salary, but also a higher age due to the necessary training.
-	\end{itemize}
+\end{itemizeM}
 %\footnote[frame]{Karimi et al. (2021). Algorithmic Recourse: From Counterfactual Explanations to Interventions.  Proceedings of the 2021 ACM Conference on Fairness, Accountability, and Transparency. 353–362.}
-\end{frame}
-
-
+\end{framev}
 
 \endlecture
 \end{document}

--- a/slides/local-explanations-counterfactual/slides08-le-counterfactuals-methods.tex
+++ b/slides/local-explanations-counterfactual/slides08-le-counterfactuals-methods.tex
@@ -4,25 +4,23 @@
 \input{../../latex-math/basic-math}
 \input{../../latex-math/basic-ml}
 % Defines macros and environments
- 
+
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
-	
-	
-	% Set style/preamble.Rnw as parent.
-	
-	% Load all R packages and set up knitr
-	
-	% This file loads R packages, configures knitr options and sets preamble.Rnw as 
-	% parent file
-	% IF YOU MODIFY THIS, PLZ ALSO MODIFY setup.Rmd ACCORDINGLY...
-	
-	% Defines macros and environments
-	
+
+% Set style/preamble.Rnw as parent.
+
+% Load all R packages and set up knitr
+
+% This file loads R packages, configures knitr options and sets preamble.Rnw as
+% parent file
+% IF YOU MODIFY THIS, PLZ ALSO MODIFY setup.Rmd ACCORDINGLY...
+
+% Defines macros and environments
+
 \titlemeta{
 Counterfactual Explanations (CEs)
 }{
@@ -34,186 +32,152 @@ figure/counterfactuals_heat.png
 \item Know problems and limitations of CEs
 }
 
-	
-	% ------------------------------------------------------------------------------
+% ------------------------------------------------------------------------------
 
-
-\begin{frame}{Overview of Counterfactual Methods}
+\begin{framev}[align=top]{Overview of Counterfactual Methods}
 Many methods exist to generate counterfactuals, they mainly differ in:
-    
-	\begin{itemize}[<+->]
-		  \item \textbf{Target:} Most support classification; few extend to regression\\
-  $\leadsto$ Recent work extends CEs to other ML tasks (un-, semi-, self-supervised)
- \item \textbf{Data type:} Focus is on tabular data; little work on text, vision, audio
-		\item \textbf{Feature space:} Some handle only numerical features; few support mixed data types
-        %Some methods can only handle numerical features, few can process mixed (numerical and discrete) feature spaces
-		\item \textbf{Objectives:} 
-        From core goals like sparsity and plausibility to emerging aims such as fairness, personalization, and robustness
-        %Many methods focus on action guidance, plausibility and sparsity, few on other objectives like fairness or individual preferences
-		\item \textbf{Model access:} 
-        Methods range from model-specific (requiring access to model internals/gradients) to model-agnostic (using only prediction funcs)
-        %Methods either require access to complete model internals, access to gradients, or only to prediction functions \\
-        %$\leadsto$ Model-agnostic and model-specific methods exist
-		 \item \textbf{Optimization:} 
-         From gradient-based (differentiable models) and mixed-integer programming (linear models) to gradient-free methods (e.g., genetic algorithms)
-         %From gradient-based (for differentiable models) to gradient-free and heuristic methods (e.g., genetic algorithms, evolutionary strategies)
-        %Gradient-based algorithms (only for differentiable models), mixed-integer programming (only linear), or gradient-free algorithms e.g. Nelder-Mead, genetic algorithm
-		\item \textbf{Rashomon Effect:} Many methods return one CE, some diverse sets of CEs, others prioritize CEs, or let the user choose
-	\end{itemize}
-\end{frame}
+\begin{itemizeM}
+\item<+-> \textbf{Target:} Most support classification; few extend to regression\\
+$\leadsto$ Recent work extends CEs to other ML tasks (un-, semi-, self-supervised)
+\item<+-> \textbf{Data type:} Focus is on tabular data; little work on text, vision, audio
+\item<+-> \textbf{Feature space:} Some handle only numerical features; few support features with mixed data types
+%Some methods can only handle numerical features, few can process mixed (numerical and discrete) feature spaces
+\item<+-> \textbf{Objectives:}
+From core goals like sparsity and plausibility to emerging aims such as fairness, personalization, and robustness
+%Many methods focus on action guidance, plausibility and sparsity, few on other objectives like fairness or individual preferences
+\item<+-> \textbf{Model access:}
+Methods range from model-specific (requiring access to model internals/gradients) to model-agnostic (using only prediction funcs)
+%Methods either require access to complete model internals, access to gradients, or only to prediction functions \\
+%$\leadsto$ Model-agnostic and model-specific methods exist
+\item<+-> \textbf{Optimization:}
+From gradient-based (differentiable models) and mixed-integer programming (linear models) to gradient-free methods (e.g. genetic algorithms)
+%From gradient-based (for differentiable models) to gradient-free and heuristic methods (e.g., genetic algorithms, evolutionary strategies)
+%Gradient-based algorithms (only for differentiable models), mixed-integer programming (only linear), or gradient-free algorithms e.g. Nelder-Mead, genetic algorithm
+\item<+-> \textbf{Rashomon Effect:} Many methods return one CE, some diverse sets of CEs, others prioritize CEs, or let the user choose
+\end{itemizeM}
+\end{framev}
 
-\begin{frame}{First Optimization-based CE Method \furtherreading{WACHTER2018}}
+
+\begin{framev}[align=top]{First Optimization-based CE Method \furtherreading{WACHTER2018}}
 Introduced CEs in context of ML predictions by solving
-		$$
-			\argmin_{\xv'} \max_{\lambda} \lambda \underbrace{(\fh(\xv') - y')^2}_{o_{target}(\fh(\xv'), y')} + \underbrace{\sum\nolimits_{j = 1}^p \frac{|x'_j - x_j|}{MAD_j}}_{o_{proximity}(\xv', \xv)}
-			%\label{eq:wachter}
-		$$
-\begin{itemize}
+$$
+\argmin_{\xv'} \max_{\lambda} \lambda \underbrace{(\fh(\xv') - y')^2}_{o_{target}(\fh(\xv'), y')} + \underbrace{\sum\nolimits_{j = 1}^p \frac{|x'_j - x_j|}{MAD_j}}_{o_{proximity}(\xv', \xv)}
+%\label{eq:wachter}
+$$
+\begin{itemizeM}
 \item $o_{target}$ ensures prediction flips to $y'$ (by increasing weight $\lambda$)
-\item $o_{proximity}$ penalizes deviations from $\xv$, rescaled by median abs. deviation: $MAD_j = \text{med}_{i \in \{1, \dots, n\}} ( | x^{(i)}_j - \text{med}_{k\in \{1, \dots, n\}} (x^{(k)}_j) | )$)
+\item $o_{proximity}$ penalizes deviations from $\xv$, rescaled by median abs. deviation: $MAD_j = \text{med}_{i \in \{1, \dots, n\}} ( | x^{(i)}_j - \text{med}_{k \in \{1, \dots, n\}} (x^{(k)}_j) | )$
 %\(L_{1}\)-distance rescaled by \(MAD_{j}\) to encourage sparse, human-interpretable edits.
-  %\item $MAD_j = \text{med}_{i \in \{1, \dots, n\}} \left( | x^{(i)}_j - \text{med}_{k\in \{1, \dots, n\}} (x^{(k)}_j) | \right)$: Median abs. deviation $x_j$
-  %\item Optimization alternates: Nelder-Mead minimizes over $\xv'$, then $\lambda$ is increased iteratively until a sufficiently close solution is found
-\end{itemize}
-
-\lz
+%\item $MAD_j = \text{med}_{i \in \{1, \dots, n\}} \left( | x^{(i)}_j - \text{med}_{k\in \{1, \dots, n\}} (x^{(k)}_j) | \right)$: Median abs. deviation $x_j$
+%\item Optimization alternates: Nelder-Mead minimizes over $\xv'$, then $\lambda$ is increased iteratively until a sufficiently close solution is found
+\end{itemizeM}
 \pause
-
-\textbf{Approach: Alternating optimization over \(\mathbf{x}'\) and \(\lambda\)}
-
-\begin{itemize}
-  \item Start with an initial \(\lambda\) (controls emphasis on $o_{target}$ vs. $o_{proximity}$)
-  \item Use a gradient-free optimizer (e.g., Nelder-Mead) to minimize over \(\mathbf{x}'\)
-  \item If prediction constraint not satisfied (\(\hat{f}(\mathbf{x}') \ne y'\)), increase \(\lambda\) and repeat
-  \\
-  $\leadsto$ \(\lambda\) serves as soft constraint, gradually enforcing prediction validity \(\hat{f}(\mathbf{x}') = y'\)
-  \item Iteratively shift focus: 1. achieve prediction validity, 2. minimize proximity%distance $o_{proximity}$
-  %\item \textbf{Intuition:} \(\lambda\) acts as a soft constraint enforcer
-\end{itemize}
-
-
-    % $MAD_j$ is the median absolute deviation of feature $j$. In each iteration, optimizers like Nelder-Mead solve the equation for $\xv'$ and then $\lambda$ is increased until a sufficiently close solution is found \\[0.2cm]
-	
-	%\pause
-	
-	% This optimization problem has several shortcomings: 	
-	% \begin{itemize}%[<+->]
-	% 	\item No principled way to set $\lambda$; it is increased manually during optimization %We do not know how to choose $\lambda$ a priori 
-	% 	\item Emphasis on $o_{\text{target}}$ dominates early iterations\\%; $o_{proximity}$ is only minimized once prediction is met
+\spacer[0.25]
+\textbf{Approach: Alternating optimization over $\mathbf{x}'$ and $\lambda$}
+\begin{itemizeM}
+\item Start with an initial $\lambda$ (controls emphasis on $o_{target}$ vs. $o_{proximity}$)
+\item Use a gradient-free optimizer (e.g., Nelder-Mead) to minimize over $\mathbf{x}'$
+\item If prediction constraint not satisfied ($\hat{f}(\mathbf{x}') \ne y'$), increase $\lambda$ and repeat\\
+$\leadsto$ $\lambda$ serves as soft constraint, gradually enforcing prediction validity $\hat{f}(\mathbf{x}') = y'$
+\item Iteratively shift focus: 1. achieve prediction validity, 2. minimize proximity%distance $o_{proximity}$
+%\item \textbf{Intuition:} \(\lambda\) acts as a soft constraint enforcer
+\end{itemizeM}
+% $MAD_j$ is the median absolute deviation of feature $j$. In each iteration, optimizers like Nelder-Mead solve the equation for $\xv'$ and then $\lambda$ is increased until a sufficiently close solution is found \\[0.2cm]
+%\pause
+% This optimization problem has several shortcomings:
+% \begin{itemize}%[<+->]
+% 	\item No principled way to set $\lambda$; it is increased manually during optimization %We do not know how to choose $\lambda$ a priori
+% 	\item Emphasis on $o_{\text{target}}$ dominates early iterations\\%; $o_{proximity}$ is only minimized once prediction is met
  %        %Due to the maximization of $\lambda$, we focus primarily on the minimization of $o_{target}$\\
-	% 	$\leadsto$ Once $\fh(\xv') \approx y'$ is met, we focus on minimizing $o_{proximity}$ 
-	% 	\item Definition of $o_{proximity}$ only covers numerical features 
-	% 	\item Additional objectives such as sparsity and plausibility are not considered
-	% \end{itemize}
-	
+% 	$\leadsto$ Once $\fh(\xv') \approx y'$ is met, we focus on minimizing $o_{proximity}$
+% 	\item Definition of $o_{proximity}$ only covers numerical features
+% 	\item Additional objectives such as sparsity and plausibility are not considered
+% \end{itemize}
+%\footnote[frame]{Wachter S, Mittelstadt B, Russel C (2017). Counterfactual Explanations Without Opening the Black Box: Automated Decisions and the GDPR. Harvard Journal of Law \& Technology, 31 (2), 2018. \url{http://dx.doi.org/10.2139/ssrn.3063289}}
+\end{framev}
 
 
-	%\footnote[frame]{Wachter S, Mittelstadt B, Russel C (2017). Counterfactual Explanations Without Opening the Black Box: Automated Decisions and the GDPR. Harvard Journal of Law \& Technology, 31 (2), 2018. \url{http://dx.doi.org/10.2139/ssrn.3063289}}
-\end{frame}
-
-
-
-%------------------------------------------------------------
-\begin{frame}{Limitations of Wachter's Approach}
-\vspace{0.2cm}
-
-\begin{itemize}
-  \item \textbf{Manual tuning:} No principled way to set \(\lambda\); requires iterative increase
-  \item \textbf{Asymmetric focus:} Early iterations dominated by minimizing target loss
-  \item \textbf{Limited feature support:} Proximity term defined only for numerical feats
-  \item \textbf{No additional objectives:} Ignores sparsity, plausibility, fairness, diversity
-  \item \textbf{Single solution:} Returns one CE; no support for diverse or ranked CEs
-\end{itemize}
-
+\begin{framei}[align=top]{Limitations of Wachter's Approach}
+\item \textbf{Manual tuning:} No principled way to set $\lambda$; requires iterative increase
+\item \textbf{Asymmetric focus:} Early iterations dominated by minimizing target loss
+\item \textbf{Limited feature support:} Proximity term defined only for numerical feats
+\item \textbf{No additional objectives:} Ignores sparsity, plausibility, fairness, diversity
+\item \textbf{Single solution:} Returns one CE; no support for diverse or ranked CEs
 % \vspace{0.3cm}
 % \textbf{Impact:} Simple and general, but lacks robustness for modern CE requirements
-\end{frame}
+\end{framei}
 
 
+\begin{framei}[align=top]{Multi-Objective CE \furtherreading{DANDL2020}}
+\item \textbf{Multi-Objective Counterfactual Explanations (MOC):} Instead of collapsing objectives into a single obj., optimize all 4 obj. simultaneously
+$$
+\argmin_{\xv'} \left(o_{target}(\fh(\xv'), y'), o_{proximity}(\xv', \xv), o_{sparse}(\xv', \xv), o_{plausible}(\xv', \Xmat) \right).
+$$
+\item Avoids using/tuning of weights (e.g., $\lambda$); returns Pareto-optimal set
+%Note: Weighting parameters like $\lambda$ not necessary anymore
+%\item This approach is called Multi-Objective Counterfactual Explanations (MOC) and was developed by Dandl et al. in 2020.
+\item Uses an adjusted multi-objective genetic algo. (NSGA-II) for mixed feats %ture types (numeric/categorical)
+%Uses an adjusted multi-objective genetic algorithm (NSGA-II) to produce a set of diverse CEs for mixed discrete and continuous feature spaces
+\item Outputs diverse CEs representing different trade-offs between objectives
+%Instead of one, MOC returns multiple CEs that represent different trade-offs between the objectives and are constructed to be diverse in feature space
+%\footnote[frame]{Dandl et al. (2020) Multi-Objective Counterfactual Explanations. In: Bäck T. et al. (eds) Parallel Problem Solving from Nature – PPSN XVI. PPSN 2020. Lecture Notes in Computer Science, vol 12269. Springer, Cham.}
+\end{framei}
 
 
-\begin{frame}{Multi-Objective CE \furtherreading{DANDL2020}}
-	\begin{itemize}
-		\item \textbf{Multi-Objective Counterfactual Explanations (MOC):} Instead of collapsing objectives into a single obj., optimize all 4 obj. simultaneously
-	$$	\argmin_{\xv'} \left(o_{target}(\fh(\xv'), y'), o_{proximity}(\xv', \xv), o_{sparse}(\xv', \xv), o_{plausible}(\xv', \Xmat) \right). $$
-		
-		\item Avoids using/tuning of weights (e.g., \(\lambda\)); returns Pareto-optimal set
-        %Note: Weighting parameters like $\lambda$ not necessary anymore
-		%\item This approach is called Multi-Objective Counterfactual Explanations (MOC) and was developed by Dandl et al. in 2020. 
-		\item Uses an adjusted multi-objective genetic algo. (NSGA-II) for mixed feats %ture types (numeric/categorical)
-        %Uses an adjusted multi-objective genetic algorithm (NSGA-II) to produce a set of diverse CEs for mixed discrete and continuous feature spaces
-		\item Outputs diverse CEs representing different trade-offs between objectives
-        %Instead of one, MOC returns multiple CEs that represent different trade-offs between the objectives and are constructed to be diverse in feature space
-	\end{itemize}
+\begin{framei}[align=top]{Example: Credit Data}
+\item Model: SVM with RBF kernel
+\item $\xv$: First data point of credit data with $\P(y = good) = 0.34$ %of being a ``good" customer
+\item Goal: Increase the probability to desired outcome $[0.5, 1]$
+\item MOC (with default parameters) returned 69 valid CEs after 200 iterations%found 69 CEs after 200 iterations that met the target
+\item All CEs modified credit duration; many also adjusted credit amount
+%proposed changes to credit duration and many of them to credit amount
+\end{framei}
 
-	%\footnote[frame]{Dandl et al. (2020) Multi-Objective Counterfactual Explanations. In: Bäck T. et al. (eds) Parallel Problem Solving from Nature – PPSN XVI. PPSN 2020. Lecture Notes in Computer Science, vol 12269. Springer, Cham.}
-\end{frame}
 
-\begin{frame}{Example: Credit Data}
-	\begin{itemize}
-		\item Model: SVM with RBF kernel
-		\item $\xv$: First data point of credit data with $\P(y = good)  = 0.34$ %of being a ``good" customer
-		\item Goal: Increase the probability to desired outcome $[0.5, 1]$
-		\item MOC (with default parameters) returned 69 valid CEs after 200 iterations%found 69 CEs after 200 iterations that met the target
-		\item All CEs modified credit duration; many also adjusted credit amount
-        %proposed changes to credit duration and many of them to credit amount
-	\end{itemize}
-\end{frame}
-
-\begin{frame}{Example: Credit Data \furtherreading{DANDL2020}}
-\begin{itemize}
-	\item<1-> Feature changes can be visualized using parallel and 2D surface plots
-    %We can visualize feature changes with a parallel plot and 2-dim surface plot
-		\item<1-> Parallel plot: All CEs had values equal to or smaller than the values of $\xv$
-		\item<2-> Surface plot: CEs in lower-left appear distant, but lie in high-density regions near training data (as shown by histograms)
-        %CE why these feature changes are recommended 
-		%\item<2-> Counterfactuals in the lower left corner seem to be in a less favorable region far from $\xv$, but they are in high density areas close to training samples (indicated by histograms)
-	\end{itemize}
-	\begin{columns}[totalwidth=\textwidth]\only<1->{
-	\begin{column}{0.5\textwidth}  
-	\centering
-			%\begin{center}
-		\includegraphics[width=0.75\textwidth]{figure/counterfactuals_credit_parallel}\\
-			%\end{center}
-		%\vspace{-0.2cm}
-			\scriptsize{
-            \textbf{Parallel plot:} Grey lines = CEs $\xv'$, blue line = $\xv$. Features without changes omitted. \\
-            Bold numbers denote numeric ranges.
-            %\textbf{Parallel plot:} Grey lines show feature values of CEs $\xv'$, blue line are values of $\xv$. Features without proposed changes are omitted. Bold numbers refer to range of numeric features.
-            } 
-			
-		\end{column}}
-		\visible<2->{
-		\begin{column}{0.5\textwidth}
-			%\begin{center}
-			\centering
-			\includegraphics[width=\textwidth]{figure/counterfactuals_credit_heat}\\
-			%\end{center}
-		%\vspace{-0.2cm}
-			\scriptsize{
-            \textbf{Surface plot:} 
-            White dot = $\xv$, black dots = CEs $\xv'$.
-            %White dot is $\xv$, black dots are CEs $\xv'$. \\
-			\textbf{Histograms:} Marginal distribution of training data $\Xmat$.
-            } 
-		\end{column}
-		}
-	\end{columns}
+\begin{framev}[align=top]{Example: Credit Data \furtherreading{DANDL2020}}
+\begin{itemizeM}
+\item<1-> Feature changes can be visualized using parallel and 2D surface plots
+%We can visualize feature changes with a parallel plot and 2-dim surface plot
+\item<1-> Parallel plot: All CEs had values equal to or smaller than the values of $\xv$
+\item<2-> Surface plot: CEs in lower-left appear distant, but lie in high-density regions near training data (as shown by histograms)
+%CE why these feature changes are recommended
+%\item<2-> Counterfactuals in the lower left corner seem to be in a less favorable region far from $\xv$, but they are in high density areas close to training samples (indicated by histograms)
+\end{itemizeM}
+\splitVTT{
+\only<1->{
+\spacer[0.25]
+\imageC[0.8]{figure/counterfactuals_credit_parallel}
+\begin{scriptsize}
+\textbf{Parallel plot:} Grey lines = CEs $\xv'$, blue line = $\xv$. Features without changes omitted.\\
+Bold numbers denote numeric ranges.
+%\textbf{Parallel plot:} Grey lines show feature values of CEs $\xv'$, blue line are values of $\xv$. Features without proposed changes are omitted. Bold numbers refer to range of numeric features.
+\end{scriptsize}
+}
+}{
+\visible<2->{
+\spacer[0.25]
+\imageC{figure/counterfactuals_credit_heat}
+\begin{scriptsize}
+\textbf{Surface plot:} White dot = $\xv$, black dots = CEs $\xv'$.\\
+%White dot is $\xv$, black dots are CEs $\xv'$. \\
+\textbf{Histograms:} Marginal distribution of training data $\Xmat$.
+\end{scriptsize}
+}
+}
 %\footnote[frame]{Dandl S., Molnar C., Binder M., Bischl B. (2020) Multi-Objective Counterfactual Explanations. In: Bäck T. et al. (eds) Parallel Problem Solving from Nature – PPSN XVI. PPSN 2020. Lecture Notes in Computer Science, vol 12269. Springer, Cham.}
-\end{frame}
-
+\end{framev}
 
 %\begin{frame}{Example: Bike Sharing Dataset}
 %	\begin{itemize}
 %		\item Model: Random Forest with 500 trees
-%		\item $\xv$ is the first data point of the dataset with $\fh(\xv) = 1767.93$ rental bikes. 
+%		\item $\xv$ is the first data point of the dataset with $\fh(\xv) = 1767.93$ rental bikes.
 %		\item Our desired goal is to increase the count of total rental bikes to $y' = [3000, \infty[$
 %		\item MOC (with default parameters) found 56 counterfactuals after 200 iterations that met the target.
-%		\item Most counterfactuals proposed to decrease the humidity (94.6 \%) and more than half to increase the temperature (55.4\%). 
+%		\item Most counterfactuals proposed to decrease the humidity (94.6 \%) and more than half to increase the temperature (55.4\%).
 %		\item Some counterfactuals proposed additional changes to the year (2012 instead of 2011) and month (December instead of Januar).
-%		\framebreak 
-%		\item We can visualize feature changes with a parallel plot. 
-%		\item For humidity and temperature, we can additionally show a 2-dim surface plot. 
+%		\framebreak
+%		\item We can visualize feature changes with a parallel plot.
+%		\item For humidity and temperature, we can additionally show a 2-dim surface plot.
 %	\end{itemize}
 %	\vspace{-0.5cm}
 %	\begin{columns}[totalwidth=\textwidth]
@@ -221,78 +185,70 @@ Introduced CEs in context of ML predictions by solving
 %			\begin{center}
 %				\includegraphics[width=1\textwidth]{figure/counterfactuals_bike_sp}
 %			\end{center}
-%		
-%			\scriptsize{\textbf{Figure:} Response surface plot. 
-%				The white dot is $\xv$, black dots are $\xv'$. The histograms display the marginal distribution of the training data $\Xmat$.} 
-%				
+%
+%			\scriptsize{\textbf{Figure:} Response surface plot.
+%				The white dot is $\xv$, black dots are $\xv'$. The histograms display the marginal distribution of the training data $\Xmat$.}
+%
 %		\end{column}
-%		\begin{column}{0.5\textwidth}  
+%		\begin{column}{0.5\textwidth}
 %			\begin{center}
 %				\includegraphics[width=1\textwidth]{figure/counterfactuals_bike_para}
 %			\end{center}
-%		
-%		\scriptsize{\textbf{Figure:} Parallel plot. 
-%			The grey lines show the feature values of the counterfactuals $\xv'$, the blue line corresponds to the values of $\xv$. Features without proposed changes are omitted. The bold numbers give minima and minima of numeric features while character strings indicate categories of character features.} 
-%		
+%
+%		\scriptsize{\textbf{Figure:} Parallel plot.
+%			The grey lines show the feature values of the counterfactuals $\xv'$, the blue line corresponds to the values of $\xv$. Features without proposed changes are omitted. The bold numbers give minima and minima of numeric features while character strings indicate categories of character features.}
+%
 %		\end{column}
 %	\end{columns}
 %\end{frame}
 
-\begin{frame}{Problems, Pitfalls, \& Limitations}
-\begin{itemize}[<+->]
-    \item \textbf{Illusion of model understanding:} 
-    CEs explain ML decisions by pointing to few specific alternatives, reducing complexity but offering limited explanatory power\\
-    $\leadsto$ %psychologists showed that even though the perceived model-understanding of end-users increases, the objective model-understanding remained unchanged
-    Psychologists have shown that although perceived model understanding of end-users increases, the objective model understanding remains unchanged
-    
-    %\item \textbf{Finding the right metric:} Similarity is the crucial concept for finding good CEs. However, our concept of similarity is context and domain dependent. E.g. while L1 can be a reasonable notion for tabular data, it is counterintuitive for image data. Sparsity is often desirable for end-users but not for data scientists searching for biases in the model.
-    \item \textbf{Right metric:} Similarity measures are crucial to find good CEs (depends on context/domain)\\
-    $\leadsto$ e.g., $L_1$ can be reasonable for tabular data but not for image data\\
-    $\leadsto$ sparsity desirable for end-users but not for auditors searching for model bias
+\begin{framei}[align=top]{Problems, Pitfalls, \& Limitations}
+\item<+-> \textbf{Illusion of model understanding:} CEs explain ML decisions by pointing to few specific alternatives, reducing complexity but offering limited explanatory power\\
+$\leadsto$ Psychologists have shown that although perceived model understanding of end-users increases, the objective model understanding remains unchanged
+%\item \textbf{Finding the right metric:} Similarity is the crucial concept for finding good CEs. However, our concept of similarity is context and domain dependent. E.g. while L1 can be a reasonable notion for tabular data, it is counterintuitive for image data. Sparsity is often desirable for end-users but not for data scientists searching for biases in the model.
+\item<+-> \textbf{Right metric:} Similarity measures are crucial to find good CEs (depends on context/domain)\\
+$\leadsto$ e.g., $L_1$ can be reasonable for tabular data but not for image data\\
+$\leadsto$ sparsity desirable for end-users but not for auditors searching for model bias
+%\item \textbf{Confusing Model and Real-World:} Explanations of the model do not easily transfer to the process in which a model is applied. This information should be conveyed to the end-user.
+\item<+-> \textbf{Confusing Model and Real-World:} Model explanations are not easily transferable to reality\\
+$\leadsto$ End-users must know that CEs explain the model, not the real world %models are only approximations %This information should be conveyed to the end-user
+\item<+-> \textbf{Disclosing too much information:}
+CEs can reveal too much information about the model and help potential attackers
+\end{framei}
 
-    %\item \textbf{Confusing Model and Real-World:} Explanations of the model do not easily transfer to the process in which a model is applied. This information should be conveyed to the end-user.
-    \item \textbf{Confusing Model and Real-World:} Model explanations are not easily transferable to reality\\
-    $\leadsto$ End-users must know that CEs explain the model, not the real world %models are only approximations %This information should be conveyed to the end-user
-    \item \textbf{Disclosing too much information:} 
-    CEs can reveal too much information about the model and help potential attackers
-    \end{itemize}
-\end{frame}
 
-\begin{frame}{Problems, Pitfalls, \& Limitations}
-\begin{itemize}[<+->]
-    \item \textbf{Rashomon effect:} One, few, all? Which CEs should be shown to the end-user?\\
-    $\leadsto$ No universal answer; depends on user goals, cognitive load, and resources
-    %No perfect answer, depends on end-users, computational resources, and knowledge
-    % \item \textbf{Actionability vs. fairness:} Some authors suggest to focus only on the actionability of CEs\\
-    % $\leadsto$ Counteract contestability, e.g., if ethnicity is not changed in a CE since it is not actionable, this could hide racial biases in the model
-    \item \textbf{Actionability vs. fairness:} Focusing on actionable changes may \\hinder contestability\\
+\begin{framei}[align=top]{Problems, Pitfalls, \& Limitations}
+\item<+-> \textbf{Rashomon effect:} One, few, all? Which CEs should be shown to end-users?\\
+$\leadsto$ No universal answer; depends on user goals, cognitive load, and resources
+%No perfect answer, depends on end-users, computational resources, and knowledge
+% \item \textbf{Actionability vs. fairness:} Some authors suggest to focus only on the actionability of CEs\\
+% $\leadsto$ Counteract contestability, e.g., if ethnicity is not changed in a CE since it is not actionable, this could hide racial biases in the model
+\item<+-> \textbf{Actionability vs. fairness:} Focusing on actionable changes may\\
+hinder contestability\\
 $\leadsto$ E.g., if ethnicity is not changed in a CE since it is not actionable, this could hide racial biases in the model
-
-    \item \textbf{Assumption of constant model:} To provide guidance for the future, CEs assume that their underlying model does not change in the future\\
-    $\leadsto$ in reality this assumption is often violated making CEs unreliable 
-    \item \textbf{Attacking CEs:} Researchers can create models with great performance, which generate arbitrary explanations specified by the ML developer\\
-    $\leadsto$ how faithful are CEs to the models underlying mechanism?
-\end{itemize}
-
+\item<+-> \textbf{Assumption of constant model:} To provide guidance for the future, CEs assume that their underlying model does not change in the future\\
+$\leadsto$ in reality this assumption is often violated making CEs unreliable
+\item<+-> \textbf{Attacking CEs:} Researchers can create models with great performance, which generate arbitrary explanations specified by the ML developer\\
+$\leadsto$ how faithful are CEs to the models underlying mechanism?
 %	\textbf{Pitfall 3:} Rashomon Effect
 %	\begin{itemize}
-%		\item Due to the Rashomon Effect, multiple counterfactual explanations could be found for an instance. 
+%		\item Due to the Rashomon Effect, multiple counterfactual explanations could be found for an instance.
 %		\item If all counterfactuals are reported the user could be overwhelmed. Instead of a comprehensible explanations for a prediction, users received an even more complex explanations.
-%		\item Another option is to only report the ``best" ones. But this requires a notion for ``superiority".  
+%		\item Another option is to only report the ``best" ones. But this requires a notion for ``superiority".
 %		\item Furthermore, users might not be interested in the ``best" but most ``diverse" counterfactuals.
-%		\item The best option might be to report all counterfactuals but let the user decide which one to select, e.g., based on their previous knowledge. 
+%		\item The best option might be to report all counterfactuals but let the user decide which one to select, e.g., based on their previous knowledge.
 %	\end{itemize}
-%	\textbf{Pitfall 4:} 
+%	\textbf{Pitfall 4:}
 %	\begin{itemize}
-%		\item 
+%		\item
 %	\end{itemize}
 %	\textbf{Pitfall 5:} Confusing model explanation with real data process explanations
 %	\begin{itemize}
 %		\item Causal dependencies
-%		\item Fixed model at time $t$ 
+%		\item Fixed model at time $t$
 %		\item Wrong input by user
 %	\end{itemize}
-\end{frame}
+\end{framei}
 
 \endlecture
 \end{document}

--- a/slides/local-explanations-counterfactual/slides09-le-trust.tex
+++ b/slides/local-explanations-counterfactual/slides09-le-trust.tex
@@ -4,16 +4,14 @@
 \input{../../latex-math/basic-math}
 \input{../../latex-math/basic-ml}
 % Defines macros and environments
- 
+
 % \usepackage{comment}
 
 
 \title{Interpretable Machine Learning}
-\date{}
 
 \begin{document}
 
-	
 % Set style/preamble.Rnw as parent.
 
 % Load all R packages and set up knitr
@@ -31,7 +29,7 @@ Increasing Trust in Explanations
 figure/dbscan.jpg
 }{
 \item Understand the aspects that undermine users' trust in an explanation
-\item Learn diagnostic tools that could increase trust 
+\item Learn diagnostic tools that could increase trust
 }
 
 
@@ -42,177 +40,168 @@ figure/dbscan.jpg
 
 % ------------------------------------------------------------------------------
 
-\begin{frame}{Motivation \& Important Properties}
-	\begin{itemize}
-		\item Local explanations should not only make a model interpretable but also reveal if the model is trustworthy
-	    \pause
-	    \item \textbf{Interpretable}: ``Why did the model come up with this decision?''
-	    \pause
-	    \item \textbf{Trustworthy}: ``How certain is this explanation?''
-	    \begin{enumerate}
-	        \item accurate insights into the inner workings of our model
-	        \begin{itemize}
-	            \item Failure case: generation is based on inputs in areas where the model was trained with little or no training data (extrapolation)
-	        \end{itemize}
-	        \pause
-	        \item robust (i.e. low variance)
-	        \begin{itemize}
-	            \item Expectation: similar explanations for similar data points with similar predictions
-	            \item However, multiple sources of uncertainty exist
-	            \item[$\leadsto$] measure how robust an IML method is to small changes in the input data or parameters
-	            \item[$\leadsto$] Is an observation out-of-distribution?
-	        \end{itemize}
-	    \end{enumerate}
-	    \pause
-		\item Failing in one of these $\leadsto$ undermining users' trust in the explanations\\ $\leadsto$ undermining trust in the model 
-		%\item In the upcoming section, we will, therefore, discuss methods to detect if a point is out-of-distribution and to measure how robust IML methods are.
-	\end{itemize}
-\end{frame}
-
-\begin{frame}[c]{Out-of-distribution (OOD) Detection}
-	\begin{itemize}
-		\item Models are unreliable in areas with little data support\\ $\leadsto$ explanations from local explanation methods are unreliable
-		\pause
-		\item For local explanation methods, the following components could be out-of-distribution (OOD): 
-		\begin{itemize}
-			\item The data for LIME's surrogate model
-			\item Counterfactuals themselves
-			\item Shapley value's permuted obs. to calculate the marginal contribs 
-			\item ICE curves grid data points 
-		\end{itemize}
-		\pause
-		\item Two very simple and intuitive approaches
-		\begin{itemize}
-		    \item Classifier for out-of-distribution
-		    \item Clustering
-		\end{itemize}
-		\item More complicated also possible, e.g., variational autoencoders \furtherreading{DAXBERGER2020}
-	\end{itemize}
-\end{frame}
-
-
-\begin{frame}[c]{OOD Detection: OOD-Classifier}
-	\begin{itemize}
-	    \item Problem: we have only in-distribution data
-	    \item Idea: Hallucinate new (ood) data by randomly sampling data points
-	    \item[$\leadsto$] Learn a binary classifier to distinguish between the origins of the data
-	    \medskip
-	    \pause
-	    \item Study whether an explanation approach can be fooled \furtherreading{SLACK2020}
-	    \begin{itemize}
-	        \item Hide bias in the true (deployed) model, but use an unbiased model for all out-of-distribution samples
-	    \end{itemize}
-	    \item[$\leadsto$] Important way to diagnose an explanation approach
-	\end{itemize}
-\end{frame}
-
-\begin{frame}[c]{OOD Detection: Clustering via DBSCAN}
-\begin{itemize}
-	\item DBSCAN is a data clustering algorithm \furtherreading{ESTER1996}\\ (Density-Based Spatial Clustering of Applications with Noise) 
-	\pause
-	\item For this method, we define an $\epsilon$-neighborhood: \\
-	Given a dataset $X = \{\xi\}_{i = 1}^n$, an $\epsilon$-neighborhood for $\xv \in \Xspace$ is defined as 
-	$$ \mathcal{N}_{\epsilon}(\xv) = \{\xi \in \Xspace | d(\xv, \xi) \le \epsilon\}.$$
-	 $d(\cdot)$ is a distance measure (e.g., Euclidean or Gower distance) 
-	 \pause
-	\item Core observations $\xv$
-	\begin{itemize}
-	    \item Have at least $m$ data points within $\mathcal{N}_{\epsilon}(\xv)$
-	    \item Forms an own cluster with all its neighborhood points
-	\end{itemize}
-	\pause
-    \item Border points
-    \begin{itemize}
-        \item Within $\mathcal{N}_{\epsilon}(\xv)$
-        \item Part of a cluster defined by a core point
-    \end{itemize}
-    \pause
-    \item Noise points
-    \begin{itemize}
-        \item Are not within $\mathcal{N}_{\epsilon}(\xv)$
-        \item Not part of any cluster
-    \end{itemize}
-\end{itemize}
-\end{frame}
-
-\begin{frame}[c]{Out-of-distribution Detection}
-\vspace{-0.6cm}
-\begin{columns}[totalwidth=\textwidth]
-
-	\begin{column}{0.5\textwidth}
-	    \vspace{-2em}
-		\begin{center}
-			\includegraphics[width=0.6\textwidth]{figure/dbscan.jpg}\\
-			\tiny{Example for DBSCAN, circles display $\epsilon$-neighborhoods, $m = 4$}
-		\end{center}
-	\end{column}
-
-	\begin{column}{0.5\textwidth}
-	
-		\begin{itemize}
-			\item Green points A and B are core points and form one cluster since they lie in each others neighborhood, all yellow points are border points of this cluster 
-			\pause
-			\item Since D is not part of the neighborhood of core points, it is a noise point 
-			\pause
-			\item In-distribution: new point lies within a cluster
-			\pause
-		    \item Out-of-distribution: new point lies outside the clusters 
-		\end{itemize}
-	\end{column}
-
-\end{columns}
-
+\begin{framei}[align=top]{Motivation \& Important Properties}
+\item Local explanations should not only make a model interpretable but also reveal if the model is trustworthy
 \pause
+\item \textbf{Interpretable}: ``Why did the model come up with this decision?''
+\pause
+\item \textbf{Trustworthy}: ``How certain is this explanation?''
+\begin{enumerate}
+\item accurate insights into the inner workings of our model
+\begin{itemizeS}
+\item Failure case: generation is based on inputs in areas where the model was trained with little or no training data (extrapolation)
+\end{itemizeS}
+\pause
+\item robust (i.e. low variance)
+\begin{itemizeS}
+\item Expectation: similar explanations for similar data points with similar predictions
+\item However, multiple sources of uncertainty exist
+\item[$\leadsto$] measure how robust an IML method is to small changes in the input data or parameters
+\item[$\leadsto$] Is an observation out-of-distribution?
+\end{itemizeS}
+\end{enumerate}
+\pause
+\item Failing in one of these $\leadsto$ undermining users' trust in the explanations\\
+$\leadsto$ undermining trust in the model
+		%\item In the upcoming section, we will, therefore, discuss methods to detect if a point is out-of-distribution and to measure how robust IML methods are.
+\end{framei}
 
-\hspace{1em}
-\begin{itemize}
-		\item Disadvantages:
-		\begin{itemize}
-		    \item Depending on the distance metric $d(\cdot)$, DBSCAN could suffer from the ``curse of dimensionality'' 
-		    \item The choice of $\epsilon$ and $m$ is not clear a-priori 
-		\end{itemize}
-\end{itemize}
-\end{frame}
 
-\begin{frame}[c]{Robustness}
-		\begin{itemize}
-		\item Differentiate between different kinds of uncertainty: 
-		\begin{enumerate}
-			\item \textbf{Explanation uncertainty}: Change of explanation if we repeat the process, e.g., the explanation could differ depending on which subset of data we use for the expl. method and which hyperparams 
-			\pause
-			\item \textbf{Process uncertainty}: Change of explanation if the underlying model is changed\\ $\leadsto$ are ML models non-robust, e.g., because they are trained on noisy data?
-		\end{enumerate}
-		\pause
-		\item We focus on explanation uncertainty 
-		\begin{itemize}
-		    \item Even with the same model and same (or similar) data points, we can receive different explanations
-		\end{itemize}
-	\end{itemize}
-\end{frame}
+\begin{framei}[align=top]{Out-of-distribution (OOD) Detection}
+\item Models are unreliable in areas with little data support\\
+$\leadsto$ explanations from local explanation methods are unreliable
+\pause
+\item For local explanation methods, the following components could be out-of-distribution (OOD):
+\begin{itemizeS}
+\item The data for LIME's surrogate model
+\item Counterfactuals themselves
+\item Shapley value's permuted obs. to calculate the marginal contribs
+\item ICE curves grid data points
+\end{itemizeS}
+\pause
+\item Two very simple and intuitive approaches
+\begin{itemizeS}
+\item Classifier for out-of-distribution
+\item Clustering
+\end{itemizeS}
+\item More complicated also possible, e.g., variational autoencoders \furtherreading{DAXBERGER2020}
+\end{framei}
 
-\begin{frame}[c]{Robustness Measure for LIME and SHAP}  
-	\begin{itemize}
-		\item Objective: Similar explanations for similar inputs (in a neighborhood) 
-		\pause
+
+\begin{framei}[align=top]{OOD Detection: OOD-Classifier}
+\item Problem: we have only in-distribution data
+\item Idea: Hallucinate new (ood) data by randomly sampling data points
+\item[$\leadsto$] Learn a binary classifier to distinguish between the origins of the data\\
+\spacer[0.25]
+\pause
+\item Study whether an explanation approach can be fooled \furtherreading{SLACK2020}
+\begin{itemizeS}
+\item Hide bias in the true (deployed) model, but use an unbiased model for all out-of-distribution samples
+\end{itemizeS}
+\item[$\leadsto$] Important way to diagnose an explanation approach
+\end{framei}
+
+
+\begin{framei}[align=top]{OOD Detection: Clustering via DBSCAN}
+\item DBSCAN is a data clustering algorithm \furtherreading{ESTER1996}\\
+(Density-Based Spatial Clustering of Applications with Noise)
+\pause
+\item For this method, we define an $\epsilon$-neighborhood:\\
+Given a dataset $X = \{\xi\}_{i = 1}^n$, an $\epsilon$-neighborhood for $\xv \in \Xspace$ is defined as
+$$\mathcal{N}_{\epsilon}(\xv) = \{\xi \in \Xspace | d(\xv, \xi) \le \epsilon\}$$
+$d(\cdot)$ is a distance measure (e.g., Euclidean or Gower distance)
+\pause
+\item Core observations $\xv$
+\begin{itemizeS}
+\item Have at least $m$ data points within $\mathcal{N}_{\epsilon}(\xv)$
+\item Forms an own cluster with all its neighborhood points
+\end{itemizeS}
+\pause
+\item Border points
+\begin{itemizeS}
+\item Within $\mathcal{N}_{\epsilon}(\xv)$
+\item Part of a cluster defined by a core point
+\end{itemizeS}
+\pause
+\item Noise points
+\begin{itemizeS}
+\item Are not within $\mathcal{N}_{\epsilon}(\xv)$
+\item Not part of any cluster
+\end{itemizeS}
+\end{framei}
+
+
+\begin{framev}[align=top]{Out-of-distribution Detection}
+\splitVTT{
+\spacer[0.25]
+\imageC[0.6]{figure/dbscan.jpg}
+\begin{center}
+\begin{footnotesize}
+Example for DBSCAN, circles display $\epsilon$-neighborhoods, $m = 4$
+\end{footnotesize}
+\end{center}
+\spacer[0]
+}{
+\spacer[0.6]
+\begin{itemizeM}
+\item Green points A and B are core points and form one cluster since they lie in each others neighborhood, all yellow points are border points of this cluster
+\pause
+\item Since D is not part of the neighborhood of core points, it is a noise point
+\pause
+\item In-distribution: new point lies within a cluster
+\pause
+\item Out-of-distribution: new point lies outside the clusters
+\end{itemizeM}
+}
+\pause
+\begin{itemizeM}
+\item Disadvantages:
+\begin{itemizeS}
+\item Depending on the distance metric $d(\cdot)$, DBSCAN could suffer from the ``curse of dimensionality''
+\item The choice of $\epsilon$ and $m$ is not clear a-priori
+\end{itemizeS}
+\end{itemizeM}
+\end{framev}
+
+
+\begin{framei}[align=top]{Robustness}
+\item Differentiate between different kinds of uncertainty:
+\begin{enumerate}
+\item \textbf{Explanation uncertainty}: Explanation changes if we repeat the process, e.g., the explanation could differ depending on which subset of data we use for the expl. method and which hyperparams 
+\pause
+\item \textbf{Process uncertainty}: Explanation changes if underlying model changed \\ $\leadsto$ are ML models non-robust, e.g., because of training on noisy data?
+\end{enumerate}
+\pause
+\item We focus on explanation uncertainty
+\begin{itemizeS}
+\item Even with the same model and same (or similar) data points, we can receive different explanations
+\end{itemizeS}
+\end{framei}
+
+
+\begin{framei}[align=top]{Robustness Measure for LIME and SHAP}
+\item Objective: Similar explanations for similar inputs (in a neighborhood)
+\pause
 		%\item In the previous chapter on the limitations of LIME, we already saw an example where LIME produced different explanations for very similar data points (with similar predictions).
-		\item For LIME and SHAP, notion of stability based on \textbf{locally Lipschitz continuity} \furtherreading{JAAKKOLA2018}:\\
-		An explanation method $g:\Xspace \rightarrow \R^m$ is locally Lipschitz if 
-		\begin{itemize}
-		    \item for every $\xv_0 \in \Xspace$ there exist $\delta > 0$ and  $\omega \in \R$
-		    \item such that $||\xv - \xv_0|| < \delta$ implies $||g(\xv) - g(\xv_0)|| < \omega ||\xv - \xv_0||$
-		\end{itemize}
-		\footnotesize Note that, for LIME, $g$ returns the $m$ coefficients of the surrogate model \normalsize
-		\pause
-		\item According to this, we can quantify the robustness of explanation models in terms of $\omega$:
-		\begin{itemize}
-		    \item[$\leadsto$] The closer $\omega$ is to 0, the more robust our explanation method is 
-		\end{itemize}
-		\pause
-		\item $\omega$ is rarely known a-priori but it could be estimated as follows: 
-		$$\hat{\omega}_{X}(\xv) \in \underset{\xi \in \mathcal{N}_{\epsilon}(\xv)}{\arg \max} \frac{||g(\xv) - g(\xi)||_2}{d(\xv, \xi)},$$
-		where $\mathcal{N}_{\epsilon}(\xv)$ is the $\epsilon$-neighborhood of $\xv$
-	\end{itemize}
-\end{frame}
+\item For LIME and SHAP, notion of stability based on \textbf{locally Lipschitz continuity} \furtherreading{JAAKKOLA2018}:\\
+An explanation method $g:\Xspace \rightarrow \R^m$ is locally Lipschitz if
+\begin{itemizeS}
+\item for every $\xv_0 \in \Xspace$ there exist $\delta > 0$ and $\omega \in \R$
+\item such that $||\xv - \xv_0|| < \delta$ implies $||g(\xv) - g(\xv_0)|| < \omega ||\xv - \xv_0||$
+\end{itemizeS}
+\begin{small}
+Note that, for LIME, $g$ returns the $m$ coefficients of the surrogate model
+\end{small}
+\pause
+\item According to this, we can quantify the robustness of explanation models in terms of $\omega$:
+\begin{itemizeS}
+\item[$\leadsto$] The closer $\omega$ is to 0, the more robust our explanation method is
+\end{itemizeS}
+\pause
+\item $\omega$ is rarely known a-priori but it could be estimated as follows:
+$$\hat{\omega}_{X}(\xv) \in \underset{\xi \in \mathcal{N}_{\epsilon}(\xv)}{\arg \max} \frac{||g(\xv) - g(\xi)||_2}{d(\xv, \xi)}$$
+where $\mathcal{N}_{\epsilon}(\xv)$ is the $\epsilon$-neighborhood of $\xv$
+\end{framei}
 
 
 % \begin{comment}


### PR DESCRIPTION
## Summary
This PR cleans up the `local-explanations-counterfactual` slide deck.

The cleanup was done by applying a cleanup skill with a coding agent, followed by manual inspection.

## Included changes
- clean up the "Local Explanations Adversarial Examples" slides
- clean up the "Adversarial Examples and Counterfactual Explanations" slides
- clean up the "Counterfactual Explanations (CEs) Motivation" slides
- clean up the "Counterfactual Explanations (CEs) Optimization Problem and Objectives" slides
- clean up the "Counterfactual Explanations (CEs) Methods & Discussion" slides
- clean up the "Local Explanations: Increasing Trust in Explanations" slides

## Scope
Files touched:
- `slides/local-explanations-counterfactual/slides02-le-adversarial.tex`
- `slides/local-explanations-counterfactual/slides03-le-adversarial-counterfactuals.tex`
- `slides/local-explanations-counterfactual/slides06-le-counterfactuals-intro.tex`
- `slides/local-explanations-counterfactual/slides07-le-counterfactuals-optim.tex`
- `slides/local-explanations-counterfactual/slides08-le-counterfactuals-methods.tex`
- `slides/local-explanations-counterfactual/slides09-le-trust.tex`
