### PR TITLE
refactor(slides): clean up local explanations LIME slides

### DIFF
--- a/slides/local-explanations-lime/slides01-le-intro.tex
+++ b/slides/local-explanations-lime/slides01-le-intro.tex
@@ -8,7 +8,6 @@
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
 
@@ -21,7 +20,7 @@
 % IF YOU MODIFY THIS, PLZ ALSO MODIFY setup.Rmd ACCORDINGLY...
 
 % Defines macros and environments
- \titlemeta{
+\titlemeta{
 Local Explanations
 }{
 Introduction
@@ -36,216 +35,156 @@ figure/lime.png
 
 % ------------------------------------------------------------------------------
 
-\begin{frame}[t]{Methodological Motivation}
-
+\begin{framei}[align=top]{Methodological Motivation}
 % Marius: We cannot write such stuff if we want to stay flexible how to combine chunks
 %Except for Shapley values and ICE curves, we focused so far mostly on global explanation methods that explain global model behavior (e.g. PDP, PFI, etc.). However, there are also many methods that explain the \textbf{local} behavior of a model.
+\item Purpose of local explanations:
+\begin{itemizeS}
+\item Insight into the driving factors for a \textbf{particular prediction/decision}
+\item Understand ML model decisions in a \textbf{local neighborhood} of a given input (e.g., feature vector)
+\end{itemizeS}
+\spacer[0.25]
+\pause
+\item Local methods can address questions such as:
+\begin{itemizeS}
+\item \textbf{Why} did the model decide to predict $\yh$ for input $\xv$?
+\item \textbf{How} does the model behave for observations similar to $\xv$?
+\item \textbf{What if} some features of $\xv$ had different values?
+\item \textbf{Where} (in which regions in $\Xspace$) does the model fail?
+\end{itemizeS}
+\end{framei}
 
-	\begin{itemize}
-	    \item Purpose of local explanations:
-	    \begin{itemize}
-	        \item Insight into the driving factors for a \textbf{particular prediction/decision}
-	        \item Understand ML model decisions in a \textbf{local neighborhood} of a given input (e.g., feature vector)
-	    \end{itemize}
-	    \medskip
-	    \pause
-		\item Local Methods can address questions such as: 
-		\begin{itemize}
-		    \item \textbf{Why} did the model decide to predict $\yh$ for input $\xv$?
-		    \item \textbf{How} does the model behave for observations similar to $\xv$?
-		    \item \textbf{What if} some features of $\xv$ had different values?
-		    \item  \textbf{Where} (in which regions in $\Xspace$) does the model fail?
-		\end{itemize}  
-	\end{itemize}
-\end{frame}
 
-\begin{frame}[t]{Social Motivation}
-
+\begin{framei}[align=top]{Social Motivation}
 %All these questions can indeed be relevant for the ML modeler. However, unlike in global methods that require expert ML understanding or even domain knowledge, many local methods aim to provide explanations also for laypersons. 
-	\begin{itemize}
-		\item Explanations for laypersons should be tailored to the \textbf{explainee}\\ % (who receives the explanation)\\ %(i.e., the person receiving the explanation)
-		%\pause
-		$\leadsto$ \textbf{case specific}, \textbf{human-intelligible}, \textbf{faithful} to explained mechanism
-		\pause
-		\item If algorithms make decisions in \textbf{socially/safety critical domains}, end users have a justified interest in receiving explanations
-		\pause
-		\item Local explanations cannot only increase \textbf{user trust}, but also help to detect \textbf{critical local biases} in algorithmic decision making
-		\pause
-		\item European citizens have the legally binding \textbf{right to explanation} as given in the General Data Protection Regulation (GDPR) and the AI Act
-		\begin{itemize}
-		    \item[$\leadsto$] Instead of explaining the entire (complex) model (with potential market secrets), explanations in a case-by-case usage are more reasonable
-		\end{itemize}
-
-	\end{itemize}
-\end{frame}
+\item Explanations for laypersons should be tailored to the \textbf{explainee}\\ % (who receives the explanation)\\ %(i.e., the person receiving the explanation)
+$\leadsto$ \textbf{case specific}, \textbf{human-intelligible}, \textbf{faithful} to explained mechanism
+\pause
+\item If algorithms make decisions in \textbf{socially/safety critical domains}, end users have a justified interest in receiving explanations
+\pause
+\item Local explanations cannot only increase \textbf{user trust}, but also help to detect \textbf{critical local biases} in algorithmic decision making
+\pause
+\item European citizens have the legally binding \textbf{right to explanation} as given in the General Data Protection Regulation (GDPR) and the AI Act
+\begin{itemizeS}
+\item[$\leadsto$] Instead of explaining the entire (complex) model (with potential market secrets), explanations in a case-by-case usage are more reasonable
+\end{itemizeS}
+\end{framei}
 
 
-\begin{frame}[t]{GDPR \& AI Act: The Right to Explanation}
-
+\begin{framev}[align=top]{GDPR \& AI Act: The Right to Explanation}
 ``The data subject should have the right not to be subject to a decision
     %, which may include a measure, evaluating personal aspects relating to him or her which is 
     [...] based solely on automated processing [...],
     %and which produces legal effects concerning him or her or similarly significantly affects him or her, 
-    such as automatic refusal of an online credit application or e-recruiting practices without any human intervention.
-
-$[\ldots]$
-
+such as automatic refusal of an online credit application or e-recruiting practices without any human intervention.
+\\
+$[\ldots]$\\
 In any case, such processing should be subject to suitable safeguards, which should include [...]
 %specific information to the data subject and 
 the \textbf{right to obtain} [...]
 %human intervention, to express his or her point of view, to obtain 
 \textbf{an explanation of the decision reached after such assessment and to challenge the decision}.''
 \hfill \furtherreading{GDPR2016}
-
-\medskip
-
+\spacer[0.25]\\
 ``Any affected person [...]
 %subject to a decision which is taken by the deployer on the basis of the output from a high-risk AI system listed in Annex III, with the exception of systems listed under point 2 thereof, and which produces legal effects or similarly significantly affects that person in a way that they consider to have an adverse impact on their health, safety or fundamental rights 
 shall have the right to obtain from the deployer clear and meaningful explanations of the role of the AI system in the decision-making procedure and the main elements of the decision taken.''
 \hfill \furtherreading{ACT2021}
-\end{frame}
+\end{framev}
 
 
-\begin{frame}[t]{Example: Husky or Wolf?}
-	\begin{itemize}
-		\item We trained a model to predict if an image shows a wolf or a husky 
-		\item Below predictions on six test images are given 
-		\item Do you trust our predictor? 
-	\end{itemize}
-	
-	\begin{columns}[T, onlytextwidth]
-	
-	\begin{column}{0.45\textwidth}
-	    \centering
-    	%\begin{center}
-    		\includegraphics[width=\textwidth]{figure/lime-wolfhusky.png}\\
-    		\includegraphics[width=\textwidth]{figure/lime-wolfhusky2.png}\\
-    		{\textbf{Source:} [\href{http://www.facweb.iitkgp.ac.in/~niloy/COURSE/Spring2018/IntelligentSystem/PPT_2018/why_should_i_trust_ppt.pdf}{Sameer Singh 2018}]}
-    	%\end{center}
-	    
-	\end{column}
-	
-	\begin{column}{0.55\textwidth}
-	    
-	\begin{itemize}
-		\item Sometimes the ML model is wrong
-		\item Can you guess the pattern the ML model learned to identify a wolf?
-	\end{itemize}
-	    
-	\end{column}
-	    
-	\end{columns}
-
-\end{frame}
+\begin{framev}[align=top]{Example: Husky or Wolf?}
+\begin{itemizeM}
+\item We trained a model to predict if an image shows a wolf or a husky
+\item Below predictions on six test images are given
+\item Do you trust our predictor?
+\end{itemizeM}
+\splitVTT[0.45]{%
+\spacer[0]
+\centering
+\image{figure/lime-wolfhusky.png}\\
+\image[1][http://www.facweb.iitkgp.ac.in/~niloy/COURSE/Spring2018/IntelligentSystem/PPT_2018/why_should_i_trust_ppt.pdf]{figure/lime-wolfhusky2.png}
+}{%
+\spacer[0.6]
+\begin{itemizeM}
+\item Sometimes the ML model is wrong
+\item Can you guess the pattern the ML model learned to identify a wolf?
+\end{itemizeM}
+}%
+\end{framev}
 
 
-\begin{frame}[t]{Example: Husky or Wolf? Using LIME}
-	\begin{itemize}
-		\item Local explanations highlight parts of image which led to the prediction\\
-        $\leadsto$ our predictor is actually a snow detector 
-	\end{itemize}
-    
-	\begin{center}
-		\includegraphics[width=0.9\textwidth]{figure/lime-wolfhusky3.png}\\
-		{\textbf{Source:} [\href{http://www.facweb.iitkgp.ac.in/~niloy/COURSE/Spring2018/IntelligentSystem/PPT_2018/why_should_i_trust_ppt.pdf}{Sameer Singh 2018}]}
-	\end{center}
+\begin{framev}[align=top]{Example: Husky or Wolf? Using LIME}
+\begin{itemizeM}
+\item Local explanations highlight parts of the image which led to the prediction\\
+$\leadsto$ our predictor is actually a snow detector
+\end{itemizeM}
+\imageC[0.9][http://www.facweb.iitkgp.ac.in/~niloy/COURSE/Spring2018/IntelligentSystem/PPT_2018/why_should_i_trust_ppt.pdf]{figure/lime-wolfhusky3.png}
+\end{framev}
 
 
+\begin{framev}[align=top]{Example: Loan Application}
+\splitVTT[0.45]{%
+\spacer[0]
+\imageC[1][https://www.elte.hu/content/trendfordulo-az-mi-fejlesztesekben.t.19025]{figure/IntroJudge.png}
+}{%
+\spacer[0.6]
+\begin{itemizeM}
+\item<1-> Imagine: You apply for a loan at an online bank and are immediately rejected without reasons
+%Imagine: You are applying at a bank's online portal for a loan and your application gets immediately rejected without reasons
+\item<2-> Bank could e.g. provide a counterfactual explanation using local explanation methods:
+\begin{itemizeS}
+\item[] ``If you were older than 21, your loan application would have been accepted."
+\end{itemizeS}
+\item<3->[$\leadsto$] helps to understand the decision and to take actions for recourse (if req.)
+\end{itemizeM}
+}%
+\end{framev}
 
 
+\begin{framev}[align=top]{Example: Stop or Right-of-Way?}
+\splitVTT[0.58]{%
+\spacer[0.6]
+\begin{itemizeM}
+\item Imagine:
+\begin{itemizeS}
+\item<1-> You work at a car company that develops image classifiers for autonomous driving
+\item<1-> You show your model the following image (an adversarial example)
+\item<2-> Classifier is $99\%$ sure it describes a right-of-way sign
+\end{itemizeS}
+\item<2-> Would you entrust other people's lives into the hands of this software?
+\end{itemizeM}
+}{%
+\spacer[0]
+\imageC[0.7][https://arxiv.org/abs/1707.08945]{figure/IntroStop.jpg}
+}%
+\end{framev}
 
 
-
-\end{frame}
-
-
-\begin{frame}{Example: Loan Application}
-
-\begin{columns}[c, totalwidth=\textwidth]
-    
-    \begin{column}{0.45\textwidth}
-        	\begin{center}
-		\includegraphics[width=1\textwidth]{figure/IntroJudge.png}\\
-		{\textbf{Source:} [\href{https://www.elte.hu/content/trendfordulo-az-mi-fejlesztesekben.t.19025}{https://www.elte.hu}]}
-	\end{center}
-	
-	\end{column}
-	
-	\begin{column}{0.55\textwidth}
-	
-    	\begin{itemize}
-    	    \item<1-> Imagine: You apply for a loan at an online bank and are immediately rejected without reasons
-    	    %Imagine: You are applying at a bank's online portal for a loan and your application gets immediately rejected without reasons
-    	    \item<2-> Bank could e.g. provide a counterfactual explanation using local explanation methods:
-    	    \begin{itemize}
-    	        \item[] ``If you were older than 21, your loan application would have been accepted."
-    	    \end{itemize}
-    	    \item<3->[$\leadsto$] helps to understand the decision and to take actions for recourse (if req.)
-    	\end{itemize}
-    	
-    \end{column}
-\end{columns}
-
-\end{frame}
-
-
-
-\begin{frame}[t]{Example: Stop or Right-of-Way?}
-
-\begin{columns}[c, totalwidth=\textwidth]
-
-	\begin{column}{0.58\textwidth}
-	\begin{itemize}
-	    \item Imagine: 
-	        \begin{itemize}
-	            \item<1-> You work at a car company that develops image classifiers for autonomous driving
-	            \item<1-> You show your model the following image (an adversarial example)
-	            \item<2-> Classifier is $99\%$ sure it describes a right-of-way sign
-	        \end{itemize}  
-	    \item<2-> Would you entrust other people's lives into the hands of this software?
-	\end{itemize}
-	
-	 \end{column}
-	
-	\begin{column}{0.45\textwidth}
-
-	\begin{center}
-		\includegraphics[width=0.7\textwidth]{figure/IntroStop.jpg}\\
-		{\textbf{Source:} [\href{https://arxiv.org/abs/1707.08945}{Eykholt et. al 2018}]}
-	\end{center}
-
-     \end{column}
-
-\end{columns}
-
-\end{frame}
-
-\begin{frame}[t]{Characteristics of Local Explanations}
-	\begin{itemize}
-		\item<1-> \textbf{Explanation scope:} Specific to one prediction, valid only in local environment
-		\item<2-> \textbf{Applicable model classes:} 
-                    \begin{itemize}
-                \item Model-agnostic (by design)
-                \item Model-specific variants (exploit internal structure for speed/accuracy)%variants for efficiency or more accurate estimation (by exploiting model structure)
-              \end{itemize}
-        %\\
-		%$\leadsto$ very popular also for deep learning models
-		\item<3-> \textbf{Audience:} ML engineers, laypersons, and domain experts
-		\item<4-> \textbf{Supported data types:} Broad applicability across modalities (tabular, image, text, audio), but method-specific adaptations often required
-        %\textbf{Data types:} Often agnostic, including tabular, image, text, and audio data
-		\item<5-> \textbf{Main method families}
-              \begin{itemize}
-                \item Single ICE curves
-                \item Shapley / SHAP values
-                \item LIME / Anchors
-                \item Counterfactual explanations
-                \item Adversarial examples
-              \end{itemize}
-        %\textbf{Methods:} Many, most prominent are counterfactual explanations, shapley values, local interpretable model-agnostic explanations (LIME), adversarial examples, single ICE curve%, anchors
-		%\footnote{For Shapley values and ICE curves see other lectures}
-		% \item<6-> \textbf{Special:} Due to audience, strong interactions with social sciences and strong connections to cognitive science and neurosciences due to data types
-	\end{itemize}
-\end{frame}
+\begin{framei}[align=top]{Characteristics of Local Explanations}
+\item<1-> \textbf{Explanation scope:} Specific to one prediction, valid only in local environment
+\item<2-> \textbf{Applicable model classes:}
+\begin{itemizeS}
+\item Model-agnostic (by design)
+\item Model-specific variants (exploit internal structure for speed/accuracy)%variants for efficiency or more accurate estimation (by exploiting model structure)
+\end{itemizeS}
+%\\
+%$\leadsto$ very popular also for deep learning models
+\item<3-> \textbf{Audience:} ML engineers, laypersons, and domain experts
+\item<4-> \textbf{Supported data types:} Broad applicability across modalities (tabular, image, text, audio), but method-specific adaptations often required
+%\textbf{Data types:} Often agnostic, including tabular, image, text, and audio data
+\item<5-> \textbf{Main method families}
+\begin{itemizeS}
+\item Single ICE curves
+\item Shapley / SHAP values
+\item LIME / Anchors
+\item Counterfactual explanations
+\item Adversarial examples
+\end{itemizeS}
+%\textbf{Methods:} Many, most prominent are counterfactual explanations, shapley values, local interpretable model-agnostic explanations (LIME), adversarial examples, single ICE curve%, anchors
+%\footnote{For Shapley values and ICE curves see other lectures}
+% \item<6-> \textbf{Special:} Due to audience, strong interactions with social sciences and strong connections to cognitive science and neurosciences due to data types
+\end{framei}
 
 % \begin{frame}{Recap: ICE Curve}
 % 		\begin{itemize}
@@ -274,35 +213,35 @@ shall have the right to obtain from the deployer clear and meaningful explanatio
 % \end{center}
 % \end{frame}
 
-\begin{frame}{Credit Dataset}
-
-	\begin{itemize}
-		\item We illustrate local explanation methods on the German credit data 
-		\furtherreading{KAGGLE}
-		\item 522 observations, 9 features containing credit and customer information
-		\item Binary target ``risk'' indicates if a customer has a `good' or `bad' credit risk
-		\item We merged categories with few observations 
-	\end{itemize}
-		\begin{center}
-			\footnotesize
-			\begin{tabular}{ccc}
-				\toprule
-				name & type & range\\
-				\midrule
-				age & numeric & [19, 75]\\
-				sex & factor & \{male, female\}\\
-				job & factor & \{0, 1, 2, 3\}\\
-				housing & factor & \{free, own, rent\}\\
-				saving.accounts & factor & \{little, moderate, rich\}\\
-				checking.accounts & factor & \{little, moderate, rich\}\\
-				credit.amount & numeric & [276, 18424]\\
-				duration & numeric &  [6, 72]\\
-				purpose & numeric &  \{others, car, furniture, radio/TV\}\\
-				risk & factor & \{good, bad\}\\
-				\bottomrule
-			\end{tabular}
-		\end{center}
-\end{frame}
+\begin{framev}[align=top]{Credit Dataset}
+\begin{itemizeM}
+\item We illustrate local explanation methods on the German credit data
+\furtherreading{KAGGLE}
+\item 522 observations, 9 features containing credit and customer information
+\item Binary target ``risk'' indicates if a customer has a `good' or `bad' credit risk
+\item We merged categories with few observations
+\end{itemizeM}
+\begin{center}
+\begin{footnotesize}
+\begin{tabular}{ccc}
+\toprule
+name & type & range\\
+\midrule
+age & numeric & [19, 75]\\
+sex & factor & \{male, female\}\\
+job & factor & \{0, 1, 2, 3\}\\
+housing & factor & \{free, own, rent\}\\
+saving.accounts & factor & \{little, moderate, rich\}\\
+checking.accounts & factor & \{little, moderate, rich\}\\
+credit.amount & numeric & [276, 18424]\\
+duration & numeric & [6, 72]\\
+purpose & numeric & \{others, car, furniture, radio/TV\}\\
+risk & factor & \{good, bad\}\\
+\bottomrule
+\end{tabular}
+\end{footnotesize}
+\end{center}
+\end{framev}
 
 \endlecture
 \end{document}

--- a/slides/local-explanations-lime/slides04-le-lime.tex
+++ b/slides/local-explanations-lime/slides04-le-lime.tex
@@ -5,17 +5,15 @@
 \input{../../latex-math/basic-ml}
 \input{../../latex-math/ml-interpretable}
 % Defines macros and environments
- 
+
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \newcommand{\gh}{\hat{g}}
 
 \begin{document}
 
-	
 % Set style/preamble.Rnw as parent.
 
 % Load all R packages and set up knitr
@@ -57,20 +55,20 @@ figure/lime5
 % \end{frame}
 
 % Improved slide: LIME – Local Surrogate Explanations
-\begin{frame}[t]{LIME}
-  \begin{itemize}%[<+->]
-    %\item \textbf{Key idea:} Approximate any black‑box model $\fh$ around a single input $\xv$ with an \emph{interpretable} surrogate $\gh$
-    \item \textbf{Locality assumption:} \\$\fh$ behaves similarly simple in small neighborhood of $\xv$\\
-    $\leadsto$ Approximate $\fh$ near $\xv$ using an interpretable surrogate model $\gh$
-    \item \textbf{Interpretation strategy:}\\ Use $\gh$'s simple internal structure to explain $\fh(\xv)$ locally\\
-    $\leadsto$ \textbf{Common surrogates:} Sparse linear models, shallow decision trees
-    %\item \textbf{Algorithm:} Perturb $\xv$, obtain $\fh(\tilde{\xv})$, weight by proximity, fit $\gh$ to weighted data, interpret $\gh$’s parameters
-    %\item \textbf{Typical uses:} Debug single predictions, detect spurious features, provide actionable recourse
-    \item \textbf{Applicability:} Model‑agnostic; supports tabular, image, and text data %via modality‑specific perturbations
-    \item \textbf{In practice:} Generate samples near $\xv$, predict with $\fh$, and fit $\gh$ to these samples using $\fh$’s outputs as targets, weighting samples by their proximity/closeness to $\xv$
-
-  \end{itemize}
-\end{frame}
+\begin{framei}[align=top]{LIME}
+%\item \textbf{Key idea:} Approximate any black‑box model $\fh$ around a single input $\xv$ with an \emph{interpretable} surrogate $\gh$
+\item \textbf{Locality assumption:}\\
+$\fh$ behaves similarly simple in a small neighborhood of $\xv$\\
+$\leadsto$ Approximate $\fh$ near $\xv$ using an interpretable surrogate model $\gh$
+\item \textbf{Interpretation strategy:}\\
+Use $\gh$'s simple internal structure to explain $\fh(\xv)$ locally\\
+$\leadsto$ \textbf{Common surrogates:} sparse linear models, shallow decision trees
+%\item \textbf{Algorithm:} Perturb $\xv$, obtain $\fh(\tilde{\xv})$, weight by proximity, fit $\gh$ to weighted data, interpret $\gh$’s parameters
+%\item \textbf{Typical uses:} Debug single predictions, detect spurious features, provide actionable recourse
+\item \textbf{Applicability:} Model‑agnostic; supports tabular, image, and text data %via modality‑specific perturbations
+\item \textbf{In practice:}
+Generate samples near $\xv$, predict with $\fh$, and fit $\gh$ to these samples using $\fh$'s outputs as targets, weighting samples by their proximity to $\xv$
+\end{framei}
 
 
 % \begin{frame}{LIME}
@@ -84,46 +82,39 @@ figure/lime5
 % \end{frame}
 
 
-\begin{frame}{LIME: Characteristics}
-
-    \textbf{Definition:}
-	LIME provides a local explanation for a black-box model $\fh$ in form of a surrogate model $\gh \in \Gspace$, where $\Gspace$ is a class of interpretable models\\[2em]
-	
-	
-	Surrogate model $\gh$ should satisfy two characteristics:
-	\begin{enumerate}
-		\item \textbf{Interpretable}: Provide human-understandable insights into the relationship between input features and prediction (e.g. via coefficients, model structure)
-	\item \textbf{Local fidelity / faithfulness}: 
-    $\gh$ closely approximates $\fh$ in the vicinity of the input $\xv$ being explained
-        %similar behavior as $\fh$ in the vicinity of the obs. being predicted
-	\end{enumerate}
-	
-	\vspace{2em}
-	\textbf{Goal:} Find $\gh$ with \textbf{minimal complexity and maximal local fidelity} 
-\end{frame}
+\begin{framev}[align=top]{LIME: Characteristics}
+\textbf{Definition:}\\
+LIME provides a local explanation for a black-box model $\fh$ in form of a surrogate model $\gh \in \Gspace$, where $\Gspace$ is a class of interpretable models\\
+\spacer[0.25]
+Surrogate model $\gh$ should satisfy two characteristics:
+\begin{enumerate}
+\item \textbf{Interpretable}: Provide human-understandable insights into the relationship between input features and prediction, e.g. via coefficients or model structure
+\item \textbf{Local fidelity / faithfulness}: $\gh$ closely approximates $\fh$ in the vicinity of the input $\xv$ being explained
+%similar behavior as $\fh$ in the vicinity of the obs. being predicted
+\end{enumerate}
+\textbf{Goal:} Find $\gh$ with \textbf{minimal complexity and maximal local fidelity}
+\end{framev}
 
 
-\begin{frame}{Model Complexity}
-    
-    We can measure complexity of $\gh \in \Gspace$ using a complexity measure $J: \mathcal{G} \to \R_{0}$ \lz % $J(\gh)$ \lz
-
- 	\textbf{Example: (Sparse) Linear Models}\\
- 	\begin{itemize}
- 	    \item Let $\Gspace = \left\{g: \Xspace \to \R ~|~g(\xv) = s(\thetav^\top \xv)\right\}$ be the class of linear models
- 	    \item $s(\cdot)$ is identity (linear model) or logistic sigmoid function  (log. reg.)
- 	    \item[$\leadsto$] $J(g) = \sum_{j = 1}^p \ind_{\{ \theta_j \neq 0 \}}$: Count number of non-zero coeffs (via L$_0$-norm of $\thetav$)
- 	\end{itemize}
- 	\lz\pause
- 	
- 	\textbf{Example: Decision Trees}\\
- 	\begin{itemize}
- 	    \item Let $\Gspace = \left\{g:\Xspace \to \R ~|~g(\xv) = \sum_{m=1}^M c_m \ind_{\{ \xv \in Q_m \}}\right\}$ be the class of trees
-        \item $Q_m$ are disjoint axis parallel regions (leaves); $c_m \in \R$ constant predictions
-        %\\ 	     i.e., the class of additive models (e.g., constant $c_m$)  over the leaf-rectangles $Q_m$
- 	    \item[$\leadsto$] $J(g) = M$: Count number of terminal/leaf nodes
- 	\end{itemize}
- 	
-\end{frame}
+\begin{framev}[align=top]{Model Complexity}
+We can measure complexity of $\gh \in \Gspace$ using a complexity measure $J: \mathcal{G} \to \R_0$ \lz % $J(\gh)$ \lz
+\begin{itemizeM}
+\item \textbf{Example: (Sparse) Linear Models}\\
+Let $\Gspace = \{g: \Xspace \to \R ~|~ g(\xv) = s(\thetav^\top \xv)\}$ be the class of linear models
+\begin{itemizeS}
+\item $s(\cdot)$ is the identity (linear model) or logistic sigmoid function (logistic regression)
+\item[$\leadsto$] $J(g) = \sum_{j = 1}^p \ind_{\{\theta_j \neq 0\}}$: count the number of non-zero coefficients via the $L_0$ norm of $\thetav$
+\end{itemizeS}
+\pause
+\item \textbf{Example: Decision Trees}\\
+Let $\Gspace = \{g: \Xspace \to \R ~|~ g(\xv) = \sum_{m=1}^M c_m \ind_{\{\xv \in Q_m\}}\}$ be the class of trees
+\begin{itemizeS}
+\item $Q_m$ are disjoint axis-parallel regions (leaves); $c_m \in \R$ are constant predictions
+%\\ 	     i.e., the class of additive models (e.g., constant $c_m$)  over the leaf-rectangles $Q_m$
+\item[$\leadsto$] $J(g) = M$: count the number of terminal or leaf nodes
+\end{itemizeS}
+\end{itemizeM}
+\end{framev}
  
 % \begin{frame}{Local model fidelity}
 %  	\begin{itemize}
@@ -147,155 +138,125 @@ figure/lime5
 %  	\end{itemize}
 % \end{frame}
 
-\begin{frame}{Local Fidelity of Surrogate Models}
-
-  \begin{itemize}
-    \item Surrogate \( \gh \) is \textbf{locally faithful} to a black-box model \( \fh \) around an input \( \xv \) if
-    \[
-    \gh(\zv) \approx \fh(\zv) \quad \text{for synthetic samples } \zv \in \Zspace \subseteq \R^p \text{ generated around } \xv
-    \]
-
-    \pause
-
-    \item \textbf{Optimization principle:} Closer \( \zv \) is to \( \xv \), the more \( \gh(\zv) \) should match \( \fh(\zv) \)
-
-    \pause
-
-    \item To operationalize this optimization, we need:
-    \begin{enumerate}
-      \item \textbf{A proximity (similarity) measure} $\neigh(\zv)$ between $\zv$ and $\xv$, e.g.:
-      
-        \medskip
-        \centerline{$
-        \neigh(\zv) = \exp(-d(\xv, \zv)^2 / \sigma^2)  \text{ (exponential kernel), where}
-        $}
-        \medskip
-        
-        \begin{itemize}
-            \item \( d \): distance metric (e.g., Euclidean or Gower for mixed types)
-            \item \( \sigma \) is the kernel width that controls locality
-        \end{itemize}
-        
-        %(e.g., Euclidean or Gower), 
-        
-
-      \pause
-      \item \textbf{A loss function} \( L(\fh(\zv), \gh(\zv)) \), e.g. the L$_2$ loss/squared error:
-        \[
-        L(\fh(\zv), \gh(\zv)) = \left( \gh(\zv) - \fh(\zv) \right)^2
-        \]
-    \end{enumerate}
-
-    \pause
-
-    \item The overall \textbf{local fidelity objective} is measured by a weighted loss:
-    \[
-    L(\fh, \gh, \neigh) = \sum_{\zv \in \Zspace} \neigh(\zv) \cdot L(\fh(\zv), \gh(\zv))
-    \]
-  \end{itemize}
-\end{frame}
+\begin{framev}[align=top]{Local Fidelity of Surrogate Models}
+\begin{itemizeM}
+\item Surrogate $\gh$ is \textbf{locally faithful} to a black-box model $\fh$ around an input $\xv$ if\\
+$$\gh(\zv) \approx \fh(\zv) \quad \text{for synthetic samples } \zv \in \Zspace \subseteq \R^p \text{ generated around } \xv$$
+\pause
+\item \textbf{Optimization principle:}
+The closer $\zv$ is to $\xv$, the more $\gh(\zv)$ should match $\fh(\zv)$
+\pause
+\item To operationalize this optimization, we need:
+\begin{enumerate}
+\item \textbf{A proximity (similarity) measure} $\neigh(\zv)$ between $\zv$ and $\xv$, e.g.:
+$$
+\neigh(\zv) = \exp(-d(\xv, \zv)^2 / \sigma^2)
+$$
+(exponential kernel), where
+\begin{itemizeS}
+\item $d$ is a distance metric, e.g. Euclidean or Gower for mixed types
+\item $\sigma$ is the kernel width that controls locality
+\end{itemizeS}
+%(e.g., Euclidean or Gower),
+\pause
+\item \textbf{A loss function} $L(\fh(\zv), \gh(\zv))$, e.g. the $L_2$ loss or squared error:
+$$
+L(\fh(\zv), \gh(\zv)) = (\gh(\zv) - \fh(\zv))^2
+$$
+\end{enumerate}
+\pause
+\item The overall \textbf{local fidelity objective} is measured by a weighted loss:
+$$
+L(\fh, \gh, \neigh) = \sum_{\zv \in \Zspace} \neigh(\zv) \cdot L(\fh(\zv), \gh(\zv))
+$$
+\end{itemizeM}
+\end{framev}
 
 
+\begin{framei}[align=top]{LIME Optimization Task}
+\item Optimization problem of LIME:
+$$
+\argmin_{\gh \in \Gspace} L(\fh, \gh, \neigh) + J(\gh)
+$$
+\item \textbf{In practice} LIME uses a two-stage approach:
+\begin{enumerate}
+\item User sets complexity $J(\gh)$ beforehand, e.g. LASSO with $k$ features
+\item Optimize $L(\fh, \gh, \neigh)$ for fixed complexity
+\end{enumerate}
+\item \textbf{Goal:} Build a \textbf{model-agnostic} explainer
+\begin{itemizeS}
+\item[$\leadsto$] Optimize $L(\fh, \gh, \neigh)$ without making assumptions on the form of $\fh$
+\item[$\leadsto$] Surrogate $\gh$ approximates $\fh$ locally through sampling and fitting
+%learn $\gh$ only approximately
+\end{itemizeS}
+\end{framei}
 
 
+\begin{framev}[align=top]{LIME Algorithm: Outline \furtherreading{RIBEIRO2016}}
+\textbf{Input}:
+\begin{itemizeM}
+\item Pre-trained black-box model $\fh$
+\item Observation $\xv$ whose prediction $\fh(\xv)$ we want to explain
+\item Interpretable model class $\Gspace$ for the local surrogate
+\end{itemizeM}
+\pause
+\textbf{Algorithm}:
+\begin{enumerate}
+\item Independently sample new points $\zv \in \Zspace$
+\item Retrieve predictions $\fh(\zv)$ for the obtained points $\zv$
+\item Weight $\zv \in \Zspace$ by their proximity $\neigh(\zv)$ to quantify closeness to $\xv$
+\item Train interpretable surrogate model $\gh$ on data $\zv \in \Zspace$ using weights $\neigh(\zv)$\\
+$\leadsto$ Predictions $\fh(\zv)$ are used as the target of this model
+\item Return $\gh$ as the local explanation for $\fh(\xv)$
+%the interpretable model $\gh$ as the explainer
+\end{enumerate}
+\end{framev}
 
 
-
-\begin{frame}{LIME Optimization Task}
-	\begin{itemize}
-		\item Optimization problem of LIME: 
-		$$ \argmin_{\gh \in \Gspace} L(\fh, \gh, \neigh) + J(\gh)$$
-		\item \textbf{In practice} LIME uses a two-stage approach:
-		\begin{enumerate}
-                \item User sets complexity $J(\gh)$ beforehand (e.g., LASSO with \( k \) features)
-		    \item Optimize $L(\fh, \gh, \neigh)$ (model fidelity) for fixed complexity
-		\end{enumerate}
-		\item \textbf{Goal:} Build a \textbf{model-agnostic} explainer
-		\begin{itemize}
-    		\item[$\leadsto$] Optimize $L(\fh, \gh, \neigh)$ without making assumptions on the form of $\fh$ 
-    		\item[$\leadsto$] Surrogate \( \gh \) approximates \( \fh \) locally through sampling and fitting
-            %learn $\gh$ only approximately  
-		\end{itemize}
-		\end{itemize}
-\end{frame} 
-
-\begin{frame}{LIME Algorithm: Outline \furtherreading{RIBEIRO2016}}
-		
-		\textbf{Input}:
-		\begin{itemize}
-		    \item Pre-trained black-box model $\fh$
-		    \item Observation $\xv$ whose prediction $\fh(\xv)$ we want to explain
-		    \item Interpretable model class $\Gspace$ for local surrogate (to limit complexity)
-		\end{itemize}
-		
-		\pause
-		\medskip
-		
-		\textbf{Algorithm}:
-		\begin{enumerate}
-    		\item Independently sample new points $\zv \in \Zspace$ 
-    		\item Retrieve predictions $\fh(\zv)$ for obtained points $\zv$ 
-    		\item Weight $\zv \in \Zspace$ by their proximity $\neigh(\zv)$ to quantify closeness to \( \xv \)
-    		\item Train interpretable surrogate model $\gh$ on data $\zv \in \Zspace$ using weights $\neigh(\zv)$\\ $\leadsto$ Predictions $\fh(\zv)$ are used as target of this model
-    		\item Return \( \gh \) as the local explanation for \( \fh(\xv) \)
-            %the interpretable model $\gh$ as the explainer
-		\end{enumerate}
-		
-
-	
-\end{frame} 
-
-\begin{frame}{LIME Algorithm: Example}
-
-    	\textbf{Illustration} of LIME based on a classification task:
-		\begin{itemize}
-			\item Light/dark gray background: prediction surface of a classifier
-			\item Yellow point: $\xv$ to be explained
-			\item $\Gspace$: class of logistic regression models 
-		\end{itemize}
-		\begin{center}
-			\includegraphics[width=0.6\textwidth]{figure/lime2}
-		\end{center}
-
-\end{frame} 
+\begin{framev}[align=top]{LIME Algorithm: Example}
+\textbf{Illustration} of LIME based on a classification task:
+\begin{itemizeM}
+\item Light/dark gray background: prediction surface of a classifier
+\item Yellow point: $\xv$ to be explained
+\item $\Gspace$: class of logistic regression models
+\end{itemizeM}
+\imageC[0.6]{figure/lime2}
+\end{framev}
 
 
-\begin{frame}{LIME Algo.: Example (Step 1+2: Sampling)}
-		
-		Strategies for sampling: 
-		\begin{itemize} 
-			\item Uniformly sample new points from the feasible feature range 
-			\item Use the training data set with or without perturbations
-			\item Draw samples from the estimated univariate distribution of each feature
-			\item Create an equidistant grid over the supported feature range  
-		\end{itemize}
-		\vspace{-.5cm}
-		\begin{columns}[totalwidth=\textwidth]
-        \begin{column}{0.5\textwidth}  %%<--- here
-            \begin{figure}
-             \includegraphics[width=.95\textwidth]{figure/lime3} 
-             \vspace{-0.3cm}
-             \caption{Uniformly sampled}
-             \end{figure}
-        \end{column}
-        \begin{column}{0.5\textwidth}  %%<--- here
-		    \begin{figure}
-			\includegraphics[width=.95\textwidth]{figure/lime3a}
-			  \vspace{-0.3cm}
-    		    \caption{Equidistant grid}
-    		\end{figure}   
-    \end{column}
-\end{columns}
-\end{frame}
-		
-\begin{frame}{LIME Algo.: Example (Step 3: Proximity)}
+\begin{framev}[align=top]{LIME Algo.: Example (Step 1+2: Sampling)}
+Strategies for sampling:
+\begin{itemizeM}
+\item Uniformly sample new points from the feasible feature range
+\item Use the training data set with or without perturbations
+\item Draw samples from the estimated univariate distribution of each feature
+\item Create an equidistant grid over the supported feature range
+\end{itemizeM}
+\splitVTT{%
+\spacer[0]
+\begin{figure}
+\centering
+\image[0.95]{figure/lime3}
+\caption{Uniformly sampled}
+\end{figure}
+}{%
+\spacer[0]
+\begin{figure}
+\centering
+\image[0.95]{figure/lime3a}
+\caption{Equidistant grid}
+\end{figure}
+}
+\end{framev}
 
-	In this example, we use the exponential kernel defined on the Euclidean distance $d$
-		 $$\neigh(\zv) = exp(-d(\xv, \zv)^2/\sigma^2).$$ 
-		\begin{center}
-			\includegraphics[width=0.7\textwidth]{figure/lime4}
-		\end{center}
-		
+
+\begin{framev}[align=top]{LIME Algo.: Example (Step 3: Proximity)}
+In this example, we use the exponential kernel defined on the Euclidean distance $d$:
+$$
+\neigh(\zv) = \exp(-d(\xv, \zv)^2 / \sigma^2)
+$$
+\imageC[0.7]{figure/lime4}
+
 % MARIUS: Not relevant for the example; if we want to introduce it, we should do it somewhere else
 % 	An alternative is the Gower proximity: 
 % 	$\neigh(\zv) = 1 - \Gower(\zv, \xv) =  1 - \frac{1}{p}\sum_{j = 1}^{p} \delta_G(z_j, x_j) $ 
@@ -304,16 +265,15 @@ figure/lime5
 % 	\frac{1}{\widehat{R}_j}|z_j- x_j| & \text{if $x_j$ and $z_j$ are numerical} \\
 % 	\mathbb{I}_{z_j \neq x_j} & \text{if $x_j$ and $z_j$ are categorical}
 % 	\end{cases}.$
-		
-\end{frame}
-		
-\begin{frame}{LIME Algo.: Example (Step 4: Surrogate)}
-		In this example, we fit a \textbf{logistic regression} model\\
-        $\leadsto$ $L(\fh(\zv), \gh(\zv))$ is the Bernoulli loss
-		\begin{center}
-			\includegraphics[width=0.7\textwidth]{figure/lime5}
-		\end{center}
-\end{frame}
+
+\end{framev}
+
+
+\begin{framev}[align=top]{LIME Algo.: Example (Step 4: Surrogate)}
+In this example, we fit a \textbf{logistic regression} model\\
+$\leadsto$ $L(\fh(\zv), \gh(\zv))$ is the Bernoulli loss
+\imageC[0.7]{figure/lime5}
+\end{framev}
 
 \endlecture
 \end{document}

--- a/slides/local-explanations-lime/slides05-le-lime-examples.tex
+++ b/slides/local-explanations-lime/slides05-le-lime-examples.tex
@@ -5,22 +5,20 @@
 \input{../../latex-math/basic-ml}
 \input{../../latex-math/ml-interpretable}
 % Defines macros and environments
- 
+
 \newcommand{\gh}{\hat{g}}
 
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
 
-	
 % Set style/preamble.Rnw as parent.
 
 % Load all R packages and set up knitr
 
-% This file loads R packages, configures knitr options and sets preamble.Rnw as 
+% This file loads R packages, configures knitr options and sets preamble.Rnw as
 % parent file
 % IF YOU MODIFY THIS, PLZ ALSO MODIFY setup.Rmd ACCORDINGLY...
 
@@ -37,176 +35,156 @@ figure/lime_credit_ice2.pdf
 \item See application to image and text data
 }
 
-
 % Prerequisite: le-intro
 
 % ------------------------------------------------------------------------------
-\begin{frame}{Example: Credit Scoring (Tabular Data)}
-
-\begin{itemize}
-  \item \textbf{Black-box model \( \fh_{bad} \):} SVM with RBF kernel (predicts probability of bad credit risk)
-  \item \textbf{Instance to explain \( \xv \):} First row in the dataset, with \( \fh_{bad}(\xv) = 0.658 \)
-{\scriptsize
+\begin{framev}[align=top]{Example: Credit Scoring (Tabular Data)}
+\begin{itemizeM}
+\item \textbf{Black-box model $\fh_{bad}$:} SVM with RBF kernel (predicts probability of bad credit risk)
+\item \textbf{Instance to explain $\xv$:} First row in the dataset, with $\fh_{bad}(\xv) = 0.658$
+\begin{scriptsize}
 \begin{tabular}{r l r l r r r l l l}
-  \hline
-  duration & sex & credit.amount & purpose & housing & age & saving & checking & ... \\
-  \hline
-  48 & female & 5951 & radio/TV & own & 22 & little & moderate & ... \\
-  \hline
+\hline
+duration & sex & credit.amount & purpose & housing & age & saving & checking & ... \\
+\hline
+48 & female & 5951 & radio/TV & own & 22 & little & moderate & ... \\
+\hline
 \end{tabular}
-
-}
-  \item \textbf{Surrogate model:} LASSO, restricted to 5 non-0 feats (via regularization)
-  \item \textbf{Training data for surrogate:} Samples \( \zv \), weighted by Gower dist. to \( \xv \)
-\end{itemize}
+\end{scriptsize}
+\item \textbf{Surrogate model:} LASSO, restricted to 5 non-0 feats (via regularization)
+\item \textbf{Training data for surrogate:} Samples $\zv$, weighted by Gower dist. to $\xv$
+\end{itemizeM}
 \pause
-\begin{columns}[T,onlytextwidth]
-  \begin{column}{0.5\textwidth}
-    \begin{itemize}
-      \item \textbf{Prediction:} \\
-      \( \gh(\xv) = 0.640 \) vs. \( \fh_{bad}(\xv) = 0.658 \)
-      \item[$\leadsto$] $\gh$ provides good local approx. of $\fh_{bad}$, but omits several features 
-      \item[$\leadsto$] Small mismatch reflects trade-off:\\
-      \textbf{interpretability vs. fidelity}
-    \end{itemize}
-  \end{column}
-
-  \begin{column}{0.5\textwidth}
-    \includegraphics[width=\linewidth]{figure/lime_credit.pdf}%\\
-    %{\scriptsize Local surrogate model: \( \gh(\xv) = \thetah^\top \xv \)}
-  \end{column}
-
-\end{columns}
+\splitVTT{
+\spacer[0.6]
+\begin{itemizeM}
+\item \textbf{Prediction:} \\
+$\gh(\xv) = 0.640$ vs. $\fh_{bad}(\xv) = 0.658$
+\item[$\leadsto$] $\gh$ provides good local approx. of $\fh_{bad}$, but omits several features
+\item[$\leadsto$] Small mismatch reflects trade-off: \\
+\textbf{interpretability vs. fidelity}
+\end{itemizeM}
+}{
+\spacer[0]
+\image{figure/lime_credit.pdf}
+%{\scriptsize Local surrogate model: \( \gh(\xv) = \thetah^\top \xv \)}
+\spacer[0]
+}
 \textbf{Interpretation:} Prediction is mainly driven by loan duration, with small positive effect from sex and credit.amount, and negative contributions from housing and purpose.
-\end{frame}
-
-\begin{frame}{Example on Credit Dataset (cont'd)}
-
-\begin{itemize}
-  \item 2D ICE plots (pred. surface plots) for \texttt{duration} and \texttt{credit.amount} 
-  \item Illustration how \( \gh \) linearly approximates nonlinear decision surface of \( \fh_{bad} \)
-\end{itemize}
-
-\begin{columns}[totalwidth=\textwidth]
-  \begin{column}{0.47\textwidth}
-    \centering
-    \includegraphics[width=\linewidth]{figure/lime_credit_ice1.pdf}
-  \end{column}
-  \begin{column}{0.46\textwidth}
-    \centering
-    \includegraphics[width=\linewidth]{figure/lime_credit_ice2.pdf}
-  \end{column}
-\end{columns}
-
-\begin{itemize}
-    \item \textbf{Left:} 2D ICE plot of \( \fh_{bad} \) showing decision surface
-    \item \textbf{Right:} Linear approximation by surrogate model \( \gh \). \\
-    $\leadsto$ White dot indicates input \( \xv \) to be explained\\
-    $\leadsto$ Histograms show marginal distribution of features in training data % training data \( \Xmat \).
-\end{itemize}
-
-\end{frame}
+\end{framev}
 
 
+\begin{framev}[align=top]{Example on Credit Dataset (cont'd)}
+\begin{itemizeM}
+\item 2D ICE plots (pred. surface plots) for \texttt{duration} and \texttt{credit.amount}
+\item Illustration how $\gh$ linearly approximates nonlinear decision surface of $\fh_{bad}$
+\end{itemizeM}
+\splitVTT{
+\spacer[0]
+\image{figure/lime_credit_ice1.pdf}
+\spacer[0]
+}{
+\spacer[0]
+\image{figure/lime_credit_ice2.pdf}
+\spacer[0]
+}
+\begin{itemizeM}
+\item \textbf{Left:} 2D ICE plot of $\fh_{bad}$ showing decision surface
+\item \textbf{Right:} Linear approximation by surrogate model $\gh$. \\
+$\leadsto$ White dot indicates input $\xv$ to be explained \\
+$\leadsto$ Histograms show marginal distribution of features in training data % training data \( \Xmat \).
+\end{itemizeM}
+\end{framev}
 
 %\begin{frame}[containsverbatim,allowframebreaks]{Bike Sharing Dataset}
 %\vspace{-.3cm}
 %
 %\begin{center}
 %\includegraphics[width=0.7\textwidth]{figure/bike-figure.png}
-%\end{center} 
+%\end{center}
 %
 %\footnotesize \textbf{Figure:} LIME for two example instances of the bike sharing dataset.
 %
 %\normalsize
 %\vspace{0.2cm}
 %The plots show the feature effect of the sparse linear model, i.e. the model coefficients times the feature value of the instance.
-%Warmer temperature has a positive effect on the prediction, 
+%Warmer temperature has a positive effect on the prediction,
 %while the year 2011 has a large negative effect as well as the springtime.
 %\end{frame}
 
-\begin{frame}{LIME for Text Data \furtherreading{IAN2019}}
-    LIME can also be applied to text data: 
-	\begin{itemize}
-		\item Raw text representations: 
-		\begin{itemize}
-		    \item Binary vector indicating the presence or absence of a word 
-		    \item A vector of word counts
-		\end{itemize}
-		\item Examples for \textit{``This text is the first text."} and \textit{``Finally, this is the last one."}:
-		\begin{center}
-			\begin{tabular}{c|c|c|c|c|c|c|c} 
-				this & text & is & the & first & finally & last & one \\ 
-				\hline
-				1 & 2 & 1 & 1 & 1 & 0 & 0 & 0 \\
-				1 & 0 & 1 & 1 & 0 & 1 & 1 & 1 \\
-			\end{tabular}
-		\end{center} 
-		\item \textbf{Sampling}: Randomly set the entry of individual words to $0$; equal to removing all occurrences of this word in the text. 
-		\item \textbf{Proximity}: Exponential kernel with cosine distance. 
-		\begin{itemize}
-		    \item Neglects words that do not occur in both texts 
-		    \item Measures the distance irrespective of the text size
-		\end{itemize}
-	\end{itemize}
-\end{frame}
-	
-\begin{frame}{LIME for Text Data (cont'd) \furtherreading{IAN2019}}	 
-	\begin{itemize}
-		\item Random forest classifier labeling movie reviews from IMDB 
-		\begin{itemize}
-		    \item \textcolor{blue}{0}: negative
-		    \item \textcolor{orange}{1}: positive
-		\end{itemize}
-		\item Surrogate model is a sparse linear model 
-	\end{itemize}
-	
-	\begin{figure}
-		\begin{center}
-			%\captionsetup{font = scriptsize, labelfont = {bf, scriptsize}}
-			\includegraphics[width=0.9\textwidth]{figure/lime_movier}
-		\end{center}
-	\end{figure}
-	
-	{Words like ``worst`` or ``waste`` indicate negative review while words like ``best`` or ``great`` indicate positive review}
-	
-	\end{frame}
-	
-\begin{frame}{LIME for image data}
-	\begin{columns}[totalwidth=\textwidth]
-		\begin{column}{0.67\textwidth}
-			LIME also works for image data:  
-			\begin{itemize}
-				\item \textbf{Idea}: Each obs. is represented by a binary vector indicating the presence or absence of superpixels \furtherreading{ACHANTA2012}
-				\item Superpixels are interconnected pixels with similar colors (absence of a single pixel might not have a (strong) effect on the prediction)
-				\item \textbf{Warning}: Size of superpixels needs to be determined before the segmentation takes place
-				\item \textbf{Sampling}: Randomly switching some of the super pixels ``off", i.e., by coloring some superpixels uniformly
-			\end{itemize}		
-		\end{column}
-		\begin{column}{0.26\textwidth}  
-			\begin{center}
-				\includegraphics[width=1\textwidth]{figure/superpixel_woman}
-				{Example for superpixels of different sizes}
-			\end{center}
-		\end{column}
-	\end{columns}
-    
-\end{frame}
-\begin{frame}{LIME for image data (cont'd) \furtherreading{RIBEIRO2016}}
-	\begin{itemize}
-		\item Explaining prediction of pre-trained inception neural network classifier
-		\item \textbf{Sampling}: Graying out all superpixels besides 10 superpixels
-		\item \textbf{Surrogate}: Locally weighted sparse linear models 
-		\item \textbf{Proximity}: Exponential kernel with euclidean distance
-	\end{itemize}
+\begin{framev}[align=top]{LIME for Text Data \furtherreading{IAN2019}}
+LIME can also be applied to text data:
+\begin{itemizeM}
+\item Raw text representations:
+\begin{itemizeS}
+\item Binary vector indicating the presence or absence of a word
+\item A vector of word counts
+\end{itemizeS}
+\item Examples for \textit{``This text is the first text."} and \textit{``Finally, this is the last one."}:
+\begin{center}
+\begin{tabular}{c|c|c|c|c|c|c|c}
+this & text & is & the & first & finally & last & one \\
+\hline
+1 & 2 & 1 & 1 & 1 & 0 & 0 & 0 \\
+1 & 0 & 1 & 1 & 0 & 1 & 1 & 1 \\
+\end{tabular}
+\end{center}
+\item \textbf{Sampling}: Randomly set the entry of individual words to $0$; equal to removing all occurrences of this word in the text.
+\item \textbf{Proximity}: Exponential kernel with cosine distance.
+\begin{itemizeS}
+\item Neglects words that do not occur in both texts
+\item Measures the distance irrespective of the text size
+\end{itemizeS}
+\end{itemizeM}
+\end{framev}
+
+
+\begin{framev}[align=top]{LIME for Text Data (cont'd) \furtherreading{IAN2019}}
+\begin{itemizeM}
+\item Random forest classifier labeling movie reviews from IMDB
+\begin{itemizeS}
+\item \textcolor{blue}{0}: negative
+\item \textcolor{orange}{1}: positive
+\end{itemizeS}
+\item Surrogate model is a sparse linear model
+\end{itemizeM}
+\imageC[0.9]{figure/lime_movier}
+\spacer[0.25]
+Words like ``worst`` or ``waste`` indicate negative review while words like ``best`` or ``great`` indicate positive review
+\end{framev}
+
+
+\begin{framev}[align=top]{LIME for image data}
+\splitVTT[0.7]{
+LIME also works for image data:
+\begin{itemizeM}
+\item \textbf{Idea}: Each obs. is represented by a binary vector indicating the presence or absence of superpixels \furtherreading{ACHANTA2012}
+\item Superpixels are interconnected pixels with similar colors (absence of a single pixel might not have a (strong) effect on the prediction)
+\item \textbf{Warning}: Size of superpixels needs to be determined before the segmentation takes place
+\item \textbf{Sampling}: Randomly switching some of the super pixels ``off", i.e., by coloring some superpixels uniformly
+\end{itemizeM}
+}{
+\spacer[0]
+\begin{center}
+\image{figure/superpixel_woman}
+Example for superpixels of different sizes
+\end{center}
+}
+\end{framev}
+
+
+\begin{framev}[align=top]{LIME for image data (cont'd) \furtherreading{RIBEIRO2016}}
+\begin{itemizeM}
+\item Explaining prediction of pre-trained inception neural network classifier
+\item \textbf{Sampling}: Graying out all superpixels besides 10 superpixels
+\item \textbf{Surrogate}: Locally weighted sparse linear models
+\item \textbf{Proximity}: Exponential kernel with euclidean distance
+\end{itemizeM}
 % https://lime-ml.readthedocs.io/en/latest/lime.html#module-lime.lime_image
-	\vspace{-0.3cm}
-	\begin{center}
-		\includegraphics[width=0.8\textwidth]{figure/lime-images}
-		
-		{Top 3 classes predicted}
-	\end{center}
-	
-\end{frame}
+\begin{center}
+\image[0.8]{figure/lime-images}\\
+Top 3 classes predicted
+\end{center}
+\end{framev}
 \endlecture
 \end{document}

--- a/slides/local-explanations-lime/slides06-le-lime-pitfalls.tex
+++ b/slides/local-explanations-lime/slides06-le-lime-pitfalls.tex
@@ -6,134 +6,111 @@
 \input{../../latex-math/ml-interpretable}
 
 % Defines macros and environments
- 
+
 \newcommand{\gh}{\hat{g}}
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
-	
-	% Set style/preamble.Rnw as parent.
-	
-	% Load all R packages and set up knitr
-	
-	% This file loads R packages, configures knitr options and sets preamble.Rnw as 
-	% parent file
-	% IF YOU MODIFY THIS, PLZ ALSO MODIFY setup.Rmd ACCORDINGLY...
-	
-	% Defines macros and environments
-	
-	\titlemeta{
+
+% Set style/preamble.Rnw as parent.
+
+% Load all R packages and set up knitr
+
+% This file loads R packages, configures knitr options and sets preamble.Rnw as
+% parent file
+% IF YOU MODIFY THIS, PLZ ALSO MODIFY setup.Rmd ACCORDINGLY...
+
+% Defines macros and environments
+
+\titlemeta{
 Local Explanations: LIME
 }{
 Pitfalls
 }{
 figure/lime5
 }{
-
-    	\item Learn why LIME should be used with caution
-    	\item Possible pitfalls of LIME
+\item Learn why LIME should be used with caution
+\item Possible pitfalls of LIME
 }
 
-	
-	% Prerequisite: le-into, le-lime
-	
-	% ------------------------------------------------------------------------------
+% Prerequisite: le-into, le-lime
+
+% ------------------------------------------------------------------------------
+
+\begin{framei}[align=top]{LIME Pitfalls}
+\item %Despite being a popular interpretation method, several papers caution to be careful in LIME
+LIME is one of the most widely used methods for local interpretability\\
+$\leadsto$ But several papers highlight important (practical) limitations
+\item Pitfalls arise at multiple levels, which will be discussed in detail:
+\begin{itemizeS}
+\item \textbf{Sampling} -- ignores feature dependencies, risks extrapolation
+\item \textbf{Locality definition} -- kernel width and dist. metrics affect sensitivity
+\item \textbf{Local vs. global feats} -- global signals may overshadow local ones
+\item \textbf{Faithfulness} -- trade-off between sparsity and local accuracy
+\item \textbf{Hiding biases} -- explanations can be manipulated to appear fair
+\item \textbf{Robustness} -- explanations vary for similar points
+\item \textbf{Superpixels (images)} -- instability due to segmentation method
+\end{itemizeS}
+% \begin{itemize}
+%     \item Sampling procedure (extrapolation)
+%     \item Definition of locality (sensitivity)
+%     \item Scope of feature effects (local vs. global)
+%     \item Faithfulness (trade-off with sparsity)
+%     \item Surrogate model (hiding biases, robustness)
+%     \item Definition of superpixels in case of image data (sensitivity)
+% \end{itemize}
+%\item These are discussed in more detail in the following
+\end{framei}
 
 
-\begin{frame}{LIME Pitfalls}
-  \begin{itemize}
-  	\item %Despite being a popular interpretation method, several papers caution to be careful in LIME
-  	LIME is one of the most widely used methods for local interpretability\\ 
-  	$\leadsto$ But several papers highlight important (practical) limitations
-  	\item Pitfalls arise at multiple levels, which will be discussed in detail:
-    \begin{itemize}
-  \item \textbf{Sampling} -- ignores feature dependencies, risks extrapolation
-  \item \textbf{Locality definition} -- kernel width and dist. metrics affect sensitivity
-  \item \textbf{Local vs. global feats} -- global signals may overshadow local ones
-  \item \textbf{Faithfulness} -- trade-off between sparsity and local accuracy
-  \item \textbf{Hiding biases} -- explanations can be manipulated to appear fair
-  \item \textbf{Robustness} -- explanations vary for similar points
-  \item \textbf{Superpixels (images)} -- instability due to segmentation method
-\end{itemize}
-  	% \begin{itemize}
-  	%     \item Sampling procedure (extrapolation)
-  	%     \item Definition of locality (sensitivity)
-  	%     \item Scope of feature effects (local vs. global)
-  	%     \item Faithfulness (trade-off with sparsity)
-  	%     \item Surrogate model (hiding biases, robustness)
-  	%     \item Definition of superpixels in case of image data (sensitivity)
-  	% \end{itemize}
-  	%\item These are discussed in more detail in the following 
-  \end{itemize}
-  
-\end{frame}
-  
-\begin{frame}{Pitfall: Sampling}
-	\begin{itemize}
-	\itemsep1em
-	  \item \textbf{Pitfall}: Common sampling strategies for $\zv \in \Zspace$ ignore feat dependencies
-      % \item \textbf{Implication}:  Unlikely data points might be used to learn local explanation models
-        \item \textbf{Implication:} Surrogate model may be trained on unrealistic points\\
-  $\leadsto$ Undermines the fidelity and validity of the explanation
-      \pause
-      \item \textbf{Solution I}: Sample locally from the true data manifold $\Xspace$\\
-  $\leadsto$ Challenging in high-dimensional or mixed-type data settings
-      \item \textbf{Solution II}: Restrict sampling to training data near $\xv$\\
-      $\leadsto$ Requires enough training data points near $\xv$
-    \end{itemize}
-    
-\end{frame}
+\begin{framei}[align=top]{Pitfall: Sampling}
+\item \textbf{Pitfall}: Common sampling strategies for $\zv \in \Zspace$ ignore feat dependencies
+% \item \textbf{Implication}:  Unlikely data points might be used to learn local explanation models
+\item \textbf{Implication:} Surrogate model may be trained on unrealistic points\\
+$\leadsto$ Undermines the fidelity and validity of the explanation
+\pause
+\item \textbf{Solution I}: Sample locally from the true data manifold $\Xspace$\\
+$\leadsto$ Challenging in high-dimensional or mixed-type data settings
+\item \textbf{Solution II}: Restrict sampling to training data near $\xv$\\
+$\leadsto$ Requires enough training data points near $\xv$
+\end{framei}
 
-\begin{frame}{LIME Pitfall: Locality}
 
-	\begin{itemize} 
-     \item \textbf{Pitfall}: Difficult to define locality (= how samples are weighted locally) %\\
-    % \begin{itemize}
-     %    \item[$\leadsto$] 
-     %$\leadsto$ Strongly affects local model, but there is no automatic procedure for choosing neighborhood
-     %\end{itemize}
-     \item \textbf{Implication:} Local model and explanation quality depend heavily on this weighting, but no principled way exists to choose it
+\begin{framev}[align=top]{LIME Pitfall: Locality}
+\begin{itemizeM}
+\item \textbf{Pitfall}: Difficult to define locality (= how samples are weighted locally) %\\
+% \begin{itemize}
+%    \item[$\leadsto$]
+%$\leadsto$ Strongly affects local model, but there is no automatic procedure for choosing neighborhood
+% \end{itemize}
+\item \textbf{Implication:} Local model and explanation quality depend heavily on this weighting, but no principled way exists to choose it
+\item \textbf{Default:} Use exponential kernel as proximity measure between $\xv$ and $\zv$:\\
+$\neigh(\zv) = exp(-d(\xv, \zv)^2/\sigma^2)$ with distance measure $d$ and kernel width $\sigma$
+% \begin{center}
+%     \includegraphics[width=0.6\textwidth]{figure/lime_locality}
+%     \vspace{-0.5cm}
+%
+%     \scriptsize{Linear surrogate models for two observations based on the same model with one target and one feature. Each line displays one linear surrogate model with different kernel width. In the right figure, larger kernel sizes are more severe.}
+%
+% \end{center}
+\end{itemizeM}
+\pause
+\textbf{Example:} For 2 obs. (green points), fit local surr. models (lines) using only $x_1$
+\splitVTT[0.72]{
+\spacer[0.25]
+\includegraphics[width=\textwidth, trim = 25px 0px 15px 40px, clip]{figure/lime_locality}
+}{
+\spacer[0.25]
+\textbf{Line colors:} different kernel widths used for proximity weighting\\
+\textbf{Right:} larger kernel widths affect lines more
+}
+\end{framev}
 
-     \item \textbf{Default:} Use exponential kernel as proximity measure between $\xv$ and $\zv$:\\
-     	$\neigh(\zv) = exp(-d(\xv, \zv)^2/\sigma^2)$ with distance measure $d$ and kernel width $\sigma$
-    %  	 \begin{center}
-    %  		\includegraphics[width=0.6\textwidth]{figure/lime_locality}
-    %  		\vspace{-0.5cm}
-     		
-    %  		\scriptsize{Linear surrogate models for two observations based on the same model with one target and one feature. Each line displays one linear surrogate model with different kernel width. In the right figure, larger kernel sizes are more severe.}
-     		
-    %  	\end{center}
-     \end{itemize}
-     \pause
-     \textbf{Example:} For 2 obs. (green points), fit local surr. models (lines) using only \( x_1 \)
-     \begin{columns}[T, totalwidth=\textwidth]
-        \begin{column}{0.72\textwidth}
-        \includegraphics[width=\textwidth, trim = 25px 0px 15px 40px, clip]{figure/lime_locality}
-         \end{column}
-         \begin{column}{0.31\textwidth}
-         % \begin{itemize}
-         %     \item Surrogate models for 2 obs. (green points) for same model with one feature $x_1$
-         %     \item Each line refers to a linear surrogate model with different kernel width
-         %     \item Right figure: larger kernel widths influence lines more
-         % \end{itemize}
-         %\begin{itemize}
-  %\item 
-    \lz
-  \textbf{Line colors:} different kernel widths used for proximity weighting\\
-  \lz
-  %\item 
-  \textbf{Right:} larger kernel widths affect lines more
-%\end{itemize}
 
-         \end{column}
-     \end{columns}
-\end{frame}
-
-\begin{frame}{LIME Pitfall: Locality \furtherreading{KOPPER2019}}
-%     \begin{itemize} 
+\begin{framei}[align=top]{LIME Pitfall: Locality \furtherreading{KOPPER2019}}
+%     \begin{itemize}
 %          \item \textbf{Solution I}: Kernel width strongly interacts with locality:
 %          \begin{itemize}
 %              \item Large kernel width leads to interaction with points further away (unwanted)
@@ -142,334 +119,281 @@ figure/lime5
 %              $\leadsto$ potentially fitting more noise
 %          \end{itemize}
 %          \pause
-%     	\item \textbf{Solution II}: Use Gower distance where no kernel width needs to be specified 
-%     	\begin{itemize}
-%     	    \item \textbf{Problem}: data points far away receive weight $ > 0$\\
-%     	    $\leadsto$ resulting explanations are rather global than local surrogates   
-%     	\end{itemize}
+%         \item \textbf{Solution II}: Use Gower distance where no kernel width needs to be specified
+%         \begin{itemize}
+%             \item \textbf{Problem}: data points far away receive weight $ > 0$\\
+%             $\leadsto$ resulting explanations are rather global than local surrogates
+%         \end{itemize}
 %     \end{itemize}
 % \vspace{0.3cm}
-
-\begin{itemize}
-  \item \textbf{Pitfall:} Choice of kernel width (\(\sigma\)) critically influences locality
-  \pause
-  \item \textbf{Implication of edge cases:}
-  \begin{itemize}
-    \item \emph{Large} $\sigma$ $\rightarrow$ overemphasize distant points, hurting locality
-    \item \emph{Small} $\sigma$ $\rightarrow$ too few points may lead to unstable or noisy explanations
-  \end{itemize}
-  \pause
-  \item  \textbf{Solution I:} Use Gower similarity directly as weights: \( \pi(\zv) = 1 - d_{\text{Gower}}(\xv, \zv) \)\\
-  $\leadsto$ No kernel width required, but far points still receive (too high) weight\\
-  $\leadsto$ Explanation may reflect more global than local structure\\
-  $\leadsto$ Used in practical LIME implementations \furtherreading{LIMEPAC}
-  \pause
-  \item \textbf{Solution II:} s-LIME adaptively selects \(\sigma\) to balance fidelity and stability \furtherreading{GAUDEL2022}
-\end{itemize}
-\end{frame}
-
-\begin{frame}{Pitfall: Local vs. Global Features \furtherreading{LAUGEL2018}}
-
-\begin{itemize}%[<+->]
-	\item<1-> \textbf{Pitfall:} Sampling from entire input space may hide influence of locally relevant feat in favor of globally relevant ones, even for narrow kernels.
- \item<1-> \textbf{Feature types:}
-  \begin{itemize}
-    \item \emph{Global features} influence predictions broadly across whole input space $\Xspace$
-    \item \emph{Local features} affect predictions only in small subregions of $\Xspace$
-  \end{itemize}
-  
-  \item<2-> \textbf{Implication:} LIME’s surrogate may over-weight global features, producing explanations that miss critical local signals.
-	% \item<2-> \textbf{Implication}: 
-	% \begin{itemize}
- %        \item \emph{Global features:} influence predictions broadly across $\Xspace$
- %    \item \emph{Local features:} affect predictions only in small subregions
-	%     % \item Some features influence the \textbf{global} shape of the black-box model
-	%     % \item Other \textbf{local} features impact predictions only in smaller regions of $\Xspace$ %for a small area of $\Xspace$ 
-	% \end{itemize}
-	\item<3-> \textbf{Example}: Decision trees
-    \begin{itemize}
-        \item Features near the root impact many instances $\rightarrow$ global
-        \item Features in lower nodes act locally
-        % \item Features used in early splits affect many predictions (global)
-        % \item Features used in later splits have localized effects
-    \end{itemize}
-    %Split features close to root have a more global influence than the ones close to leaves
-\end{itemize}
-
-\end{frame}
+\item \textbf{Pitfall:} Choice of kernel width ($\sigma$) critically influences locality
+\pause
+\item \textbf{Implication of edge cases:}
+\begin{itemizeS}
+\item \emph{Large} $\sigma$ $\rightarrow$ overemphasize distant points, hurting locality
+\item \emph{Small} $\sigma$ $\rightarrow$ too few points may lead to unstable or noisy explanations
+\end{itemizeS}
+\pause
+\item \textbf{Solution I:} Use Gower similarity directly as weights: $\pi(\zv) = 1 - d_{\text{Gower}}(\xv, \zv)$\\
+$\leadsto$ No kernel width required, but far points still receive (too high) weight\\
+$\leadsto$ Explanation may reflect more global than local structure\\
+$\leadsto$ Used in practical LIME implementations \furtherreading{LIMEPAC}
+\pause
+\item \textbf{Solution II:} s-LIME adaptively selects $\sigma$ to balance fidelity and stability \furtherreading{GAUDEL2022}
+\end{framei}
 
 
+\begin{framei}[align=top]{Pitfall: Local vs. Global Features \furtherreading{LAUGEL2018}}
+\item<1-> \textbf{Pitfall:} Sampling from entire input space may hide influence of locally relevant feat in favor of globally relevant ones, even for narrow kernels.
+\item<1-> \textbf{Feature types:}
+\begin{itemizeS}
+\item \emph{Global features} influence predictions broadly across whole input space $\Xspace$
+\item \emph{Local features} affect predictions only in small subregions of $\Xspace$
+\end{itemizeS}
+\item<2-> \textbf{Implication:} LIME’s surrogate may over-weight global features, producing explanations that miss critical local signals.
+% \item<2-> \textbf{Implication}:
+% \begin{itemize}
+%     \item \emph{Global features:} influence predictions broadly across $\Xspace$
+%     \item \emph{Local features:} affect predictions only in small subregions
+%     % \item Some features influence the \textbf{global} shape of the black-box model
+%     % \item Other \textbf{local} features impact predictions only in smaller regions of $\Xspace$ %for a small area of $\Xspace$
+% \end{itemize}
+\item<3-> \textbf{Example:} Decision trees
+\begin{itemizeS}
+\item Features near the root impact many instances $\rightarrow$ global
+\item Features in lower nodes act locally
+% \item Features used in early splits affect many predictions (global)
+% \item Features used in later splits have localized effects
+\end{itemizeS}
+%Split features close to root have a more global influence than the ones close to leaves
+\end{framei}
 
-\begin{frame}{Pitfall: Local vs. Global Features \furtherreading{LAUGEL2018}}
+
+\begin{framev}[align=top]{Pitfall: Local vs. Global Features \furtherreading{LAUGEL2018}}
 %\begin{columns}[T, totalwidth=\textwidth]
-%	\begin{column}{0.6\textwidth}
-	%\vspace{-.5cm}
-		\begin{itemize}
-             \item \textbf{Problem:} Sampling around observation to be explained $\xv$ may miss decision boundary
-		\item \textbf{Solution (LS: Local Surrogate Method):}
-  \begin{enumerate}
+%   \begin{column}{0.6\textwidth}
+%\vspace{-.5cm}
+\begin{itemizeM}
+\item \textbf{Problem:} Sampling around observation to be explained $\xv$ may miss decision boundary
+\item \textbf{Solution (LS: Local Surrogate Method):}
+\begin{enumerate}
+% \item Red point: Obs. $\xv$ to be explained
+\item Find closest point to $\xv$ (red dot) from opposite class (black cross)
+\item Sample around that point to better capture boundary
+\item Train local surrogate using those samples\\
+$\leadsto$ better approximates the local direction of the decision boundary
+\end{enumerate}
+%       \textbf{Solution}:
+% Find closest point to $\xv$ from other class and sample new points $\zv$ around it for higher local accuracy
+\image{figure/laugel_method}
+\begin{center}
+\begin{small}
+\textbf{Example:} $\xv$ (red point), closest point from other class (black cross)
+\end{small}
+\end{center}
+\end{itemizeM}
+%{Local surrogate (LS) method by \furtherreading{LAUGEL2018}}
+%Sample new instances $\zv$ around the decision boundary closest from point $\xv$ for higher local accuracy
+% \pause
+% \item Red dot (right figure): Closest point from other class
 
-    %\item Red point: Obs. $\xv$ to be explained
-    \item Find closest point to $\xv$ (red dot) from opposite class (black cross)
-    \item Sample around that point to better capture boundary
-    \item Train local surrogate using those samples\\
-		$\leadsto$ better approximates the local direction of the decision boundary 
-    \end{enumerate}
-  %       \textbf{Solution}: 
-		% Find closest point to $\xv$ from other class and sample new points $\zv$ around it for higher local accuracy
-		\begin{center}
-		\includegraphics[width=\linewidth]{figure/laugel_method}
-		\scriptsize{\textbf{Example:} $\xv$ (red point), closest point from other class (black cross)}
-	    %{Local surrogate (LS) method by \furtherreading{LAUGEL2018}}
-		\end{center}
-		%Sample new instances $\zv$ around the decision boundary closest from point $\xv$ for higher local accuracy
-		% \pause
-		% \item Red dot (right figure): Closest point from other class
+% \item Red line: Local surrogate (LS) method \furtherreading{LAUGEL2018}\\
+% $\leadsto$ better approximates the local direction of the decision boundary
+\begin{itemizeM}
+\item LIME: What does the model do around this point?
+\item LS: How does the model change when crossing boundary near this point?
+\end{itemizeM}
 
-		% \item Red line: Local surrogate (LS) method \furtherreading{LAUGEL2018}\\
-		% $\leadsto$ better approximates the local direction of the decision boundary 
-    \item LIME: What does the model do around this point?
-    \item LS: How does the model change when crossing boundary near this point?
-	\end{itemize}
-
-% 	\begin{center}
-% 		\includegraphics[width=1\textwidth]{figure/laugel_method}
-% 	    {Local surrogate (LS) method by \furtherreading{LAUGEL2018}}
-% 		\vspace{-0.3cm}
-% 		\end{center}
+%   \begin{center}
+%       \includegraphics[width=1\textwidth]{figure/laugel_method}
+%       {Local surrogate (LS) method by \furtherreading{LAUGEL2018}}
+%       \vspace{-0.3cm}
+%       \end{center}
 % \end{column}
 % \begin{column}{0.39\textwidth}
 % %\vspace{0.3cm}
 
-% 	\begin{center}
-% 	\includegraphics[width=1\textwidth]{figure/lime-globallocal2}
-	
-% 	{Half-moons dataset}
-	
+%   \begin{center}
+%   \includegraphics[width=1\textwidth]{figure/lime-globallocal2}
+%
+%   {Half-moons dataset}
+%
 % \end{center}
 
-% 	\end{column}
+%   \end{column}
 
 % \end{columns}
 %\footnote[frame]{Laugel et al. (2018). Defining Locality for Surrogates in Post-hoc Interpretability. \url{https://arxiv.org/pdf/1806.07498.pdf}.}
-\end{frame}
+\end{framev}
 
-\begin{frame}{Pitfall: Local vs. Global Feats -- Example}
-\begin{itemize}
-		\item Random forest (RF) classification on half-moons dataset
-		    \item \textbf{Background color:} Classification of RF (prediction surface)
-		    \item \textbf{Black/grey crosses:} training data
-            \item \textbf{Green dot:} Obs. to be explained; \textbf{Red dot:} nearest  opposite-class point
-		    \item \textbf{Grey curve:} RF's decision boundary; \textbf{Dotted lines:} LIME dec. bound.
-             \item \textbf{Red line:} Local surrogate (LS) method \furtherreading{LAUGEL2018}
-	\end{itemize}
 
-    
-\begin{columns}[T, totalwidth=\textwidth]
-  \begin{column}{0.63\textwidth}
-	\includegraphics[width=\textwidth, trim = 5px 5px 0px 10px, clip]{figure/lime-globallocal2}
-  \end{column}
-  \pause
-  \begin{column}{0.37\textwidth}
-  %\begin{itemize}
-  %\item
-  \textbf{Feature 0} is global;
-  class always flips when moving left (red) to right (blue)
-  %\item 
-  \medskip
-  
-  \textbf{Feature 1} is local;
-  class flips only near boundary when moving up/down
-  %\item Image Source: \furtherreading{LAUGEL2018}
-  %\item 
-\medskip
+\begin{framev}[align=top]{Pitfall: Local vs. Global Feats -- Example}
+\begin{itemizeM}
+\item Random forest (RF) classification on half-moons dataset
+\item \textbf{Background color:} Classification of RF (prediction surface)
+\item \textbf{Black/grey crosses:} training data
+\item \textbf{Green dot:} Obs. to be explained; \textbf{Red dot:} nearest opposite-class point
+\item \textbf{Grey curve:} RF's decision boundary; \textbf{Dotted lines:} LIME dec. bound.
+\item \textbf{Red line:} Local surrogate (LS) method \furtherreading{LAUGEL2018}
+\end{itemizeM}
+\splitVTT[0.63]{
+\spacer[0]
+\includegraphics[width=\textwidth, trim = 5px 5px 0px 10px, clip]{figure/lime-globallocal2}
+}{
+\pause
+\textbf{Feature 0} is global;\\
+class always flips when moving left (red) to right (blue)\\
+\textbf{Feature 1} is local;\\
+class flips only near boundary when moving up/down\\
+\textbf{Observation:} LIME decision boundaries (blue/green) fail to match the steep local bound captured by LS (red)
+}
 
-\textbf{Observation:} LIME decision boundaries (blue/green) fail to match the steep local bound. captured by LS (red)
-%\end{itemize}
-
-    % \begin{itemize}
-    %   \item \textbf{Feature 0} is global; class flips from left (red) to right (blue)
-    %   \item \textbf{Feature 1} is local; class flips only in a narrow band around boundary when moving up or down
-    % \end{itemize}
-  \end{column}
-\end{columns}
-        
 % \begin{center}
 %LIME decision boundaries with different kernels (blue and green lines) do not match the direction of the local decision boundary (which appears steeper)
 %\footnote[frame]{Laugel et al. (2018). Defining Locality for Surrogates in Post-hoc Interpretability. \url{https://arxiv.org/pdf/1806.07498.pdf}.}
-\end{frame}
+\end{framev}
 
 
-
-\begin{frame}{Pitfall: Faithfulness}
-\begin{itemize}
+\begin{framev}[align=top]{Pitfall: Faithfulness}
+\begin{itemizeM}
 %\itemsep1em
-	\item \textbf{Problem}: Trade-off between local fidelity vs. sparsity
-	\item \textbf{Observation}:
-    \begin{itemize}
-        \item Too simple model $\leadsto$ low fidelity $\leadsto$ unreliable explanations
-        \item Complex model $\leadsto$ high fidelity $\leadsto$ difficult to interpret surrogate %surrogate model cannot easily be interpreted
-    \end{itemize}
-	\pause
-	\item \textbf{Example: Credit data} 
-	\begin{itemize}
-	\itemsep0em
-	    \item Random forest prediction for $\xv$: 
-	    $\fh(\xv) = \hat{\P}(y = \text{bad} ~|~ \xv) = 0.143$
-	    \item %Regularized linear model with only three selected features (\code{sex}, \code{checking.account}, \code{duration}) $g_{lm}(\xv) = 0.283$
-	    Sparse LM with 3 features (\code{age}, \code{checking.account}, \code{duration}):
-	    $$\gh_{lm}(\xv) = \thetah_0 + \thetah_1 x_{age} + \thetah_2 x_{checking.account} + \thetah_3 x_{duration} = 0.283$$
-	    \item Generalized additive model (with all 9 features) is more complex:
-    $$%\begin{equation*} 
-    %\begin{split}
-    \gh_{gam}(\xv) = \thetah_0 + f_{1}(x_{age}) + f_{2}(x_{checking.account}) + f_{3}(x_{duration}) +  \dots %& = \thetah_0 + s_{age}(x_{age}) +s_{credit.amount}(x_{credit.amount}) s_{duration}(x_{duration}) + \thetah_{sex = male} \ind_{sex = male}   \\
-    %& + \thetah_{job}(x_{job}) + \thetah_{housing = own} \ind_{housing = own} +   \thetah_{housing = rent} \ind_{housing = rent} \\
-    %& + \thetah_{saving.accounts = moderate} \ind_{saving.accounts = moderate} + \thetah_{saving.accounts = rich} \ind_{saving.accounts = rich} \\
-    %& + ... + \thetah_{purpose = radio/TV} \ind_{purpose = radio/TV}  
-    = 0.148$$
-    %\end{split}
-    %\end{equation*}
-	\end{itemize}
-\end{itemize}
+\item \textbf{Problem}: Trade-off between local fidelity vs. sparsity
+\item \textbf{Observation:}
+\begin{itemizeS}
+\item Too simple model $\leadsto$ low fidelity $\leadsto$ unreliable explanations
+\item Complex model $\leadsto$ high fidelity $\leadsto$ difficult to interpret surrogate %surrogate model cannot easily be interpreted
+\end{itemizeS}
+\pause
+\item \textbf{Example: Credit data}
+\begin{itemizeS}
+\item Random forest prediction for $\xv$:
+$\fh(\xv) = \hat{\P}(y = \text{bad} ~|~ \xv) = 0.143$
+\item %Regularized linear model with only three selected features (\code{sex}, \code{checking.account}, \code{duration}) $g_{lm}(\xv) = 0.283$
+Sparse LM with 3 features (\code{age}, \code{checking.account}, \code{duration}):
+$$\gh_{lm}(\xv) = \thetah_0 + \thetah_1 x_{age} + \thetah_2 x_{checking.account} + \thetah_3 x_{duration} = 0.283$$
+\item Generalized additive model (with all 9 features) is more complex:
+$$\gh_{gam}(\xv) = \thetah_0 + f_1(x_{age}) + f_2(x_{checking.account}) + f_3(x_{duration}) + \dots = 0.148$$
+%$$%\begin{equation*}
+%\begin{split}
+%\gh_{gam}(\xv) = \thetah_0 + f_{1}(x_{age}) + f_{2}(x_{checking.account}) + f_{3}(x_{duration}) +  \dots %& = \thetah_0 + s_{age}(x_{age}) +s_{credit.amount}(x_{credit.amount}) s_{duration}(x_{duration}) + \thetah_{sex = male} \ind_{sex = male}   \\
+%& + \thetah_{job}(x_{job}) + \thetah_{housing = own} \ind_{housing = own} +   \thetah_{housing = rent} \ind_{housing = rent} \\
+%& + \thetah_{saving.accounts = moderate} \ind_{saving.accounts = moderate} + \thetah_{saving.accounts = rich} \ind_{saving.accounts = rich} \\
+%& + ... + \thetah_{purpose = radio/TV} \ind_{purpose = radio/TV}
+%= 0.148$$
+%\end{split}
+%\end{equation*}
+\end{itemizeS}
+\end{itemizeM}
+\end{framev}
 
-\end{frame}
 
-\begin{frame}{Pitfall: Hiding biases \furtherreading{SLACK2020}}
-
-\begin{itemize}
-	% \item \textbf{Problem}: Developer could manipulate their model to hide biases 
-	% \item \textbf{Observation}: LIME can sample out-of-distribution points (extrapolation)
-      \item \textbf{Problem:} LIME samples out-of-distribution (OOD) points, making it exploitable
-  \item \textbf{Risk:} Developers can adversarially hide bias in the original model
-	\pause
-	\item \textbf{Attack} with adversarial model:
-	    \begin{enumerate}
-	    \item Train a detector to distinguish in-distribution vs. OOD points
-        %classifier to discriminate between in-distribution and out-of-distribution data points
-	    %\item for in-distribution points, use the original (biased) model
-        \item Use \textbf{biased model} for in-distribution inputs (i.e., true predictions)
-	    %\item for out-of-distribution points produced for local explanation, use an unbiased model
-        \item Use \textbf{unbiased model} for OOD samples to get LIME explanations
-        \item[$\leadsto$] LIME explanations rely on unbiased model \\$\Rightarrow$ hides bias in original model 
-	    % \item[$\leadsto$] LIME samples out-of-distribution points and uses the unbiased model for local explanation\\
-	    % \item[$\leadsto$] this hides the bias of the true model
-	    \end{enumerate}
-\end{itemize}
-%	\begin{columns}[T, totalwidth=\textwidth]
-%		\begin{column}{0.5\textwidth}
-	    \centering
-	    \includegraphics[width=0.85\textwidth]{figure/attack_biased_unbiased.jpg}\\
-	    Image Source: \furtherreading{SIKONJA2021}
-%	    \end{column}
+\begin{framev}[align=top]{Pitfall: Hiding biases \furtherreading{SLACK2020}}
+\begin{itemizeM}
+% \item \textbf{Problem}: Developer could manipulate their model to hide biases
+% \item \textbf{Observation}: LIME can sample out-of-distribution points (extrapolation)
+\item \textbf{Problem:} LIME samples out-of-distribution (OOD) points, making it exploitable
+\item \textbf{Risk:} Developers can adversarially hide bias in the original model
+\pause
+\item \textbf{Attack} with adversarial model:
+\end{itemizeM}
+\begin{enumerate}
+\item Train a detector to distinguish in-distribution vs. OOD points
+%classifier to discriminate between in-distribution and out-of-distribution data points
+%\item for in-distribution points, use the original (biased) model
+\item Use \textbf{biased model} for in-distribution inputs (i.e., true predictions)
+%\item for out-of-distribution points produced for local explanation, use an unbiased model
+\item Use \textbf{unbiased model} for OOD samples to get LIME explanations
+\item[$\leadsto$] LIME explanations rely on unbiased model\\
+$\Rightarrow$ hides bias in original model
+% \item[$\leadsto$] LIME samples out-of-distribution points and uses the unbiased model for local explanation\\
+% \item[$\leadsto$] this hides the bias of the true model
+\end{enumerate}
+%   \begin{columns}[T, totalwidth=\textwidth]
+%       \begin{column}{0.5\textwidth}
+\imageC[0.8][SIKONJA2021]{figure/attack_biased_unbiased.jpg}
+%       \end{column}
 %\pause
-	%     \begin{column}{0.5\textwidth}
-	%     \textbf{Example}: Not using `gender` to approve a loan % Credit dataset %
-	%     \begin{itemize}
-	%         \item biased model trained on features correlated with `gender` (e.g. duration of parental leave)\\
-	%         $\leadsto$ used 
-	%         %for in-distribution points (realistic values) 
-	%         to make biased / unfair predictions
-	%         \item unbiased model trained on features uncorrelated with `gender`\\
-	%         $\leadsto$ used to produce explanations based on unbiased predictions to hide bias
-	%         %$\leadsto$ used for (extrapolated) LIME samples\\
-	%         %$\Rightarrow$ produced local explanations seem fair as they are based on unbiased model
-	%         %could be trained on features uncorrelated with `gender`
-	%     \end{itemize}
-	%     \end{column}
-	% \end{columns}
-\end{frame}
+%     \begin{column}{0.5\textwidth}
+%     \textbf{Example}: Not using `gender` to approve a loan % Credit dataset %
+%     \begin{itemize}
+%         \item biased model trained on features correlated with `gender` (e.g. duration of parental leave)\\
+%         $\leadsto$ used
+%         %for in-distribution points (realistic values)
+%         to make biased / unfair predictions
+%         \item unbiased model trained on features uncorrelated with `gender`\\
+%         $\leadsto$ used to produce explanations based on unbiased predictions to hide bias
+%         %$\leadsto$ used for (extrapolated) LIME samples\\
+%         %$\Rightarrow$ produced local explanations seem fair as they are based on unbiased model
+%         %could be trained on features uncorrelated with `gender`
+%     \end{itemize}
+%     \end{column}
+% \end{columns}
+\end{framev}
 
 
-
-\begin{frame}{Pitfall: Hiding biases \furtherreading{SLACK2020}}
-
-\textbf{Key insight:} LIME can be fooled if explanations rely on model behavior outside the true data manifold.
-
-\lz
-   
+\begin{framev}[align=top]{Pitfall: Hiding biases \furtherreading{SLACK2020}}
+\textbf{Key insight:} LIME can be fooled if explanations rely on model behavior outside the true data manifold.\\
+\spacer[0.25]
 \textbf{Example:} Credit approval
-  \begin{itemize}
-    \item Biased model uses feats correlated with gender (parental leave duration)\\
-    $\leadsto$ used to make biased/unfair predictions
-    \item Unbiased model uses only features unrelated to gender for fairness\\%omits these correlations
-    $\leadsto$ used to produce explanations based on unbiased predictions in order to hide bias
-    \item LIME’s extrapolated samples trigger the unbiased model\\
-    $\Rightarrow$ explanation appears fair, but original predictions are biased
-  \end{itemize}
-
-\end{frame}
-
+\begin{itemizeM}
+\item Biased model uses feats correlated with gender (parental leave duration)\\
+$\leadsto$ used to make biased/unfair predictions
+\item Unbiased model uses only features unrelated to gender for fairness\\%omits these correlations
+$\leadsto$ used to produce explanations based on unbiased predictions in order to hide bias
+\item LIME’s extrapolated samples trigger the unbiased model\\
+$\Rightarrow$ explanation appears fair, but original predictions are biased
+\end{itemizeM}
+\end{framev}
 
 
+\begin{framev}[align=top]{Pitfall: Robustness \furtherreading{JAAKKOLA2018}}
+\begin{itemizeM}
+\item \textbf{Problem}: Instability of LIME explanations
+\item \textbf{Observation}: Explanations of two very close points could vary greatly
+\begin{itemizeS}
+\item[$\leadsto$] Variability driven by the stochastic sampling of $\zv$ for each explanation
+%can happen because of other sampled data points $\zv$
+\end{itemizeS}
+\item \textbf{Example:}
+\end{itemizeM}
+\splitVTT{
+\spacer[0]
+\imageC[0.8]{figure/lime_robustness_1.png}
+\begin{center}
+\begin{small}
+Linear task (logistic regression).\\
+LIME returns similar coefficients for similar points.
+\end{small}
+\end{center}
+}{
+\spacer[0]
+\imageC[0.8]{figure/lime_robustness_2.png}
+\begin{center}
+\begin{small}
+Nonlinear task (random forest).\\
+LIME returns different coefficients for similar points.
+\end{small}
+\end{center}
+}
+\end{framev}
 
 
-
-
-
-
-
-
-\begin{frame}{Pitfall: Robustness \furtherreading{JAAKKOLA2018}}
-\begin{itemize}
-	\item \textbf{Problem}: Instability of LIME explanations 
-	\item \textbf{Observation}: Explanations of two very close points could vary greatly 
-	\begin{itemize}
-	    \item[$\leadsto$] Variability driven by the stochastic sampling of $\zv$ for each explanation
-        %can happen because of other sampled data points $\zv$
-	\end{itemize}
-    \item \textbf{Example:}
-\end{itemize}
-\vspace{-0.7cm}
-\begin{columns}[totalwidth=\textwidth]
-	\begin{column}{0.5\textwidth}
-		\begin{center}
-		
-		\includegraphics[width=0.8\textwidth]{figure/lime_robustness_1.png}
-		
-		{Linear task (logistic regression). \\
-        LIME returns similar coefficients for similar points.}
-		
-		\end{center}
-	\end{column}
-	\begin{column}{0.5\textwidth}
-		\begin{center}
-	\includegraphics[width=0.8\textwidth]{figure/lime_robustness_2.png}
-	
-	{Nonlinear task (random forest). 
-    \\LIME returns different coefficients for similar points.}
-	
-	\end{center}
-\end{column}
-\end{columns}
-\end{frame}
-
-\begin{frame}{Pitfall: Definition of Superpixels \furtherreading{ACHANTA2012}}
-
-\begin{columns}[totalwidth=\textwidth]
-    
-    \begin{column}{0.64\textwidth}
-        
-        \begin{itemize}
-        	\item \textbf{Problem}: LIME relies on superpixels (but their definition differ) for image data
-            %Instability because of specification of superpixels for image data 
-        	\item \textbf{Observation}: Definition of superpixel differ, influencing their size, shape, and alignment 
-        	\pause
-        	\item \textbf{Implication}: Specification of superpixel has a large influence on LIME explanations 
-        	\item \textbf{Attack}: Change superpixels as part of an adversarial attack $\leadsto$ changed explanation
-        \end{itemize}
-        
-    \end{column}
-    
-    \begin{column}{0.4\textwidth}
-    
-        \centering
-        \includegraphics[width=0.7\textwidth]{figure/superpixel_woman}
-        
-    \end{column}
-    
-\end{columns}
-
-\end{frame}
+\begin{framev}[align=top]{Pitfall: Definition of Superpixels \furtherreading{ACHANTA2012}}
+\splitVTT[0.64]{
+\spacer[0.6]
+\begin{itemizeM}
+\item \textbf{Problem}: LIME relies on superpixels (but their definition differ) for image data
+%Instability because of specification of superpixels for image data
+\item \textbf{Observation}: Definition of superpixel differ, influencing their size, shape, and alignment
+\pause
+\item \textbf{Implication}: Specification of superpixel has a large influence on LIME explanations
+\item \textbf{Attack}: Change superpixels as part of an adversarial attack $\leadsto$ changed explanation
+\end{itemizeM}
+}{
+\spacer[0]
+\imageC[0.7]{figure/superpixel_woman}
+}
+\end{framev}
 
 
 \endlecture


### PR DESCRIPTION
## Summary
This PR cleans up the `local-explanations-lime` slide deck.

The cleanup was done by applying a cleanup skill with a coding agent, followed by manual inspection.

## Included changes
- clean up the "Local Explanations" introduction slides
- clean up the "Local Explanations: LIME" slides
- clean up the "Examples" slides
- clean up the "LIME Pitfalls" slides

## Scope
Files touched:
- `slides/local-explanations-lime/slides01-le-intro.tex`
- `slides/local-explanations-lime/slides04-le-lime.tex`
- `slides/local-explanations-lime/slides05-le-lime-examples.tex`
- `slides/local-explanations-lime/slides06-le-lime-pitfalls.tex`
