### PR TITLE
(refactor slides): Cleanup feature effects

### DIFF
--- a/slides/feature-effects/slides01-fe-intro.tex
+++ b/slides/feature-effects/slides01-fe-intro.tex
@@ -2,7 +2,7 @@
 
 \input{../../style/preamble}
 % Defines macros and environments
- \input{../../latex-math/basic-math}
+\input{../../latex-math/basic-math}
 \input{../../latex-math/basic-ml}
 
 \usepackage{adjustbox} % need for the last slide
@@ -10,7 +10,6 @@
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
 
@@ -61,54 +60,54 @@ figure/feature-effect
 % \end{frame}
 
 
-\begin{frame}{Feature Effects - Global View}
+\begin{framev}[align=top]{Feature Effects - Global View}
 %\includegraphics[width=0.375\textwidth, trim=0cm 0.1cm 10.4cm 0cm, clip]{figure/lm_main_effects}\phantom{\includegraphics[width=0.375\textwidth, trim=10cm 0.1cm 0.4cm 0cm, clip]{figure/lm_main_effects}}
-
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.49\linewidth}
-\includegraphics[width=0.85\textwidth, trim=0cm 0.1cm 10.4cm 0cm, clip]{figure/lm_main_effects}
-
-\bigskip
+\splitVTT[0.5]{
+\spacer[0]
+\includegraphics[width=0.85\linewidth, trim=0cm 0.1cm 10.4cm 0cm, clip]{figure/lm_main_effects}
+\\
+\spacer[0.25]
 LM without interaction:\\ $\hat\theta_j$ is linear effect of feature $x_j$\\ (applies globally to all observations):
-\medskip
-\begin{itemize}
-    \item Model equation: $\fh(\xv) = \hat\theta_0 + x_1\hat\theta_1$
-    \item Scalar $\hat\theta_1$ describes global effect
-\end{itemize}
+\\
+\spacer[0.25]
+\begin{itemizeM}
+\item Model equation: $\fh(\xv) = \hat\theta_0 + x_1\hat\theta_1$
+\item Scalar $\hat\theta_1$ describes global effect
+\end{itemizeM}
 %$$% + \dots + x_p\hat\theta_p.$$
-\end{column}\pause
-\begin{column}{0.51\linewidth}
-\invisible<1>{\includegraphics[width=0.85\textwidth, trim=10cm 0.1cm 0.4cm 0cm, clip]{figure/lm_main_effects}}
-
-\bigskip
+}{
+\pause
+\spacer[0]
+\invisible<1>{\includegraphics[width=0.85\linewidth, trim=10cm 0.1cm 0.4cm 0cm, clip]{figure/lm_main_effects}}
+\\
+\spacer[0.25]
 GAM without interaction:\\ $\fh_j(x_j)$ is non-lin. effect of feature $x_j$\\  (applies globally to all observations):
-\begin{itemize}
-    \item Model equation: $\fh(\xv) = \hat\theta_0 + \fh_1(x_1)$
-    \item Curve $\fh_1$ describes global effect
-\end{itemize}
+\\
+\spacer[0.25]
+\begin{itemizeM}
+\item Model equation: $\fh(\xv) = \hat\theta_0 + \fh_1(x_1)$
+\item Curve $\fh_1$ describes global effect
+\end{itemizeM}
 %$$% + \dots + \hat{h}_p(x_p).$$
-\end{column}
-\end{columns}
-
-\end{frame}
+}
+\end{framev}
 
 
-\begin{frame}{Feature Effects - Localized View}
-
-\centerline{\includegraphics[width=0.8\textwidth, trim=0cm 0.1cm 0cm 0cm, clip]{figure/lm_main_interactions}}
-
-\begin{itemize}
-    \item \textbf{Interactions:} Feature effect depends on other features and varies across obs. \\ 
-    $\Rightarrow$ E.g., effect of \textbf{temperature} varies across \textbf{season}\\
-    $\Rightarrow$ Multiple values / curves needed to describe effect
-    \item ML models capture non-linear effects and high-order interactions \\
-    $\Rightarrow$ Global view may mislead (single curve may fail to capture complexity)\\
-    $\Rightarrow$ Local feat. effect methods needed to estimate effects for individ. obs.\\
-    %Need for local feature effect methods, e.g., analyze effect for individual obs.\\
-    $\Rightarrow$ Global view can be reconstructed by aggregating local effects
-\end{itemize}
-
-\end{frame}
+\begin{framev}[align=top]{Feature Effects - Localized View}
+\begin{center}
+\includegraphics[width=0.8\textwidth, trim=0cm 0.1cm 0cm 0cm, clip]{figure/lm_main_interactions}
+\end{center}
+\begin{itemizeM}
+\item \textbf{Interactions:} Feature effect depends on other features and varies across obs. \\
+$\Rightarrow$ E.g., effect of \textbf{temperature} varies across \textbf{season}\\
+$\Rightarrow$ Multiple values / curves needed to describe effect
+\item ML models capture non-linear effects and high-order interactions \\
+$\Rightarrow$ Global view may mislead (single curve may fail to capture complexity)\\
+$\Rightarrow$ Local feat. effect methods needed to estimate effects for individ. obs.\\
+%Need for local feature effect methods, e.g., analyze effect for individual obs.\\
+$\Rightarrow$ Global view can be reconstructed by aggregating local effects
+\end{itemizeM}
+\end{framev}
 
 %
 % \begin{frame}{Feature Effects}
@@ -135,34 +134,31 @@ GAM without interaction:\\ $\fh_j(x_j)$ is non-lin. effect of feature $x_j$\\  (
 
 
 
-\begin{frame}{Feature Effects}
-
+\begin{framev}[align=top]{Feature Effects}
 \textbf{Feature effects} visualize or quantify how model predictions change as a single feature varies, while all other features are held fixed.
 %marginal contribution of a feature of interest w.r.t. predictions %marginal contribution of a feature to the model \textbf{prediction}. % $\hat{y} = \fh(\xi[])$. effect (e.g., the average relationship) between a
-\begin{itemize}
+\begin{itemizeM}
 %\tightlist
 \item Analogous to regression coefficients (LMs) or Splines (GAMs)
 \item Different aggregation levels exist (simplification but information loss)
 \item Methods: \visible<1-3>{ICE curves (local curves)}\visible<2-3>{, PD and ALE plots (global curves)}\visible<3>{, AME (global value)}
-\end{itemize}
-
+\end{itemizeM}
 %\centerline{\includegraphics[width=\textwidth]{figure/feature-effect.pdf}}
-\centerline{
+\begin{center}
 \visible<1-3>{\adjincludegraphics[width=0.32\textwidth, trim={0 0 {.6667\width} 0}, clip]{figure/feature-effect.pdf}}
 \visible<2-3>{\adjincludegraphics[width=0.32\textwidth, trim={{.33\width} 0 {.33\width} 0}, clip]{figure/feature-effect.pdf}}
 \visible<3>{\adjincludegraphics[width=0.32\textwidth, trim={{.6667\width} 0 0 0}, clip]{figure/feature-effect.pdf}}
-}
-
-\smallskip
+\end{center}
+\spacer[0.25]
 %\includegraphics[width=0.33\textwidth, trim=7.4cm 0.1cm 7.4cm 0cm, clip]{figure/feature-effect.pdf}
 %\invisible<1>{\includegraphics[width=0.33\textwidth, trim=14cm 0.1cm 0.4cm 0cm, clip]{figure/feature-effect.pdf}}
-
-\small  \visible<1-3>{Individual (curves) \hspace{4px}}
-\visible<2-3>{$\xrightarrow[\text{curves}]{\text{aggregate}}$ \hspace{4px} Global (single curve)}\visible<3>{\hspace{4px}
+\begin{small}
+\visible<1-3>{Individual (curves) \hspace{4px}}
+\visible<2-3>{$\xrightarrow[\text{curves}]{\text{aggregate}}$ \hspace{4px} Global (single curve)}
+\visible<3>{\hspace{4px}
 $\xrightarrow[\text{slopes}]{\text{aggregate}}$ \hspace{4px} Global (single value)}
-
-
-\end{frame}
+\end{small}
+\end{framev}
 
 
 \endlecture

--- a/slides/feature-effects/slides02-fe-ice.tex
+++ b/slides/feature-effects/slides02-fe-ice.tex
@@ -2,93 +2,72 @@
 
 \input{../../style/preamble}
 % Defines macros and environments
- \input{../../latex-math/basic-math}
+\input{../../latex-math/basic-math}
 \input{../../latex-math/basic-ml}
 \input{../../latex-math/ml-interpretable}
 
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
 
 \titlemeta{
 Feature Effects
 }{
-Individual Conditional Expectation (ICE) Plot % we have an isolated word here, not sure how to fix 
+Individual Conditional Expectation (ICE) Plot % we have an isolated word here, not sure how to fix
 }{
 figure/feature-effect
 }{
-
 %\item Intro to feature effects
 \item ICE curves as local effect method
 \item How to sample grid points for ICE curves
 %\item Understand how to interpret ICE curves and PD plots
-
 }
 
 
-
-\begin{frame}{Motivation}
+\begin{framev}[align=top]{Motivation}
 %ICE curves show how different feature values of an observation affect its model prediction \newline $\Rightarrow$ \textbf{local interpretation method}
 %From a local perspective, one might be interested in how changing feature values of an observation affect model prediction
-
-\textbf{Question:} How does varying a single feature of an observation affect its predicted outcome?
-
-\smallskip
-
-\textbf{Idea:} For a given observation, change the value of the feature of interest, and visualize how prediction changes
-
-\smallskip
-
+\textbf{Question:} How does varying a single feature of an observation affect its predicted outcome?\\
+\spacer[0.25]
+\textbf{Idea:} For a given observation, change the value of the feature of interest, and visualize how prediction changes\\
+\spacer[0.25]
 \textbf{Example:} On model prediction surface (left), select observation and visualize changes in prediction for different values of $x_2$, while keeping $x_1$ fixed \\ $\Rightarrow$ \textbf{local interpretation}
-
-\bigskip
-\centering
-\includegraphics[width=\textwidth]{figure/ice_motivation}
-
+\\
+\spacer[0.25]
+\image{figure/ice_motivation}
 %$\Rightarrow$ Repeat for all observations and average the curves for global feature effect ($\leadsto$ PD plots)
-\end{frame}
+\end{framev}
 
 
-
-
-\begin{frame}[c]{Individual Conditional Expectation (ICE) \furtherreading{GOLDSTEIN2013}}
-
+\begin{framev}[align=top]{Individual Conditional Expectation (ICE) \furtherreading{GOLDSTEIN2013}}
 %Consider an index set $S \subseteq \{1, \dots, p\}$ and its complement $C = S^\complement$.
 %\lz
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.16\textwidth} % 0.2 4.26cm
+\splitVTT[0.16]{
+\spacer[0]
 \includegraphics[page=1, trim=0cm 0.35cm 4.53cm 0.35cm, clip, width=0.9\textwidth]{../../figure_man/ice_plot_demo}
-\end{column}
-\begin{column}{0.84\textwidth}
-
+}{ % 0.2 4.26cm
 %%%
-
 %Assume each observation $\xi$ can be partitioned into $\xi_S$ and $\xi_C$ containing only feature values from the index set $S \subseteq \{1, \dots, p\}$ and its complement $C = S^\complement$, respectively.
 %Assume each observation $\xi$ can be partitioned into $\xi_S$ and $\xi_C$ containing only feature values addressed by the feature's index set $S \subseteq \{1, \dots, p\}$ and its complement $C = S^\complement$, respectively.
 %Assume each observation $\xi$ can be partitioned into $\xi_S$ and $\xi_C$ containing values from features addressed by the index set $S \subseteq \{1, \dots, p\}$ and its complement $C = S^\complement$, respectively.
 Partition each observation $\xv$ into $\xv_S$ (feature(s) of interest) and $\xv_{-S}$ (remaining features)
-\begin{itemize}
-    \item[$\leadsto$] In practice, $\xv_S$ consists of one or two features \\ (i.e., $|S| \leq 2$ and ${-S} = S^\complement$).
+\begin{itemizeM}
+\item[$\leadsto$] In practice, $\xv_S$ consists of one or two features \\ (i.e., $|S| \leq 2$ and ${-S} = S^\complement$).
     %, containing only feature values indexed by $S \subseteq \{1, \dots, p\}$ and its complement $C = S^\complement$.
-\end{itemize}
-
-\medskip
-
-Formal definition of ICE curves: 
-\begin{itemize}
-    \item Define grid points $\xv_S^* = \xv_S^{*^{(1)}}, \dots, \xv_S^{*^{(g)}}$ to vary $\xv_S$
-    \item Plot point pairs $ \Bigl\{\left(\xv_S^{*^{(k)}}, \fhice{S}^{(i)}(\xv_S^{*^{(k)}}) \right) \Bigr\}_{k=1}^g$
-    \\where $\fhice{S}^{(i)}(\xv_S^*) = \fh(\xv_S^*, \xi_{-S})$
-    \item For each $k$ connect point pairs to obtain \textbf{ICE curve}
-\end{itemize}
-
-\medskip
-
-\begin{itemize}
-    \item[$\leadsto$] ICE curves visualize how prediction of $i$-th observation changes after varying its feature values indexed by $S$ using grid points $\xv_S^*$ while keeping all values in $-S$ fixed
+\end{itemizeM}
+\spacer[0.25]
+Formal definition of ICE curves:
+\begin{itemizeM}
+\item Define grid points $\xv_S^* = \xv_S^{*^{(1)}}, \dots, \xv_S^{*^{(g)}}$ to vary $\xv_S$
+\item Plot point pairs $ \Bigl\{\left(\xv_S^{*^{(k)}}, \fhice{S}^{(i)}(\xv_S^{*^{(k)}}) \right) \Bigr\}_{k=1}^g$
+\\where $\fhice{S}^{(i)}(\xv_S^*) = \fh(\xv_S^*, \xi_{-S})$
+\item For each $k$ connect point pairs to obtain \textbf{ICE curve}
+\end{itemizeM}
+\spacer[0.25]
+\begin{itemizeM}
+\item[$\leadsto$] ICE curves visualize how prediction of $i$-th observation changes after varying its feature values indexed by $S$ using grid points $\xv_S^*$ while keeping all values in $-S$ fixed
 %by replacing the feature values $\xv_S^{(i)}$ with other values $\xv_S$ while keeping all other features in $\xi_C$ fixed:
 %by varying the feature values in $\xv_S$ while keeping all other features in $\xi_C$ fixed.
 
@@ -96,14 +75,9 @@ Formal definition of ICE curves:
 %     \item[$\leadsto$] Plot \quad $\fh_{S}^{(i)}(\xv_S^*) \; \text{ vs. } \; \xv_S^*$ \\
 %     where $\fh_{S}^{(i)}(\xv_S^*) = \fh(\xv_S^*, \xi_{-S})$ is prediction of $i$-th observation in which original feature value $\xi_S$ was replaced by $\xv_S^*$.
 % \end{itemize}
-\end{itemize}
-
-
+\end{itemizeM}
 %Visualize for \textbf{I}ndividual observations and \textbf{C}onditional on all other features how \textbf{E}xpected prediction changes
-
-\end{column}
-\end{columns}
-
+}
 % \begin{columns}[T, totalwidth=\textwidth]
 % \begin{column}{0.6\textwidth}
 
@@ -119,7 +93,7 @@ Formal definition of ICE curves:
 % \end{column}
 % \end{columns}
 %\footnote[frame]{Goldstein, A., Kapelner, A., Bleich, J., and Pitkin, E. (2013). Peeking Inside the Black Box: Visualizing Statistical Learning with Plots of Individual Conditional Expectation, 1-22. https://doi.org/10.1080/10618600.2014.907095}
-\end{frame}
+\end{framev}
 
 % \begin{frame}{Individual Conditional Expectation (ICE)}
 %
@@ -154,54 +128,42 @@ Formal definition of ICE curves:
 % aa
 % \end{frame}
 
-\begin{frame}{ICE Curves - Illustration}
-
-\begin{columns}[c, totalwidth=\textwidth]
-\begin{column}{0.4\textwidth}
+\begin{framev}[align=top]{ICE Curves - Illustration}
+\splitVCC[0.4]{
 \includegraphics[page=2, trim=0cm 0.35cm 0.85cm 0.35cm, width=0.9\textwidth]{../../figure_man/ice_plot_demo}
-\end{column}
-\begin{column}{0.55\textwidth}
-
-\end{column}
-\end{columns}
-\vspace*{\topsep}
-
+\spacer[0]
+}{
+}
+\spacer[0.25]
 \textbf{1. Step - Grid points:}
-
 %For the $i$-th observation, we
-\begin{itemize}
-    \item Sample grid values $\xv_S^{*^{(1)}}, \dots, \xv_S^{*^{(g)}}$ along possible values of feature $S$ ($|S| = 1$)
-\item For $\xv^{(i)} = (\xv_S, \xv_{-S})$, replace  $\xv_S$ with those grid values
-\end{itemize}
+\begin{itemizeM}
+\item Sample grid values $\xv_S^{*^{(1)}}, \dots, \xv_S^{*^{(g)}}$ along possible values of feature $S$ ($|S| = 1$)
+\item For $\xv^{(i)} = (\xv_S, \xv_{-S})$, replace $\xv_S$ with those grid values
+\end{itemizeM}
 %h observation with these sampled grid values.
 %$\Rightarrow$ New artificial data points for $i$-th obs.
 $\Rightarrow$ Creates new artificial points for $i$-th obs. (here: $\xv_S^* = x_1^* \in \{1, 2, 3\}$ scalar)
+\end{framev}
 
-\end{frame}
 
-\begin{frame}{ICE Curves - Illustration}
-
-\begin{columns}[c, totalwidth=\textwidth]
-\begin{column}{0.4\textwidth}
+\begin{framev}[align=top]{ICE Curves - Illustration}
+\splitVCC[0.4]{
 \includegraphics<1>[page=3, trim=0cm 0.35cm 0.85cm 0.35cm, width=0.9\textwidth]{../../figure_man/ice_plot_demo}
 \includegraphics<2>[page=4, trim=0cm 0.35cm 0.85cm 0.35cm, width=0.9\textwidth]{../../figure_man/ice_plot_demo}
 \includegraphics<3>[page=5, trim=0cm 0.35cm 0.85cm 0.35cm, width=0.9\textwidth]{../../figure_man/ice_plot_demo}
-\end{column}
-\begin{column}{0.55\textwidth}
+\spacer[0]
+}{
 \includegraphics<1>[page=1, width=0.85\textwidth]{figure/ICE}
 \includegraphics<2>[page=2, width=0.85\textwidth]{figure/ICE}
 \includegraphics<3>[page=3, width=0.85\textwidth]{figure/ICE}
-\end{column}
-\end{columns}
-\vspace*{\topsep}
-
+\spacer[0]
+}
+\spacer[0.25]
 \textbf{2. Step - Predict and visualize:}
-
 For each artificially created data point of $i$-th observation, plot prediction $\fhice{S}^{(i)}(\xv_S^*)$ vs. grid values $\xv_S^*$:
-
 $$\fhice{1}^{(i)}(x_1^*) = \fh(x_1^*, \xi_{2, 3}) \text{ vs. } x_1^* \in \{1, 2, 3\}$$
-
-\end{frame}
+\end{framev}
 
 % \begin{frame}{Individual Conditional Expectation (ICE)}
 
@@ -264,24 +226,22 @@ $$\fhice{1}^{(i)}(x_1^*) = \fh(x_1^*, \xi_{2, 3}) \text{ vs. } x_1^* \in \{1, 2,
 % % ICE curves involve plotting the pairs $ \{(\xv_S^{*^{(k)}}, \fh_{S}^{(i)}(\xv_S^*{^{(k)}})) \}_{k=1}^g $ for grid points $\xv_S^{*^{(1)}}, \dots, \xv_S^{*^{(g)}}$.
 % \end{frame}
 
-\begin{frame}{ICE Curves - Illustration}
-
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.4\textwidth}
+\begin{framev}[align=top]{ICE Curves - Illustration}
+\splitVTT[0.4]{
+\spacer[0]
 \includegraphics<1>[page=6, trim=0cm 0.35cm 0.85cm 0.35cm, width=0.9\textwidth]{../../figure_man/ice_plot_demo}
 \includegraphics<2>[page=7, trim=0cm 0.35cm 0.85cm 0.35cm, width=0.9\textwidth]{../../figure_man/ice_plot_demo}
-\end{column}
-\begin{column}{0.55\textwidth}
+\spacer[0]
+}{
+\spacer[0]
 \includegraphics<1>[page=4, width=0.85\textwidth]{figure/ICE}
 \includegraphics<2>[page=5, width=0.85\textwidth]{figure/ICE}
-\end{column}
-\end{columns}
-\vspace*{\topsep}
-
+\spacer[0]
+}
+\spacer[0.25]
 \textbf{3. Step - Repeat for other observations:}
-
-ICE curve for\only<1>{ $i=2$ }\only<2>{ $i=3$ }connects all predictions at grid values associated to the $i$-th observation.
-\end{frame}
+ICE curve for \only<1>{$i=2$}\only<2>{$i=3$} connects all predictions at grid values associated to the $i$-th observation.
+\end{framev}
 
 % \begin{frame}{ICE Curves - Illustration}
 
@@ -307,29 +267,27 @@ ICE curve for\only<1>{ $i=2$ }\only<2>{ $i=3$ }connects all predictions at grid 
 % % ICE curves involve plotting the pairs $ \{(\xv_S^{*^{(k)}}, \fh_{S}^{(i)}(\xv_S^*{^{(k)}})) \}_{k=1}^g $ for grid points $\xv_S^{*^{(1)}}, \dots, \xv_S^{*^{(g)}}$.
 % \end{frame}
 
-\begin{frame}{ICE Curves - Interpretation}
+\begin{framev}[align=top]{ICE Curves - Interpretation}
 \textbf{Example:} Prediction surface of a model (left), select observation and visualize changes in prediction for different values of $x_2$ while keeping $x_1$ fixed \\ $\Rightarrow$ \textbf{local interpretation}
-
-\bigskip
-\centering
-\includegraphics[width=\textwidth]{figure/ice_motivation}
-
+\\
+\spacer[0.25]
+\image{figure/ice_motivation}
 %% Wie nutzt man ICE Kurven zur lokalen Interpretation?
-\end{frame}
+\end{framev}
 
 
-\begin{frame}{Comments on Grid values}
-\begin{itemize}
+\begin{framev}[align=top]{Comments on Grid values}
+\begin{itemizeM}
 %\item ICE curves show how different feature values of an observation affect its prediction \newline $\Rightarrow$ \textbf{local interpretation method}
 \item Plotting ICE curves involves generating grid values $\xv_S^*$; shown on x-axis
 \item \textbf{Three common strategies} for grid definition:
-\begin{itemize}
+\begin{itemizeS}
 \item Equidistant grid values within feature range
 \item Random samples from observed feature values
 \item Quantiles of observed feature values
-\end{itemize}
+\end{itemizeS}
 \item \textbf{Marginal realism:} Random and quantile grids better reflect the marginal distribution of $x_S$
-        $\Rightarrow$ reduce unrealistic values along $x_S$
+$\Rightarrow$ reduce unrealistic values along $x_S$
 %Except equidistant grid, the other two options preserve (approximately) the marginal distribution of feature of interest
 %$\Rightarrow$ Avoids unrealistic feature values for distributions with outliers %or dependencies
 \item<2> \textbf{However:} For \textbf{correlated features}, extrapolation remains:
@@ -340,47 +298,38 @@ ICE curve for\only<1>{ $i=2$ }\only<2>{ $i=3$ }connects all predictions at grid 
 % \item sub-sampled grid values:
 % \item quantile grid values:
 % \end{itemize}
-\end{itemize}
-
-\vspace{0.3cm}
+\end{itemizeM}
+\spacer[0.25]
 \centering
 \includegraphics<1>[width=0.85\textwidth, trim=0cm 0cm 0cm 0cm, clip]{figure/sampling2}
 \includegraphics<2>[width=0.85\textwidth, trim=0cm 0cm 0cm 0cm, clip]{figure/sampling}
-
-
-\end{frame}
+\end{framev}
 
 % bike sharing example + defaults
-\begin{frame}{Practical considerations}
-
+\begin{framev}[align=top]{Practical considerations}
 % \begin{itemize} % removes in order to fix hanging words
   % \item 
-  \textbf{Grid resolution} (instances $\times$ grid over feature of interest)
-        \begin{itemize}
-            \item Too coarse $\Rightarrow$ may miss sharp nonlinearities or discontinuities
+\textbf{Grid resolution} (instances $\times$ grid over feature of interest)
+\begin{itemizeM}
+\item Too coarse $\Rightarrow$ may miss sharp nonlinearities or discontinuities
             %may miss sharp changes%
-            \item Too fine $\Rightarrow$ high runtime (without gaining much)
+\item Too fine $\Rightarrow$ high runtime (without gaining much)
             %time intensive%
-            \item Fix: cap at $\approx 50 - 100$ grid points; vectorize predictions by feeding the model a single data frame containing all grid-modified instances
-        \end{itemize}
+\item Fix: cap at $\approx 50 - 100$ grid points; vectorize predictions by feeding the model a single data frame containing all grid-modified instances
+\end{itemizeM}
   % \item 
-  \textbf{ICE curves} (number of instances/curves visualized)
-        \begin{itemize}
-            \item Too few $\Rightarrow$ hides instance variability, misses subgroup differences
+\textbf{ICE curves} (number of instances/curves visualized)
+\begin{itemizeM}
+\item Too few $\Rightarrow$ hides instance variability, misses subgroup differences
             %heterogeneity is hidden%
-            \item Too many $\Rightarrow$ visual overload (many overlapping curves), time intensive%
-            \item Fix: Stratified or cluster-based subsample (e.g., 100); facet by subgroup
-        \end{itemize}
+\item Too many $\Rightarrow$ visual overload (many overlapping curves), time intensive%
+\item Fix: Stratified or cluster-based subsample (e.g., 100); facet by subgroup
+\end{itemizeM}
 % \end{itemize}
-
-\begin{columns}[T, onlytextwidth]
-\begin{column}{0.5\textwidth}
-\small
-
-Default values for popular libraries: 
-
-\medskip
-
+\splitVTT[0.5]{
+\begin{small}
+Default values for popular libraries:\\
+\spacer[0.25]
 %\centering
 \begin{tabular}{lcc}
 \textbf{Library} & \textbf{Grid} & \textbf{ICE curves}\\\hline
@@ -389,21 +338,20 @@ PDPbox  (Py) & 10  & num. rows\\
 iml (R)      & 20  & num. rows\\
 pdp (R)      & 51  & num. rows\\
 \end{tabular}
-
-\end{column}
-
+\end{small}
+\spacer[0]
+}{
 % -------- RIGHT COLUMN: FIGURE --------
-\begin{column}{0.5\textwidth}
-\centering
-\includegraphics[width=\textwidth]{figure/pdp_bike.pdf}
-
-\end{column}
-\end{columns}
-
-\centerline{\small
-ICE curves (\textbf{black lines}) and their point-wise average across the grid (\textbf{yellow line})%, known as "partial dependence plot"
+\spacer[0]
+\image{figure/pdp_bike.pdf}
+\spacer[0]
 }
-\end{frame}
+{\centering
+\begin{small}
+ICE curves (\textbf{black lines}) and their point-wise average across the grid (\textbf{yellow line})%, known as "partial dependence plot"
+\end{small}
+\par}
+\end{framev}
 
 \endlecture
 \end{document}

--- a/slides/feature-effects/slides03-fe-pdp.tex
+++ b/slides/feature-effects/slides03-fe-pdp.tex
@@ -2,16 +2,13 @@
 
 \input{../../style/preamble}
 % Defines macros and environments
- 
 \input{../../latex-math/basic-math}
 \input{../../latex-math/basic-ml}
 \input{../../latex-math/ml-interpretable}
 
-
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
 
@@ -22,164 +19,111 @@ Partial Dependence (PD) plot
 }{
 figure/pdp_bike
 }{
-
 \item PD plots and relation to ICE plots
 \item Interpretation of PDP
-
 }
 
 
-\begin{frame}{Partial Dependence (PD) \furtherreading{FRIEDMAN2001}}
-
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.55\textwidth}
+\begin{framev}[align=top]{Partial Dependence (PD) \furtherreading{FRIEDMAN2001}}
+\splitVTT[0.56]{
 \textbf{Definition:} PD function is expectation of $\fh(\xv_S, \xv_{-S})$ w.r.t. marginal distribution of features $\xv_{-S}$:
 \begin{align*}
-    f_{S, PD}(\xv_S) &= \E_{\xv_{-S}} \left( \fh(\xv_S, \xv_{-S}) \right) \\
-    &= \int_{-\infty}^{\infty} \fh(\xv_S, \xv_{-S}) \, d\P(\xv_{-S})
+f_{S, PD}(\xv_S) &= \E_{\xv_{-S}} ( \fh(\xv_S, \xv_{-S}) ) \\
+&= \int_{-\infty}^{\infty} \fh(\xv_S, \xv_{-S}) \, d\P(\xv_{-S})
 \end{align*}
-
-\medskip
-
+\spacer[0.25]
 \textbf{Estimation:} For a grid value $\xv_S^*$, average ICE curves point-wise at $\xv_S^*$ over all observed $\xv_{-S}^{(i)}$:
 \begin{align*}
-    \fh_{S, PD}(\xv_S^*) &= \frac{1}{n} \sum_{i=1}^n \fh(\xv_S^*, \xv_{-S}^{(i)})   \\
-    &= \frac{1}{n} \sum_{i=1}^n \fhice{S}^{(i)}(\xv_S^*) 
+\fh_{S, PD}(\xv_S^*) &= \frac{1}{n} \sum_{i=1}^n \fh(\xv_S^*, \xv_{-S}^{(i)}) \\
+&= \frac{1}{n} \sum_{i=1}^n \fhice{S}^{(i)}(\xv_S^*)
 \end{align*}
-
-\end{column}
-
-\begin{column}{0.43\textwidth}
-\centering
-\includegraphics[width=\textwidth]{figure/pdplot.pdf}\\
-\medskip
-\includegraphics[width=\textwidth]{figure/pdp_bike.pdf}
-\end{column}
-\end{columns}
+}{
+\spacer[0]
+\image{figure/pdplot.pdf}
+\\
+\spacer[0.25]
+\image{figure/pdp_bike.pdf}
+}
 %Within the SIPA framework, the partial dependence builds the \textbf{Aggregation} step.
-
 %\footnote[frame]{Friedman, Jerome H. (2001). Greedy Function Approximation: A Gradient Boosting Machine. Annals of Statistics: 1189-1232.}
 %\footnote[frame]{Scholbeck, C. A., Molnar, C., Heumann, C., Bischl, B., and Casalicchio, G. (2019). Sampling, Intervention, Prediction, Aggregation: A Generalized Framework for Model Agnostic Interpretations. ECML PKDD 2019. (pp. 205-216).}
-\end{frame}
+\end{framev}
 
 
-\frame{
-\frametitle{Partial Dependence}
+\begin{framev}[align=top]{Partial Dependence}
 %\begin{onlyenv}
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.5\textwidth}
+\splitVTT[0.5]{
+\spacer[0]
 \centering
-\only<1>{
-\includegraphics[page=8, width=0.8\textwidth]{../../figure_man/ice_pd_plot_demo}
-\end{column}
-\begin{column}{0.5\textwidth}
-
-\begin{center}
-\includegraphics[page=1, width=\textwidth]{figure/PD}
-\end{center}
+\includegraphics<1>[page=8, width=0.8\textwidth]{../../figure_man/ice_pd_plot_demo}
+\includegraphics<2>[page=9, width=0.8\textwidth]{../../figure_man/ice_pd_plot_demo}
+\includegraphics<3>[page=10, width=0.8\textwidth]{../../figure_man/ice_pd_plot_demo}
+\spacer[0]
+}{
+\spacer[0]
+\centering
+\includegraphics<1>[page=1, width=\textwidth]{figure/PD}
+\includegraphics<2>[page=2, width=\textwidth]{figure/PD}
+\includegraphics<3>[page=3, width=\textwidth]{figure/PD}
+\spacer[0]
 }
-
-\only<2>{
-\includegraphics[page=9, width=0.8\textwidth]{../../figure_man/ice_pd_plot_demo}
-\end{column}
-\begin{column}{0.5\textwidth}
-
-\begin{center}
-\includegraphics[page=2, width=\textwidth]{figure/PD}
-\end{center}
-}
-
-\only<3>{
-\includegraphics[page=10, width=0.8\textwidth]{../../figure_man/ice_pd_plot_demo}
-\end{column}
-\begin{column}{0.5\textwidth}
-
-\begin{center}
-\includegraphics[page=3, width=\textwidth]{figure/PD}
-\end{center}
-}
-\end{column}
-\end{columns}
 %\end{onlyenv}
-
+\spacer[0.25]
 Estimate PD function by \textbf{point-wise} average of ICE curves at grid value \fcolorbox{red}{white}{$\xv_S^* = x_1^* = \only<1>{1}\only<2>{2}\only<3>{3}$}:
 $$\textstyle\fh_{1, PD}(x_1^*) = \frac{1}{n} \sum_{i=1}^n \fh(x_1^*, \xv_{2, 3}^{(i)})$$
-}
+\end{framev}
 
 
-\frame{
-\frametitle{Example: PD for Linear Model}
-
+\begin{framev}[align=top]{Example: PD for Linear Model}
 Assume a linear regression model with two features:
-
 $$\fh(\xv) = \fh(\xv_1, \xv_2) = \hat\theta_1 \xv_1 + \hat\theta_2 \xv_2 + \hat\theta_0$$
-
 PD function for feature of interest $S = \{1\}$ (with $-S = \{2\}$) is:
-
 $$
 \begin{aligned}
-f_{1, PD}(\xv_1) = \E_{\xv_2} \left( \fh(\xv_1, \xv_2) \right) &= \int_{-\infty}^{\infty} \left( \hat\theta_1 \xv_1 + \hat\theta_2 \xv_2 + \hat\theta_0 \right) \, d\P(\xv_2) \\
+f_{1, PD}(\xv_1) = \E_{\xv_2} ( \fh(\xv_1, \xv_2) ) &= \int_{-\infty}^{\infty} ( \hat\theta_1 \xv_1 + \hat\theta_2 \xv_2 + \hat\theta_0 ) \, d\P(\xv_2) \\
 &= \hat\theta_1 \xv_1 + \hat\theta_2 \cdot \int_{-\infty}^{\infty} \xv_2 \, d\P(\xv_2) + \hat\theta_0 \\
 &= \hat\theta_1 \xv_1 + \underbrace{\hat\theta_2 \cdot \E_{\xv_2} (\xv_2) + \hat\theta_0}_{:= const}
 \end{aligned}
 $$
-
 $\Rightarrow$ PD plot visualizes function $f_{1, PD}(\xv_1) = \hat\theta_1 \xv_1 + const$ ($\hat =$ feature effect of $\xv_1$).
+\end{framev}
 
-}
 
-
-\frame{
-\frametitle{Interpretation: PD and ICE}
-
+\begin{framev}[align=top]{Interpretation: PD and ICE}
 If feature varies:\\
-\begin{itemize}
-\item
-  \textbf{ICE:} How does \textbf{prediction of
-  individual observation} change? 
-  \\ \(\Rightarrow\) \textbf{local} interpretation
-\item
-  \textbf{PD:} How does \textbf{average effect / expected prediction} change? 
-  \\ \(\Rightarrow\) \textbf{global} interpretation
-\end{itemize}
-
-\begin{columns}[c, totalwidth=\textwidth]
-\begin{column}{0.5\textwidth}
-\begin{center}
-\includegraphics[width=\textwidth]{figure/pdp_bike}
-\end{center}
-\end{column}
+\begin{itemizeM}
+\item \textbf{ICE:} How does \textbf{prediction of individual observation} change? \\
+\(\Rightarrow\) \textbf{local} interpretation
+\item \textbf{PD:} How does \textbf{average effect / expected prediction} change? \\
+\(\Rightarrow\) \textbf{global} interpretation
+\end{itemizeM}
+\splitVTT[0.5]{
+\spacer[0]
+\image{figure/pdp_bike}
+}{
 \pause
-\begin{column}{0.5\textwidth}
 Insights from bike sharing data:
-\begin{itemize}
+\begin{itemizeM}
 %  \item Averaging ICE curves yields PD plot (yellow curve)
-  \item Parallel ICE curves = homogeneous effect across obs.
-  \item Warmer $\Rightarrow$ more rented bikes
-  \item Too hot $\Rightarrow$ slightly less bikes 
-  \item Steepest increase in rentals occurs as temperature rises from 10°C to 15°C.
-\end{itemize}
-\end{column}
-\end{columns}
+\item Parallel ICE curves = homogeneous effect across obs.
+\item Warmer $\Rightarrow$ more rented bikes
+\item Too hot $\Rightarrow$ slightly less bikes
+\item Steepest increase in rentals occurs as temperature rises from 10°C to 15°C.
+\end{itemizeM}
 }
+\end{framev}
 
 
-\frame{
-\frametitle{Interpretation: Categorical Features}
-
-\begin{center}
-\includegraphics[width=0.9\textwidth]{figure/pdp_ice_cat}
-\end{center}
-
-\begin{itemize}
+\begin{framev}[align=top]{Interpretation: Categorical Features}
+\imageC[0.9]{figure/pdp_ice_cat}
+\begin{itemizeM}
 \item PDP with boxplots and ICE with parallel coordinates plots
 %lot visualizes expected prediction if all observations would belong to a certain category (and shows distribution of predictions in a box plot)
 \item NB: Categories can be unordered, if so, rather compare pairwise
-\end{itemize}
+\end{itemizeM}
 %ICE plot connects predictions of individual observations (might identify heterogenous effects between categories if many lines are crossing)\\
 %to identify heterogenous effects between categories (here: lines between SPRING and SUMMER are heterogenous).\\
-
-}
+\end{framev}
 
 
 % \begin{frame}{Comments on Extrapolation}

--- a/slides/feature-effects/slides04-fe-pdp-comments.tex
+++ b/slides/feature-effects/slides04-fe-pdp-comments.tex
@@ -1,16 +1,14 @@
 \documentclass[10pt,compress,t,notes=noshow, xcolor=table]{beamer}
 
 \input{../../style/preamble}
-\input{../../latex-math/basic-ml}
 \input{../../latex-math/basic-math.tex}
-\input{../../latex-math/ml-interpretable}
+\input{../../latex-math/basic-ml}
 
 % Defines macros and environments
- 
+
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
 
@@ -21,45 +19,38 @@ PDP - Comments and Extensions
 }{
 figure/pdp_bike
 }{
-
 \item Extrapolation and Interactions in PDPs
 \item Centered ICE and PDP
-
 }
 
 
-\begin{frame}{Comments on Extrapolation}
-
+\begin{framev}[align=top]{Comments on Extrapolation}
 % \begin{center}
 % \includegraphics[width=0.8\textwidth]{figure_man/extrapolation01.png}
 % \end{center}
- 
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.5\textwidth}
-\centering
-\includegraphics[width=\textwidth]{figure/ale_scatter_grid}
-\end{column}
-\begin{column}{0.5\textwidth}
-\centering
-\includegraphics[width=\textwidth]{figure/ale_pdplot}
-\end{column}
-\end{columns}
-
+\splitVTT[0.5]{
+\spacer[0]
+\image{figure/ale_scatter_grid}
+\spacer[0]
+}{
+\spacer[0]
+\image{figure/ale_pdplot}
+\spacer[0]
+}
 Extrapolation occurs in regions with few obs. or if features are correlated
-\begin{itemize}
+\begin{itemizeM}
 \item \textbf{Example:} Features $x_1$ and $x_2$ are strongly correlated
 \item \textbf{Black points:} Observed points of the original data
 \item \textbf{\textcolor{red}{Red:}} Grid points to calculate ICE/PD (many unrealistic $x_1$, $x_2$ combinations)\\ %combination of feature values
 $\Rightarrow$ %Unrealistic combination of feature values are used, e.g., the
 \textbf{PD at $x_1=0$:} Averages predictions over \textit{full} marginal distribution of $x_2$\\
 $\Rightarrow$ \textbf{Issue:} Model may behave strangely outside training distribution\\
-$\Rightarrow$ Especially problematic for overfitted or interaction-heavy models 
+$\Rightarrow$ Especially problematic for overfitted or interaction-heavy models
 % which amplify risk of erratic predictions at extrapolated grid point
 %can bias ICE and PD curves Be careful with interpretations 
 %\item For correlated features and in regions with few observations with care
 %Extrapolation: interpret curves for highly correlated features and in feature regions with few observations with care
-\end{itemize}
-
+\end{itemizeM}
 %
 % \framebreak
 %
@@ -74,7 +65,7 @@ $\Rightarrow$ Especially problematic for overfitted or interaction-heavy models
 % \item \textcolor{green}{Green:} Grid points used to calculate the ICE and PD curves.
 % \item Example: PD plot at $x_1=1.9$ averages predictions over the whole marginal distribution of feature $x_2$.
 % \end{itemize}
-\end{frame}
+\end{framev}
 
 
 
@@ -105,27 +96,23 @@ $\Rightarrow$ Especially problematic for overfitted or interaction-heavy models
 % % Apley, D. W., \& Zhu, J. (2020). Visualizing the effects of predictor variables in black box supervised learning models. Journal of the Royal Statistical Society: Series B, 82(4), 1059-1086. \par}
 % \end{frame}
 
-\begin{frame}{Comments on Interactions}
+\begin{framev}[align=top]{Comments on Interactions}
 % \begin{itemize}
 % %\lz
 % %\item Accumulated Local Effects (ALE) plots are a novel alternative to PD plots developed by Apley (2016) that do not suffer from extrapolation in case of correlated features.
 % \item PD plots: averaging of ICE curves might \textbf{obfuscate} heterogeneous effects and interactions \\ 
 % \(\Rightarrow\) Ideally plot ICE curves and PD plots together to uncover this fact\\
 % \(\Rightarrow\) Different shapes of ICE curves suggest interaction (but do not tell with which  feature)
-
 % \end{itemize}
 PD plots average ICE curves \\$\leadsto$ May \textbf{obscure heterogeneous effects} (interactions)
-    \begin{itemize}
-      \item \textbf{Example:} Feature $x_1$ = treatment dosage; $x_2$ = gender \\
-      \(\Rightarrow\)  Males ($\nearrow$) and females ($\searrow$) respond differently to dosage\\
-      \(\Rightarrow\)  PD curve (yellow) hides this divergence
-      \item Plotting ICE and PD together helps detect interaction
-      \item Diverse ICE shapes suggest interaction  (but not with which feature)
-    \end{itemize}
-    
-\begin{center}\includegraphics[width=0.65\textwidth]{figure/pdp_xor.pdf} \end{center}
-
-
+\begin{itemizeM}
+\item \textbf{Example:} Feature $x_1$ = treatment dosage; $x_2$ = gender \\
+\(\Rightarrow\)  Males ($\nearrow$) and females ($\searrow$) respond differently to dosage\\
+\(\Rightarrow\)  PD curve (yellow) hides this divergence
+\item Plotting ICE and PD together helps detect interaction
+\item Diverse ICE shapes suggest interaction  (but not with which feature)
+\end{itemizeM}
+\imageC[0.65]{figure/pdp_xor.pdf}
 %     \begin{columns}[T, totalwidth=\textwidth]
 %   \begin{column}{0.45\textwidth}
 %     \centering
@@ -153,48 +140,38 @@ PD plots average ICE curves \\$\leadsto$ May \textbf{obscure heterogeneous effec
 %   \end{column}
 % \end{columns}
 %\footnote[frame]{Apley, Daniel W., and Jingyu Zhu (2020). Visualizing the Effects of Predictor Variables in Black Box Supervised Learning Models. Journal of the Royal Statistical Society: Series B (Statistical Methodology) 82.4: 1059-1086.}
-\end{frame}
-
-\begin{frame}{Comments on Interactions - 2D PD plot}
-
-\begin{center}
-\includegraphics[width=\textwidth]{figure/pdp2d_bike}
-\end{center}
-
-\begin{itemize}
- \item Humidity and temperature interact at high values (see shape difference)\\
- $\leadsto$ ICE curve shape changes across different (higher) values of other feat.% %(esp. for high values)%at different horizontal and vertical slices varies 
-  \begin{itemize}
-    \item ICE (temp): At high humidity, temp effect flattens (pink line)
-    %or reverses
-    \item ICE (hum): At high temp., humidity effect falls steeper (blue/pink)
-  \end{itemize}
-
- \item Most rentals occur at \textit{high temperature} and \textit{low to medium humidity}
- %Many rented bikesThe number of bike rentals is especially high when humidity is below 75 percent and temperature is between 15 $^{\circ}$C and 27 $^{\circ}$C
-\end{itemize}
+\end{framev}
 
 
+\begin{framev}[align=top]{Comments on Interactions - 2D PD plot}
+\imageC{figure/pdp2d_bike}
+\begin{itemizeM}
+\item Humidity and temperature interact at high values (see shape difference)\\
+$\leadsto$ ICE curve shape changes across different (higher) values of other feat.% %(esp. for high values)%at different horizontal and vertical slices varies
+\begin{itemizeS}
+\item ICE (temp): At high humidity, temp effect flattens (pink line)
+%or reverses
+\item ICE (hum): At high temp., humidity effect falls steeper (blue/pink)
+\end{itemizeS}
+\item Most rentals occur at \textit{high temperature} and \textit{low to medium humidity}
+%Many rented bikesThe number of bike rentals is especially high when humidity is below 75 percent and temperature is between 15 $^{\circ}$C and 27 $^{\circ}$C
+\end{itemizeM}
 % \framebreak
 %
 % add datapoints to previous figure and mention convex hull (see pdp package)
+\end{framev}
 
-\end{frame}
 
-\begin{frame}{Centered ICE Plot (c-ICE) \furtherreading{GOLDSTEIN2015}}
-
-\textbf{Issue:} Varying-intercept (stacked) ICE curves obscure shape heterogeneity
+\begin{framev}[align=top]{Centered ICE Plot (c-ICE) \furtherreading{GOLDSTEIN2015}}
+\textbf{Issue:} Varying-intercept (stacked) ICE curves obscure shape heterogeneity\\
 %Difficult to identify heterogeneous ICE curves if curves have different intercepts (are stacked)
 %When ICE curves start at different intercepts (are stacked), it is difficult to identify heterogenous predictions.
-
 \textbf{Solution:} Center ICE curves at fixed reference value, often $x' = \min(\xv_S)$\\
 $\Rightarrow$ Easier to identify heterogeneous shapes with c-ICE curves
-$$\begin{aligned}
+$$
 \fh_{S, cICE}^{(i)}(\xv_S) = \fh(\xv_S, \xi_{-S}) - \fh(x', \xi_{-S}) = \fh_{S}^{(i)}(\xv_S) - \fh_{S}^{(i)}(x')
-\end{aligned}$$
-\vspace{-0.2cm}
-\begin{columns}[c, totalwidth=\textwidth]
-\begin{column}{0.5\textwidth}
+$$
+\splitVCC[0.5]{
 %\centering
 % $$\begin{aligned}
 % \fh_{S, cICE}^{(i)}(\xv_S)
@@ -205,53 +182,35 @@ $$\begin{aligned}
 %\lz
 \pause
 \textbf{Interpretation}% \\
-\begin{itemize}
-  \item Yellow: c-PDP (mean of c-ICE)
-  \item \textbf{c-PDP:} At 97\% humidity, predicted rentals are 1000 fewer than at 0\% humidity (on average)
-  \item \textbf{Opening of c-ICE curves:} suggests interaction or varying effect across instances
-\end{itemize}
+\begin{itemizeM}
+\item Yellow: c-PDP (mean of c-ICE)
+\item \textbf{c-PDP:} At 97\% humidity, predicted rentals are 1000 fewer than at 0\% humidity (on average)
+\item \textbf{Opening of c-ICE curves:} suggests interaction or varying effect across instances
+\end{itemizeM}
 %(yellow curve: analog to PDP the average of c-ICE curves): \\
 %On average, the number of bike rentals at $\sim 97$ \% humidity decreased by 1000 bikes compared to a humidity of 0 \%
-\end{column}
-\begin{column}{0.5\textwidth}
-\begin{center}
+}{
 %\vspace{-0.3cm}
-\includegraphics[width=\textwidth]{figure/cICE}
-\end{center}
-\end{column}
-\end{columns}
-
+\image{figure/cICE}
+}
 %\vspace{-0.4cm}
+\end{framev}
 
-\end{frame}
 
-
-\begin{frame}{Centered ICE Plot (c-ICE)}
-
+\begin{framev}[align=top]{Centered ICE Plot (c-ICE)}
 Categorical features: c-ICE plots can be interpreted as in LMs due to reference value
-
-\begin{columns}[c, totalwidth=\textwidth]
-\begin{column}{0.4\textwidth}
-
-\begin{center}
-\includegraphics[width=\textwidth]{figure/cICEcat}
-\end{center}
-
-\end{column}
-\begin{column}{0.6\textwidth}
-
+\splitVCC[0.4]{
+\image{figure/cICEcat}
+}{
 \textbf{Interpretation}: \\
-\begin{itemize}
+\begin{itemizeM}
 %\item Centered ICE plots are useful for categorical features and can be interpreted as in LMs
 \item The reference category is $x' =$ SPRING
 \item Yellow crosses: Average rentals if we jump from SPRING to any other season\\
 $\Rightarrow$ Number of bike rentals drops by $\sim 560$ in \code{WINTER} and is slightly higher in \code{SUMMER} and \code{FALL} compared to \code{SPRING}
-\end{itemize}
-
-\end{column}
-\end{columns}
-
-\end{frame}
+\end{itemizeM}
+}
+\end{framev}
 
 
 \endlecture

--- a/slides/feature-effects/slides05-fe-ale-intro.tex
+++ b/slides/feature-effects/slides05-fe-ale-intro.tex
@@ -2,29 +2,26 @@
 
 \input{../../style/preamble}
 % Defines macros and environments
- 
+
 \input{../../latex-math/basic-math}
 \input{../../latex-math/basic-ml}
 
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
 
 \titlemeta{
-Feature Effects 
+Feature Effects
 }{
 Accumulated Local Effect (ALE): Intro
 }{
 figure/ale_plot.pdf
 }{
-
 \item PD plots and its extrapolation issue
 \item M plots and its omitted-variable bias
 \item Understand ALE plots
-
 }
 
 %
@@ -62,62 +59,49 @@ figure/ale_plot.pdf
 
 
 
-\begin{frame}{Motivation - Correlated Features}
-
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.5\textwidth}
-\centering
-\includegraphics[width=0.9\textwidth]{figure/ale_scatter_grid}
-\end{column}
-\begin{column}{0.5\textwidth}
-\centering
-\includegraphics[width=0.9\textwidth]{figure/ale_pdplot}
-\end{column}
-\end{columns}
-
+\begin{framev}[align=top]{Motivation - Correlated Features}
+\splitVTT[0.5]{
+\spacer[0]
+\imageC[0.9]{figure/ale_scatter_grid}
+\spacer[0]
+}{
+\spacer[0]
+\imageC[0.9]{figure/ale_pdplot}
+\spacer[0]
+}
 %\begin{center}
 %\includegraphics[width=0.8\textwidth]{figure_man/pd_grid}
 %\tiny{Source: Figure taken from Apley et al. (2020)}
 %\end{center}
-
 %In case of strongly correlated features $x_1$ and $x_2$, PD plots \textbf{average predictions} of artificial data points that are unlikely in reality (red).
-
-\begin{itemize}
-    \item PD plots \textbf{average over predictions} of artificial points that are out of distribution/ unlikely (red)\\
-    $\Rightarrow$ Can lead to misleading / biased interpretations, especially if model also contains interactions
-    \item Not wanted if interest is to interpret effects within data distribution
-\end{itemize}
+\begin{itemizeM}
+\item PD plots \textbf{average over predictions} of artificial points that are out of distribution/ unlikely (red)\\
+$\Rightarrow$ Can lead to misleading / biased interpretations, especially if model also contains interactions
+\item Not wanted if interest is to interpret effects within data distribution
+\end{itemizeM}
 %If features are correlated, PD plots \textbf{average predictions} of artificial points that are unlikely (red).
 %\textbf{But:} This might be undesired if interest is to interpret effects within data distribution.
 %This can be an undesired property if the model contains interactions and one is interested in interpreting effects w.r.t. the data distribution.
-
 %\lz
-
 %\textbf{Question:} Can we avoid the extrapolation issue by averaging only over points in an appropriate neighborhood? % of a specific point $x_1$? %, i.e., using the conditional distribution at
+\end{framev}
 
-\end{frame}
 
-
-\begin{frame}{Motivation - Correlated Features}
-
+\begin{framev}[align=top]{Motivation - Correlated Features}
 %TODO: Example what can go wrong with PDPs and NNs
-
 Example: Fit an NN to $5000$ simulated data points with $x \sim Unif(0,1)$, $\epsilon \sim N(0, 0.2)$ and
-
 \centerline{$y = x_1 + x_2^2 + \epsilon$, where
-$x_1 = x + \epsilon_1$, 
+$x_1 = x + \epsilon_1$,
 $x_2 = x + \epsilon_2$ and $\epsilon_1, \epsilon_2 \sim N(0, 0.05)$.}
-
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.6\textwidth}
-\centering
-\only<1>{\includegraphics[width=\textwidth]{figure/ale_vs_pdp_surf}}
-\only<2>{\includegraphics[width=\textwidth]{figure/ale_vs_pdp_nn}}
-\end{column}
-\begin{column}{0.4\textwidth}
+\splitVTT[0.55]{
+\spacer[0.6]
+\only<1>{\image{figure/ale_vs_pdp_surf}}
+\only<2>{\image{figure/ale_vs_pdp_nn}}
+\spacer[0]
+}{
 %What went wrong here?
-
-\begin{itemize}
+\spacer[0.6]
+\begin{itemizeM}
 \item Test error (MSE) of NN is comparable to other models
 \item NN contains interactions (see complex pred. surface)
 %\item ALE shows a linear effect for $x_1$ and quadratic effect for $x_2$\\
@@ -127,116 +111,106 @@ $x_2 = x + \epsilon_2$ and $\epsilon_1, \epsilon_2 \sim N(0, 0.05)$.}
 \item<2> ALE in line with ground truth
 \item<2> PDP does not reflect ground truth effects of DGP well \\
 $\Rightarrow$ Due to interactions and averaging of points outside data distribution
-\end{itemize}
+\end{itemizeM}
+}
+\end{framev}
 
-\end{column}
-\end{columns}
 
-\end{frame}
-
-\begin{frame}{M Plot vs. PD plot}
-
+\begin{framev}[align=top]{M Plot vs. PD plot}
 % \begin{center}
 % \includegraphics[width=0.7\textwidth]{figure_man/PD_M.jpg}\\
 % \tiny{Source: Figure taken from Apley et al. (2020)}
 % \end{center}
-
-\begin{columns}[T, totalwidth=\textwidth]
-\visible<1-2>{\begin{column}{0.5\textwidth}
-\vspace*{-1em}
-\centering
+\splitVTT[0.5]{
+\spacer[0]
+\visible<1-2>{
 \textbf{a) PD plot}
-\includegraphics[width=0.9\textwidth]{figure/ale_pdplot}
-\end{column}
+\imageL[0.9]{figure/ale_pdplot}
 }
-\visible<2>{\begin{column}{0.5\textwidth}
-\vspace*{-1em}
+\spacer[0]
+}{
+\spacer[0]
+\visible<2>{
 \textbf{b) M plot}
-\centering
-\includegraphics[width=0.9\textwidth]{figure/ale_mplot}
-\end{column}
+\imageL[0.9]{figure/ale_mplot}
 }
-\end{columns}
-
+\spacer[0]
+}
 \begin{enumerate}[<+->]
 %\item[a)] PD plot $\fh_{1, PD}(x_1) = \hat{\E}_{\xv_2} \left( \fh(x_1, \xv_2) \right) = \frac{1}{n} \sum_{i=1}^n \fh(x_1, \xv_2^{(i)})$
 %\item[b)] M plot $\fh_{1, M}(x_1) = \hat{\E}_{\xv_2|\xv_1} \left( \fh(x_1, \xv_2) \middle| \xv_1\right) = \frac{1}{|N(x_1)|} \sum\limits_{i \in N(x_1)} \fh(x_1, \xv_2^{(i)})$, where $N(x_1) = \{i: x_1^{(i)} \in [x_1 - \epsilon, x_1 + \epsilon]\}$ is an index set referring to observations in an appropriate neighborhood of feature value $x_1$.
-\item[a)] PD plot $\E_{\xv_2} \left( \fh(x_1, \xv_2) \right)$ is estimated by $ \fh_{1, PD}(x_1) = \frac{1}{n} \sum\limits_{i=1}^n \fh(x_1, \xv_2^{(i)})$
-\item[b)] M plot $\E_{\xv_2|\xv_1} \left( \fh(x_1, \xv_2) \middle| \xv_1\right)$ is
+\item[a)] PD plot $\E_{\xv_2}(\fh(x_1, \xv_2))$ is estimated by $ \fh_{1, PD}(x_1) = \frac{1}{n} \sum\limits_{i=1}^n \fh(x_1, \xv_2^{(i)})$
+\item[b)] M plot $\E_{\xv_2|\xv_1}(\fh(x_1, \xv_2) \mid \xv_1)$ is
 estimated by $\fh_{1, M}(x_1) = \textstyle\frac{1}{|N(x_1)|} \sum_{i \in N(x_1)} \fh(x_1, \xv_2^{(i)}),$
 where index set $N(x_1) = \{i: x_1^{(i)} \in [x_1 - \epsilon, x_1 + \epsilon]\}$ refers to observations with feature value close to $x_1$. %in an appropriate neighborhood of feature value $x_1$.
 \end{enumerate}
-\end{frame}
+\end{framev}
 
-\begin{frame}{M Plot vs. PD plot}
 
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.5\textwidth}
-\centering
-\includegraphics[width=0.9\textwidth]{figure/ale_scatter}
-\end{column}
-\begin{column}{0.5\textwidth}
-\centering
-\includegraphics[width=0.9\textwidth]{figure/ale_mplot}
-\end{column}
-\end{columns}
-
+\begin{framev}[align=top]{M Plot vs. PD plot}
+\splitVTT[0.5]{
+\spacer[0]
+\imageC[0.9]{figure/ale_scatter}
+\spacer[0]
+}{
+\spacer[0]
+\imageC[0.9]{figure/ale_mplot}
+\spacer[0]
+}
 %\textbf{Answer:} Yes, we could.
 %\textbf{Recall:} Marginal plots (M plots) do this by averaging (i.e., marginalizing) over the conditional distribution $\P(\xv_2|x_1)$.
 %\textbf{Recall:}
-
-\begin{itemize}
-    \item M plots average predictions over conditional distribution (e.g., $\P(\xv_2|x_1)$)\\
-    $\Rightarrow$ Averaging predictions close to data distrib. avoids extrapolation issues
-    \item \textbf{But:} M plots suffer from omitted-variable bias (OVB)
-\begin{itemize}
+\begin{itemizeM}
+\item M plots average predictions over conditional distribution (e.g., $\P(\xv_2|x_1)$)\\
+$\Rightarrow$ Averaging predictions close to data distrib. avoids extrapolation issues
+\item \textbf{But:} M plots suffer from omitted-variable bias (OVB)
+\begin{itemizeS}
 \item Because of the conditioning M plots contain effects of other dependent features
 \item Useless in assessing a feature's marginal effect if feature dependencies are present
-\end{itemize}
-\end{itemize}
-
+\end{itemizeS}
+\end{itemizeM}
 % in case of dependent features.
-
 %M plots average over the conditional distribution $x_2|x_1$. However, the M plot of $x_1$ also includes the marginal effect of other dependent features $\Rightarrow$ We don't want this.
 % do not include the marginal effect of the considered feature but
 % mixture of its marginal effect and the marginal effects of all dependent features
-\end{frame}
+\end{framev}
 
-\begin{frame}{M Plot vs. PD plot - OVB Example}
+
+\begin{framev}[align=top]{M Plot vs. PD plot - OVB Example}
 %\vspace*{-\topsep}
 %\vspace*{-3\lineskip}
-
-\begin{center}
-\includegraphics[width=0.9\textwidth]{figure/pd_vs_mplot}
-\end{center}
-
-\textbf{Illustration:} Fit LM on 500 i.i.d. observations with features $x_1, x_2 \sim N(0,1)$, $Cor(x_1, x_2) = 0.9$ and $$y = -x_1 + 2 \cdot x_2 + \epsilon, \; \epsilon \sim N(0,1).$$
-
+\imageC[0.9]{figure/pd_vs_mplot}
+\textbf{Illustration:} Fit LM on 500 i.i.d. observations with features $x_1, x_2 \sim N(0,1)$, $Cor(x_1, x_2) = 0.9$ and
+$$
+y = -x_1 + 2 \cdot x_2 + \epsilon \quad \epsilon \sim N(0,1)
+$$
 \textbf{Results:} M plot of $x_1$ also includes marginal effect of all other dependent features (here: $x_2$)
-\end{frame}
+\end{framev}
 
-\begin{frame}{Idea: Integrating Partial Derivatives}
 
+\begin{framev}[align=top]{Idea: Integrating Partial Derivatives}
 \textbf{Idea:} To remove unwanted effects of other features, take partial derivatives (local effects) of prediction function w.r.t. feature of interest and integrate (accumulate) them w.r.t. the same feature
-
-\begin{itemize}
+\begin{itemizeM}
 \item[$\Rightarrow$] Computing the partial derivative of $\fh$ w.r.t. $\xv_j$ removes other main effects
 \item[$\Rightarrow$] Integrating again w.r.t. $\xv_j$ recovers the original main effect of $\xv_j$
-\end{itemize}
-
+\end{itemizeM}
 \pause %\lz
-
 \textbf{Example:}
-\begin{itemize}[<+->]
-\item Consider an additive prediction function: $$\fh(x_1, x_2) = 2x_1 + 2x_2 - 4x_1 x_2$$
-\item Partial derivative of $\fh$ w.r.t. $x_1$:
+\begin{itemizeM}
+\item<+-> Consider an additive prediction function:
+$$
+\fh(x_1, x_2) = 2x_1 + 2x_2 - 4x_1 x_2
+$$
+\item<+-> Partial derivative of $\fh$ w.r.t. $x_1$:
 $\frac{\partial \fh(x_1, x_2)}{\partial x_1} = 2 - 4x_2$
-\item Integral of partial derivative ($z_0 = \min(x_1)$):
-$$\int_{z_0}^{x} \frac{\partial \fh(x_1, x_2)}{\partial x_1} dx_1 = \left[2x_1 - 4x_1 x_2\right]_{z_0}^{x}$$
-\item We removed the main effect of $x_2$, which was our goal % (Note: interaction is still there)
-\end{itemize}
-\end{frame}
-    
+\item<+-> Integral of partial derivative ($z_0 = \min(x_1)$):
+$$
+\int_{z_0}^{x} \frac{\partial \fh(x_1, x_2)}{\partial x_1} dx_1 = [2x_1 - 4x_1 x_2]_{z_0}^{x}
+$$
+\item<+-> We removed the main effect of $x_2$, which was our goal % (Note: interaction is still there)
+\end{itemizeM}
+\end{framev}
+
 
 \endlecture
 \end{document}

--- a/slides/feature-effects/slides06-fe-ale.tex
+++ b/slides/feature-effects/slides06-fe-ale.tex
@@ -2,14 +2,13 @@
 
 \input{../../style/preamble}
 % Defines macros and environments
- 
+
 \input{../../latex-math/basic-math}
 \input{../../latex-math/basic-ml}
 
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
 
@@ -20,10 +19,8 @@ Accumulated Local Effect (ALE) plot
 }{
 figure/ale_plot.pdf
 }{
-
 \item Understand ALE plots
 \item Difference between ALE and PD plots
-
 }
 
 %
@@ -236,7 +233,7 @@ figure/ale_plot.pdf
 % \end{itemize}
 % \end{frame}
 
-\begin{frame}{Accumulated Local Effects (ALE) \furtherreading{APLEYZHU2020}}
+\begin{framev}[align=top]{Accumulated Local Effects (ALE) \furtherreading{APLEYZHU2020}}
 %\begin{columns}[T, totalwidth=\textwidth]
 %\begin{column}{0.65\textwidth}
 %ALE plots use the idea of integrating partial derivatives. They do not suffer from the extrapolation issue of PD plots and the OVB issue of M plots when features are dependent.
@@ -247,32 +244,27 @@ figure/ale_plot.pdf
 %\tiny{Source: Figure taken from Apley et al. (2020)}
 %\end{column}
 %\end{columns}
-
-ALE plots estimate marginal effect of a feature by accumulating its local effects (integrating partial derivatives), evaluated in regions supported by the data. 
-
+ALE plots estimate marginal effect of a feature by accumulating its local effects (integrating partial derivatives), evaluated in regions supported by the data.\\
 % \medskip
 % \textbf{Key advantages:}
 % \begin{itemize}
 %     \item No extrapolation beyond observed data (unlike PD plots)
 %     \item No omitted variable bias (OVB) from dependent features (unlike M plots)
 % \end{itemize}
-
 %Let $z_0$ denote the minimum of observed values of feature $\xv_S$, i.e., $z_0 = \min(\xv_S)$. All complementary features are denoted by $\xv_C$.
-
-\medskip
+\spacer[0.25]
 \textbf{Computation Steps:}
 \begin{enumerate}[<+->]
 \item \textbf{Estimate local effects} $\frac{\partial \fh(x_S, \xv_{-S})}{\partial x_S}$ (via finite differences) \label{ref1}\\ %evaluated at certain points $(x_S = z_S, \xv_{-S})$
 $\Rightarrow$ Removes unwanted main effects of other features $\xv_{-S}$ (unlike M plots)
 \item \textbf{Average local effects} over conditional distr. $\P(\xv_{-S}|x_S)$ similar to M plots\\ %across all values of $\xv_{-S}$, i.e.,
 $\Rightarrow$ Avoids extrapolation (unlike PD plots)\label{ref2}
-\item \textbf{Accumulate:} Integrate averaged local effects up to a specific  $x \in \mathcal{X}_S$\\ %all values of $z_S$   from $z_0 := \min(x_S)$ u
+\item \textbf{Accumulate:} Integrate averaged local effects up to a specific $x \in \mathcal{X}_S$\\ %all values of $z_S$   from $z_0 := \min(x_S)$ u
 $\Rightarrow$ Reconstructs main effect of $x_S$ \label{ref3}\\
 %$\Rightarrow$ Avoids OVB issue as other unwanted main effects were removed in \eqref{ref1}
 \end{enumerate}
-
 %\footnote[frame]{Apley, Daniel W., and Jingyu Zhu (2020). Visualizing the Effects of Predictor Variables in Black Box Supervised Learning Models. Journal of the Royal Statistical Society: Series B (Statistical Methodology) 82.4: 1059-1086.}
-\end{frame}
+\end{framev}
 %\begin{itemize}
   %\item Accumulated Local Effect (ALE) plots were developed by Apley (2020) to overcome the extrapolation issue of PD plots and the OVB issue of M plots when features are dependent.
   %. \item ALEs are an alternative to PD that do not suffer from extrapolation
@@ -313,36 +305,32 @@ $\Rightarrow$ Reconstructs main effect of $x_S$ \label{ref3}\\
 
 % \end{frame}
 
-\begin{frame}{First Order ALE Function}
-
+\begin{framev}[align=top]{First Order ALE Function}
 \textbf{Uncentered ALE Function} evaluated at $x \in \mathcal{X}_S$ (domain of feature $x_S$):
-\[
-\tilde{f}_{S, \text{ALE}}(x) 
-= \underbrace{\int_{z_0}^{x}}_{\text{\eqref{ref3}}} 
-\underbrace{\E_{\xv_{-S} \mid x_S = z_S}}_{\substack{\text{\eqref{ref2} average} \\ \text{locally }}} 
+$$
+\tilde{f}_{S, \text{ALE}}(x)
+= \underbrace{\int_{z_0}^{x}}_{\text{\eqref{ref3}}}
+\underbrace{\E_{\xv_{-S} \mid x_S = z_S}}_{\substack{\text{\eqref{ref2} average} \\ \text{locally }}}
 \left( \underbrace{\frac{\partial \hat{f}(z_S, \xv_{-S})}{\partial z_S}}_{\text{\eqref{ref1} local effect}} \right) dz_S
 = \int\limits_{z_0}^{x} \int \frac{\partial \hat{f}(z_S, \xv_{-S})}{\partial z_S} d\P(\xv_{-S} \mid z_S) dz_S
-\]
-\begin{itemize}
+$$
+\begin{itemizeM}
 % \tightlist
-    \item $x_S$ is feature of interest, with minimum value $z_0 = \min(x_S)$
-    \item $z_S$ is integration variable ranging over $\mathcal{X}_S$, used to evaluate local effects
-    \item $\xv_{-S}$ denotes all other features (complement of $S$)
-\end{itemize}
-
+\item $x_S$ is feature of interest, with minimum value $z_0 = \min(x_S)$
+\item $z_S$ is integration variable ranging over $\mathcal{X}_S$, used to evaluate local effects
+\item $\xv_{-S}$ denotes all other features (complement of $S$)
+\end{itemizeM}
 \pause
-\medskip
+\spacer[0.25]
 \textbf{Centering (to ensure identifiability):}
-\[
-f_{S, \text{ALE}}(x) = \tilde{f}_{S, \text{ALE}}(x) 
+$$
+f_{S, \text{ALE}}(x) = \tilde{f}_{S, \text{ALE}}(x)
 - \underbrace{\int \tilde{f}_{S, \text{ALE}}(x_S) \, d\P(x_S)}_{\text{constant shift to mean zero}}
-\]
-
+$$
 % \medskip
 % \textbf{Interpretation:}
 % ALE curves accumulate local effects of $x_S$ while averaging out the influence of other features, using only data-supported regions.
-
-\end{frame}
+\end{framev}
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -371,95 +359,86 @@ f_{S, \text{ALE}}(x) = \tilde{f}_{S, \text{ALE}}(x)
 
 
 
-\begin{frame}{ALE Estimation: Illustration}
-
+\begin{framev}[align=top]{ALE Estimation: Illustration}
 %\centerline{\includegraphics[width=0.8\textwidth]{figure/ale_interval}}
-
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.6\textwidth}
+\splitVTT[0.6]{
+\spacer[0]
 \centering
 \includegraphics<1>[width=0.7\textwidth, trim=0 0 0 30, clip]{figure/ale_step1_2D.pdf}
-\end{column}
-\begin{column}{0.4\textwidth}
+\spacer[0]
+}{
+\spacer[0]
 \centering
 \includegraphics<1>[width=0.8\textwidth, trim=150 40 150 130, clip]{figure/ale_step1_3D_plotly.pdf}
-\end{column}
-\end{columns}
-
+\spacer[0]
+}
 %Compared to PD, ALE avoids averaging predictions of unlikely data instances and blocks the effect of other correlated features.
 % \begin{itemize}
 % \item Divide feature of interest into intervals (vertical lines)
 % \item For all points within an interval, compute \textbf{prediction difference} when we replace feature value with upper/lower interval bound (blue points) while keeping other feature values unchanged
 % \item These \textbf{finite differences} (approximate local effect) are accumulated \& centered $\Rightarrow$ ALE plot %to produce
 % \end{itemize}
-
-\begin{itemize}
+\begin{itemizeM}
 % \tightlist
-\item \textbf{Motivation:} Partial derivatives are not well-defined for all models (e.g., tree-based methods).  
+\item \textbf{Motivation:} Partial derivatives are not well-defined for all models (e.g., tree-based methods).
 $\Rightarrow$ Use finite differences within intervals instead.
 \item<1-> Partition the feature range of $x_S$ into $K$ intervals (vertical lines)
-    \begin{itemize}
-      \item Define intervals:
-      $$x_S \in [\min(x_S), \max(x_S)] \Rightarrow 
-  x_S \in [z_{0}, z_{1, S}] \cup [z_{1, S}, z_{2, S}] \cup \dots \cup [z_{K-1, S}, z_{K, S}]$$
-      \item \textit{Equidistant}: preserves resolution
-      \item \textit{Quantile-based}: balances sample size per interval
-    \end{itemize}
-\end{itemize}
+\begin{itemizeS}
+\item Define intervals:
+$$
+x_S \in [\min(x_S), \max(x_S)] \Rightarrow x_S \in [z_{0}, z_{1, S}] \cup [z_{1, S}, z_{2, S}] \cup \dots \cup [z_{K-1, S}, z_{K, S}]
+$$
+\item \textit{Equidistant}: preserves resolution
+\item \textit{Quantile-based}: balances sample size per interval
+\end{itemizeS}
+\end{itemizeM}
+\end{framev}
 
 
-\end{frame}
-
-
-
-\begin{frame}{ALE Estimation: Illustration}
-
+\begin{framev}[align=top]{ALE Estimation: Illustration}
 %\centerline{\includegraphics[width=0.8\textwidth]{figure/ale_interval}}
-
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.6\textwidth}
+\splitVTT[0.6]{
+\spacer[0]
 \centering
 %\includegraphics<1>[width=0.7\textwidth, trim=0 0 0 30, clip]{figure/ale_step1_2D.pdf}
 \includegraphics<1>[width=0.7\textwidth, trim=0 0 0 30, clip]{figure/ale_step2_2D.pdf}
 \includegraphics<2>[width=0.7\textwidth, trim=0 0 0 30, clip]{figure/ale_step3_2D.pdf}
 %\includegraphics<4>[width=0.7\textwidth, trim=0 0 0 30, clip]{figure/ale_step4_2D.pdf}
-\end{column}
-\begin{column}{0.4\textwidth}
+\spacer[0]
+}{
+\spacer[0]
 \centering
 %\includegraphics<1>[width=0.8\textwidth, trim=150 40 150 130, clip]{figure/ale_step1_3D_plotly.pdf}
 \includegraphics<1>[width=0.8\textwidth, trim=150 40 150 130, clip]{figure/ale_step2_3D_plotly.pdf}
 \includegraphics<2>[width=0.8\textwidth, trim=150 40 150 130, clip]{figure/ale_step3_3D_plotly.pdf}
 %\includegraphics<4>[width=0.7\textwidth, trim=150 40 150 100, clip]{figure/ale_step4_3D_plotly.pdf}
-\end{column}
-\end{columns}
-
+\spacer[0]
+}
 %Compared to PD, ALE avoids averaging predictions of unlikely data instances and blocks the effect of other correlated features.
 % \begin{itemize}
 % \item Divide feature of interest into intervals (vertical lines)
 % \item For all points within an interval, compute \textbf{prediction difference} when we replace feature value with upper/lower interval bound (blue points) while keeping other feature values unchanged
 % \item These \textbf{finite differences} (approximate local effect) are accumulated \& centered $\Rightarrow$ ALE plot %to produce
 % \end{itemize}
-
-\begin{itemize}
+\begin{itemizeM}
 % \tightlist
 %\item<1-> Partition the feature range of $x_S$ into $K$ intervals (vertical lines)
 \item<1-> For each observation in $k$-th interval, i.e., $\{i: x_S^{(i)} \in \; [z_{k-1, S}, z_{k, S}]\}$:
-  \begin{itemize}
-    \item Replace $x_S^{(i)}$ with \textcolor{blue}{upper/lower interval bounds}, keeping $\xv_{-S}^{(i)}$ fixed
-    \item Compute obs.-wise finite difference of $i$-th obs. in $k$-th interval \\
-    %Compute \textbf{prediction difference} (local effect) for $i$-th dobservation \\
-    $\leadsto$ $\fh(z_{k, S}, \xi_{-S}) - \fh(z_{k-1, S}, \xi_{-S})$  \; (approximates local effect)  %\\
-    %$\leadsto$ Approximates local effect of $x_S$ for $i$-th data point
-  \end{itemize}
+\begin{itemizeS}
+\item Replace $x_S^{(i)}$ with \textcolor{blue}{upper/lower interval bounds}, keeping $\xv_{-S}^{(i)}$ fixed
+\item Compute obs.-wise finite difference of $i$-th obs. in $k$-th interval \\
+%Compute \textbf{prediction difference} (local effect) for $i$-th dobservation \\
+$\leadsto$ $\fh(z_{k, S}, \xi_{-S}) - \fh(z_{k-1, S}, \xi_{-S})$ \; (approximates local effect)  %\\
+%$\leadsto$ Approximates local effect of $x_S$ for $i$-th data point
+\end{itemizeS}
 \item<2-> Average these finite differences over all observations in each interval \\
-$\leadsto$ Approximates \textbf{inner integral} \textcolor{red}{\( \E_{\xv_{-S} \mid x_S = z_S} \left[ \partial \hat{f}/\partial z_S \right] \)}
-\item<2-> Accumulate these averages from \( z_0 \) to the point of interest \( x \in \mathcal{X}_S \) \\
-$\leadsto$ Approximates \textbf{outer integral} over \( z_S \in [z_{0}, x] \) \\$\Rightarrow$ uncentered ALE function
-
+$\leadsto$ Approximates \textbf{inner integral} \textcolor{red}{$\E_{\xv_{-S} \mid x_S = z_S} \left[ \partial \hat{f}/\partial z_S \right]$}
+\item<2-> Accumulate these averages from $z_0$ to the point of interest $x \in \mathcal{X}_S$ \\
+$\leadsto$ Approximates \textbf{outer integral} over $z_S \in [z_{0}, x]$ \\
+$\Rightarrow$ uncentered ALE function
 %\item Accumulate and center differences over all data points $\Rightarrow$ ALE curve
-\end{itemize}
-
-\end{frame}
+\end{itemizeM}
+\end{framev}
 
 
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -592,24 +571,21 @@ $\leadsto$ Approximates \textbf{outer integral} over \( z_S \in [z_{0}, x] \) \\
 % \end{itemize}
 % \end{frame}
 
-\begin{frame}{ALE Estimation: Formula}
-
-\textbf{Estimated uncentered ALE:}  
+\begin{framev}[fs=small,align=top]{ALE Estimation: Formula}
+\textbf{Estimated uncentered ALE:}
 For a point $x \in \mathcal{X}_S$, define:
-\[
+$$
 \hat{\tilde{f}}_{S, ALE}(x) = \sum_{k = 1}^{k_S(x)}\frac{1}{n_S(k)}\sum_{i: \; x_S^{(i)} \in \; [z_{k-1, S}, z_{k, S}]}\left[\fh(z_{k, S}, \xi_{-S}) -\fh(z_{k-1, S}, \xi_{-S})\right]
-\]
-
-\begin{itemize}
+$$
+\begin{itemizeM}
 % \tightlist
-  \item $[z_{k-1, S}, z_{k,S}]$: $k$-th interval of feat. $x_S$ with interval bounds $z_{k-1, S}$ and $z_{k,S}$ 
-  \item $k_S(x)$: index of the interval in which $x$ lies
-  \item $n_S(k)$: number of observations in interval $k$
-  \item $\xv_{-S}^{(i)}$: all other features held fixed for $i$-th observation
-\end{itemize}
-
+\item $[z_{k-1, S}, z_{k,S}]$: $k$-th interval of feat. $x_S$ with interval bounds $z_{k-1, S}$ and $z_{k,S}$
+\item $k_S(x)$: index of the interval in which $x$ lies
+\item $n_S(k)$: number of observations in interval $k$
+\item $\xv_{-S}^{(i)}$: all other features held fixed for $i$-th observation
+\end{itemizeM}
 \pause
-\medskip
+\spacer[0.25]
 % \textbf{Centering:}  
 % Ensure identifiability by subtracting the average uncentered ALE:
 % \[
@@ -617,29 +593,26 @@ For a point $x \in \mathcal{X}_S$, define:
 % \hat{\tilde{f}}_{S, \text{ALE}}(x)
 % - \frac{1}{n} \sum_{i = 1}^n \hat{\tilde{f}}_{S, \text{ALE}}(x_S^{(i)})
 % \]
-\textbf{Centering:}  
+\textbf{Centering:}
 Ensure identifiability by subtracting mean uncentered ALE ($c$):
-\[
+$$
 \hat f_{S,\text{ALE}}(x)=
 \hat{\tilde f}_{S,\text{ALE}}(x)\;-\;c,
 \qquad
 c=\tfrac{1}{n}\textstyle\sum_{i=1}^{n}\hat{\tilde f}_{S,\text{ALE}}\bigl(x_S^{(i)}\bigr).
-\]
-
+$$
 %\vspace{0.4em}
 \textbf{Efficient centering (used in implementations):}
 Use weighted trapezoidal averaging of interval-wise boundary values (avoids redundant re-evaluation at all $n$ points):
-\[
+$$
 c =
-\textstyle\sum_{k = 1}^{K} 
-\tfrac{1
-}{2} \cdot \left( 
+\textstyle\sum_{k = 1}^{K}
+\tfrac{1}{2} \cdot \left(
 \hat{\tilde{f}}_{S, \text{ALE}}(z_{k-1,S}) +
-\hat{\tilde{f}}_{S, \text{ALE}}(z_{k,S}) \right) \cdot \tfrac{n_S(k)}{n} 
-\]
-
+\hat{\tilde{f}}_{S, \text{ALE}}(z_{k,S}) \right) \cdot \tfrac{n_S(k)}{n}
+$$
 \textbf{Plotting:} Visualize pairs $\left( z_{k,S}, \hat{f}_{S, \text{ALE}}(z_{k,S}) \right)$ for all interval boundaries $z_{k,S}$.
-\end{frame}
+\end{framev}
 
 %------------------------------------------------------------
 
@@ -720,81 +693,67 @@ c =
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
-\begin{frame}{Bike Sharing Dataset: First Order ALE}
-
+\begin{framev}[align=top]{Bike Sharing Dataset: First Order ALE}
 % Shape of PD plot (top) often looks similar to (centered) first order ALE plot (bottom) but on different $y$-axis scale.
 % In case of correlated features, ALE might be better due to PD's extrapolation issue.
-\begin{itemize}
-  \item \textbf{Visual comparison:} PD plot (top) vs. First-order ALE plot (bottom)
-  \item \textbf{Shape:} Similar trends in both plots; $y$-axis scale differs due to centering
-  \item \textbf{Interpretation:} ALE accounts for feature dependencies and avoids extrapolation into unsupported regions
-  %\item \textbf{Implication:} 
-  \\$\leadsto$ PD reflects model behavior in entire feature space ("true to the model")\\
-  $\leadsto$ ALE focuses on effects in data-supported regions ("true to the data")
-\end{itemize}
-
-\begin{center}
-\includegraphics[width=0.8\textwidth]{figure/ale1d}
-\end{center}
-
-
-\end{frame}
+\begin{itemizeM}
+\item \textbf{Visual comparison:} PD plot (top) vs. First-order ALE plot (bottom)
+\item \textbf{Shape:} Similar trends in both plots; $y$-axis scale differs due to centering
+\item \textbf{Interpretation:} ALE accounts for feature dependencies and avoids extrapolation into unsupported regions
+%\item \textbf{Implication:} 
+\\$\leadsto$ PD reflects model behavior in entire feature space ("true to the model")\\
+$\leadsto$ ALE focuses on effects in data-supported regions ("true to the data")
+\end{itemizeM}
+\imageC[0.8]{figure/ale1d}
+\end{framev}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\begin{frame}{Bike Sharing Dataset: Second Order ALE}
-
+\begin{framev}[align=top]{Bike Sharing Dataset: Second Order ALE}
 %It is possible to estimate higher-order ALEs, e.g., 2nd-order ALEs.
-Unlike bivariate PD plots, 2nd-order ALE plots only estimate pure interaction between two features (1st-order effects are not included).
-
-\vspace{0.1cm}
-
-\begin{center}
-\includegraphics[width=0.8\textwidth]{figure/ale2d}
-\end{center}
-
-\end{frame}
+Unlike bivariate PD plots, 2nd-order ALE plots only estimate pure interaction between two features (1st-order effects are not included).\\
+\spacer[0.25]
+\imageC[0.8]{figure/ale2d}
+\end{framev}
 
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\begin{frame}{PD vs. ALE}
+\begin{framev}[align=top]{PD vs. ALE}
 %$$\int_{z_{0}}^{x} \E_{\xv_{-S} \vert x_S} \Bigg(  \frac{\partial \fh(x_S, \xv_{-S})}{\partial x_S} \bigg \vert x_S = z_S \Bigg) dz_S - const$$
-
-    \textbf{PD:}
-    \centerline{$
-    \begin{aligned}
-      %\hspace{2cm} 
-      f_{S, PD}(x_S) &= \E_{\xv_{-S}} \left( \fh(x_S, \xv_{-S}) \right) %= \int_{-\infty}^{\infty} \fh(x_S, \xv_{-S}) \, d\P(\xv_{-S})
-    \end{aligned}
-    $} \\
-    \lz
-    \textbf{ALE:}
-    \centerline{$
-    \begin{aligned}
-    \only<1>{
-    f_{S, \text{ALE}}(x)
-    &= \int_{z_0}^{x} \E_{\textcolor{blue}{\xv_{-S} \mid x_S = z_S}}
-    \left( \textcolor{purple}{\frac{\partial \hat{f}(z_S, \xv_{-S})}{\partial z_S}} \right) dz - \text{const}
-    }
-    \only<2>{
-    f_{S, \text{ALE}}(x)
-    &= \textcolor{blue}{\int_{z_0}^{x}}
-    \E_{\xv_{-S} \mid x_S = z_S}
-    \left( {\frac{\partial \hat{f}(z_S, \xv_{-S})}{\partial z_S}} \right)
-    \textcolor{blue}{dz} - {\text{const}}
-    }
-    \only<3>{
-    f_{S, \text{ALE}}(x)
-    &= \int_{z_0}^{x}
-    \E_{\xv_{-S} \mid x_S = z_S}
-    \left( \frac{\partial \hat{f}(z_S, \xv_{-S})}{\partial z_S} \right) dz
-    - \textcolor{blue}{\int \tilde{f}_{S, \text{ALE}}(x_S) \, d\P(x_S)}
-    }
-    \end{aligned}
-    $}
-
+\textbf{PD:}
+$$
+\begin{aligned}
+%\hspace{2cm} 
+f_{S, PD}(x_S) &= \E_{\xv_{-S}} \left( \fh(x_S, \xv_{-S}) \right) %= \int_{-\infty}^{\infty} \fh(x_S, \xv_{-S}) \, d\P(\xv_{-S})
+\end{aligned}
+$$
+\lz
+\textbf{ALE:}
+$$
+\begin{aligned}
+\only<1>{
+f_{S, \text{ALE}}(x)
+&= \int_{z_0}^{x} \E_{\textcolor{blue}{\xv_{-S} \mid x_S = z_S}}
+\left( \textcolor{purple}{\frac{\partial \hat{f}(z_S, \xv_{-S})}{\partial z_S}} \right) dz - \text{const}
+}
+\only<2>{
+f_{S, \text{ALE}}(x)
+&= \textcolor{blue}{\int_{z_0}^{x}}
+\E_{\xv_{-S} \mid x_S = z_S}
+\left( {\frac{\partial \hat{f}(z_S, \xv_{-S})}{\partial z_S}} \right)
+\textcolor{blue}{dz} - {\text{const}}
+}
+\only<3>{
+f_{S, \text{ALE}}(x)
+&= \int_{z_0}^{x}
+\E_{\xv_{-S} \mid x_S = z_S}
+\left( \frac{\partial \hat{f}(z_S, \xv_{-S})}{\partial z_S} \right) dz
+- \textcolor{blue}{\int \tilde{f}_{S, \text{ALE}}(x_S) \, d\P(x_S)}
+}
+\end{aligned}
+$$
 %     \centerline{$
 %     \begin{aligned}
 %       \only<1>{%\hspace{1cm}
@@ -820,39 +779,38 @@ Unlike bivariate PD plots, 2nd-order ALE plots only estimate pure interaction be
 % }
 %  \end{aligned}
 %    $}
-    \lz
-    \begin{itemize}
-    \item<1-> Recall: PD directly averages predictions over marginal distribution of $\xv_{-S}$
-    \item<1-> ALE is faster: $O(2 \cdot n)$ model calls vs. $O(n \cdot g)$ for PD with $g$ grid points
-    \only<1>{
-    \item Difference 1: ALE averages 
-    \begin{itemize}
-        \item \textcolor{purple}{prediction changes} (via partial derivatives, estimated by finite differences) 
-        \item over \textcolor{blue}{conditional distribution $\P(\xv_{-S}| x_S = z_S)$}
-    \end{itemize}
-    }
-    \only<2-3>{
-    \item Difference 1: ALE averages the
-        \begin{itemize}
-        \item prediction changes (via partial derivatives, estimated by finite differences) 
-        \item over conditional distribution $\P(\xv_{-S}| x_S = z_S)$
-        \end{itemize}
-    }
-    \only<2>{
-    \item Difference 2: ALE \textcolor{blue}{integrates these partial deriv. over $z_S \in [z_0, x] \subseteq \mathcal{X}_S$ }\\
-    $\leadsto$ isolates effect of \( x_S \) and removes main effect of other dependent feat.
-    }
-    \only<3>{
-    \item Difference 2: ALE integrates these partial deriv. over $z_S \in [z_0, x] \subseteq \mathcal{X}_S$\\
-    %integrates partial derivatives of feature $S$ over $z_S$\\
-    $\leadsto$ isolates effect of \( x_S \) and removes main effect of other dependent feat.
-    }
-    %\item Difference 2: ALE has an additional \textcolor{blue}{integral over $z_S$}. Instead of directly averaging the predictions, the ALE method calculates the prediction differences conditional on features S and integrates the derivative over features $S$ to estimate the effect. The derivative (or interval difference) isolates the effect of the feature of interest and blocks the effect of correlated features.
-    %}
-    \item<3-> Difference 3: ALE is \textcolor{blue}{centered} so that $\E_{x_S} \left( f_{S, ALE}(x) \right) = 0$
-
-    \end{itemize}
-\end{frame}
+\lz
+\begin{itemizeM}
+\item<1-> Recall: PD directly averages predictions over marginal distribution of $\xv_{-S}$
+\item<1-> ALE is faster: $O(2 \cdot n)$ model calls vs. $O(n \cdot g)$ for PD with $g$ grid points
+\only<1>{
+\item Difference 1: ALE averages
+\begin{itemizeS}
+\item \textcolor{purple}{prediction changes} (via partial derivatives, estimated by finite differences)
+\item over \textcolor{blue}{conditional distribution $\P(\xv_{-S}| x_S = z_S)$}
+\end{itemizeS}
+}
+\only<2-3>{
+\item Difference 1: ALE averages the
+\begin{itemizeS}
+\item prediction changes (via partial derivatives, estimated by finite differences)
+\item over conditional distribution $\P(\xv_{-S}| x_S = z_S)$
+\end{itemizeS}
+}
+\only<2>{
+\item Difference 2: ALE \textcolor{blue}{integrates these partial deriv. over $z_S \in [z_0, x] \subseteq \mathcal{X}_S$ }\\
+$\leadsto$ isolates effect of $x_S$ and removes main effect of other dependent feat.
+}
+\only<3>{
+\item Difference 2: ALE integrates these partial deriv. over $z_S \in [z_0, x] \subseteq \mathcal{X}_S$\\
+%integrates partial derivatives of feature $S$ over $z_S$\\
+$\leadsto$ isolates effect of $x_S$ and removes main effect of other dependent feat.
+}
+%\item Difference 2: ALE has an additional \textcolor{blue}{integral over $z_S$}. Instead of directly averaging the predictions, the ALE method calculates the prediction differences conditional on features S and integrates the derivative over features $S$ to estimate the effect. The derivative (or interval difference) isolates the effect of the feature of interest and blocks the effect of correlated features.
+%}
+\item<3-> Difference 3: ALE is \textcolor{blue}{centered} so that $\E_{x_S} \left( f_{S, ALE}(x) \right) = 0$
+\end{itemizeM}
+\end{framev}
 
 
 \endlecture

--- a/slides/feature-effects/slides07-fe-marginal-effects.tex
+++ b/slides/feature-effects/slides07-fe-marginal-effects.tex
@@ -2,14 +2,12 @@
 
 \input{../../style/preamble}
 % Defines macros and environments
- 
 \input{../../latex-math/basic-math}
 \input{../../latex-math/basic-ml}
 
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
 
@@ -20,7 +18,6 @@ Marginal Effects
 }{
 figure_man/me_movement
 }{
-
 \item Why parameter-based interpretations are not always possible for parametric models
 \item How marginal effects can be used in such cases
 \item Drawbacks of marginal effects
@@ -30,30 +27,28 @@ figure_man/me_movement
 
 
 % Interpretation of Simple Models
-\begin{frame}{Interpretation of Simple Models}
-\begin{itemize}
+\begin{framei}[align=top]{Interpretation of Simple Models}
 \item \textbf{Linear Models}:
-\begin{itemize}
+\begin{itemizeS}
 \item Change in $x_j$ by $\Delta x_j$ results in change in $y$ by $\Delta y = \Delta x_j \cdot \theta_j$
 \item Model equation:
-\[
+$$
 y = \theta_0 + \theta_1 x_1 + \dots + \theta_p x_p + \epsilon
-\]
+$$
 \item Default interpretations correspond to $\Delta x_j = 1$, i.e., $\Delta y = \theta_j$
 \item Assumes "ceteris paribus" (all other features held constant)
-\end{itemize}
+\end{itemizeS}
 \pause
 \item \textbf{Non-Linear Models with Interactions}:
-\begin{itemize}
+\begin{itemizeS}
 \item For models with higher-order or interaction terms, single coefficients are not sufficient:
-\[
+$$
 y = \theta_0 + \theta_{1} x_1^2 + \theta_{2} x_2^2 + \theta_{1,2} x_1 x_2 + \epsilon
-\]
+$$
 \item Marginal effect of $x_1$ varies with different values of $x_2$ (and vice versa)
 \item Interactions depend on the values of other features
-\end{itemize}
-\end{itemize}
-\end{frame}
+\end{itemizeS}
+\end{framei}
 
 % \begin{frame}{Interpretation of Simple Models}
 
@@ -109,42 +104,29 @@ y = \theta_0 + \theta_{1} x_1^2 + \theta_{2} x_2^2 + \theta_{1,2} x_1 x_2 + \eps
 % ---------------------------------------------------------------- %
 %  Slide – Marginal Effects: Local flavours & a global summary
 % ---------------------------------------------------------------- %
-\begin{frame}{Marginal Effects (ME)  \furtherreading{BARTUS2005} \furtherreading{SCHOLBECK2024}}
-
-\begin{itemize}\setlength\itemsep{0.45em}
-
+\begin{framei}[align=top]{Marginal Effects (ME) \furtherreading{BARTUS2005} \furtherreading{SCHOLBECK2024}}
 % --- core definition ------------------------------------------------ %
-\item %\textbf{What is a Marginal Effect?}  
+\item %\textbf{What is a Marginal Effect?}
       %Change in the model’s prediction when \emph{one or several} features are nudged.
-MEs measures prediction changes due to varying \emph{one/several} features.
- 
+MEs measure prediction changes due to varying \emph{one/several} features.
 % --- two numerical definitions ------------------------------------- %
-\item \textbf{How to compute it?}  
-      \begin{enumerate}%[--]
-        \item \textbf{Derivative MEs (dMEs)}: \emph{numeric deriv.} (slope of tangent) \\
-              \(\;\leadsto\) needs differentiability, fails for step-wise models.
-        \item \textbf{Forward MEs (fMEs)}: \emph{forward difference} \(\hat f(\boldsymbol x+\boldsymbol h)-\hat f(\boldsymbol x)\)  \\
-        
-              \(\;\leadsto\) works for \emph{any} model, any feature type.
-      \end{enumerate}
-
+\item \textbf{How to compute it?}
+\begin{enumerate}
+\item \textbf{Derivative MEs (dMEs)}: \emph{numeric deriv.} (slope of tangent) \\
+$\leadsto$ needs differentiability, fails for step-wise models.
+\item \textbf{Forward MEs (fMEs)}: \emph{forward difference} $\hat f(\boldsymbol x+\boldsymbol h)-\hat f(\boldsymbol x)$ \\
+$\leadsto$ works for \emph{any} model, any feature type.
+\end{enumerate}
 % --- short caution on dME ------------------------------------------ %
 \item \textbf{Caveat}: dMEs can mislead when the prediction surface is non-smooth (e.g., decision trees); fMEs remain well-defined (due to finite differences).
-
 \pause
 % --- three local instantiations ------------------------------------ %
-\item \textbf{Local instantiations (one number per data point)}  
-\begin{itemize}
-  \item \textbf{ME} (at observed point $\boldsymbol{x}^{(i)}$):  
-        Individual, obs.-specific "what-if" effect.
-
-  \item \textbf{MEM} (at mean $\bar{\boldsymbol{x}}$):  
-        Effect at artificial profile ("average obs.").
-
-  \item \textbf{MER} (at representative value $\boldsymbol{x}^{*}$):  
-        Effect at a user-defined profile.
-\end{itemize}
-
+\item \textbf{Local instantiations (one number per data point)}
+\begin{itemizeS}
+\item \textbf{ME} (at observed point $\boldsymbol{x}^{(i)}$): Individual, obs.-specific "what-if" effect.
+\item \textbf{MEM} (at mean $\bar{\boldsymbol{x}}$): Effect at artificial profile ("average obs.").
+\item \textbf{MER} (at representative value $\boldsymbol{x}^{*}$): Effect at a user-defined profile.
+\end{itemizeS}
       % \begin{description}
       %   \item[\textit{ME}]  at the \emph{observed} vector \(\boldsymbol x^{(i)}\)  
       %         – patient-specific “what-if” effect.
@@ -153,15 +135,10 @@ MEs measures prediction changes due to varying \emph{one/several} features.
       %   \item[\textit{MER}] “at a representative value” \(\boldsymbol x^{*}\)  
       %         – user-chosen scenario or archetype.
       % \end{description}
-
 % --- global summary ------------------------------------------------- %
 \item \textbf{Global summary -- Average Marginal Effect (AME)}:\\
 Expectation of the (d/f)MEs; captures the \emph{global overall} effect.
-
-
-\end{itemize}
-
-\end{frame}
+\end{framei}
 
 
 
@@ -240,75 +217,65 @@ Expectation of the (d/f)MEs; captures the \emph{global overall} effect.
 % \end{frame}
 
 % ----------------------------------------------------------------
-\begin{frame}{Derivative vs.\ Forward Difference}
-
-\begin{columns}[T,onlytextwidth]
+\begin{framev}[align=top]{Derivative vs.\ Forward Difference}
+\splitVTT[0.67]{
 % ----- LEFT COLUMN ----------------------------------------------
-\begin{column}{0.67\textwidth}
 % \begin{itemize}%\setlength\itemsep{0.5em}
   % \item 
-  \textbf{dME (tangent, green)}
-        \begin{itemize}
-            \item slope of the tangent at \(x\);
-            \item delivers a \emph{rate} of change \(\tfrac{\partial\widehat f}{\partial x}\).
-        \end{itemize}
+\textbf{dME (tangent, green)}
+\begin{itemizeM}
+\item slope of the tangent at $x$;
+\item delivers a \emph{rate} of change $\tfrac{\partial\widehat f}{\partial x}$.
+\end{itemizeM}
   % \item 
-  \textbf{fME (secant, orange)}
-        \begin{itemize}
-            \item vertical gap between two model evaluations;
-            \item always \emph{exact} change in predicted outcome.
-            \item Non-linearity measure (pink band, bottom): quantifies deviation of secant and true curve 
+\textbf{fME (secant, orange)}
+\begin{itemizeM}
+\item vertical gap between two model evaluations;
+\item always \emph{exact} change in predicted outcome.
+\item Non-linearity measure (pink band, bottom): quantifies deviation of secant and true curve
             %We can quantify how much fME secant deviates from the true curve -- a quick "non-linearity measure"’ for each fME (purple band, bottom figure)
-        \end{itemize}
-
+\end{itemizeM}
   % \item 
-  \textbf{When the two differ}
-        \begin{itemize}
-            \item Curvature makes the tangent overshoot or undershoot  
-                  \(\Rightarrow\) dME may be badly biased.
-            \item fME is robust to kinks, plateaus, trees, $\dots$
-        \end{itemize}
+\textbf{When the two differ}
+\begin{itemizeM}
+\item Curvature makes the tangent overshoot or undershoot $\Rightarrow$ dME may be badly biased.
+\item fME is robust to kinks, plateaus, trees, $\dots$
+\end{itemizeM}
     %\item<2-> Both lead to information loss about prediction function along the finite difference
     % \item
 \only<2->{\textbf{Recommendations}}
-\begin{itemize}
-    \item<2-> Use fME for any non-linear / non-smooth model
-    \item<2-> Use dME for lin. func.-s or analytic convenience
-\end{itemize}
-
+\begin{itemizeM}
+\item<2-> Use fME for any non-linear / non-smooth model
+\item<2-> Use dME for lin. func.-s or analytic convenience
+\end{itemizeM}
 % \end{itemize}
-
-\end{column}
-
+}{
 % ----- RIGHT COLUMN ---------------------------------------------
-\begin{column}{0.33\textwidth}
-    \centering
-    \includegraphics[width=\linewidth]{figure_man/dme_error.png}\\
-    \scriptsize
-    black = non-lin. function\\
-    blue = fME; pink = dME error
-
-    \includegraphics[width=0.8\linewidth]{figure_man/forward_me_deviation.png}
-\end{column}
+\spacer[0]
+\centering
+\image{figure_man/dme_error.png}\\
+\begin{scriptsize}
+black = non-lin. function\\
+blue = fME; pink = dME error
+\end{scriptsize}
+\image[0.8]{figure_man/forward_me_deviation.png}
 % ---------------------------------------------------------------
-\end{columns}
-\end{frame}
+}
+\end{framev}
 % ----------------------------------------------------------------
 
 
 % Marginal Effects for Continuous Features
-\begin{frame}{ME for Continuous Features}
-\begin{itemize}
+\begin{framei}[align=top]{ME for Continuous Features}
 \item \textbf{Derivative Marginal Effect (dME)}:
-\[
-\text{dME}_j(\xv) = \frac{\partial \fh(\xv)}{\partial x_j} \approx \frac{ \fh(x_1, \dots, x_j + h_j, \dots, x_p) -  \fh(x_1, \dots, x_j - h_j, \dots, x_p)}{2h_j}
-\]
+$$
+\text{dME}_j(\xv) = \frac{\partial \fh(\xv)}{\partial x_j} \approx \frac{\fh(x_1, \dots, x_j + h_j, \dots, x_p) - \fh(x_1, \dots, x_j - h_j, \dots, x_p)}{2h_j}
+$$
 %where $\mathbf{e}_j$ is the unit vector in the $j$-th direction.
 \item \textbf{Forward Marginal Effect (fME)}:
-\[
+$$
 \text{fME}_j(\xv, h_j) = \fh(x_1, \dots, x_j + h_j, \dots, x_p) - \fh(\xv)
-\]
-
+$$
 % \item \textbf{Example Model}:
 % $\fh(\xv)  = \fh(x_1,x_2) = \theta_0 + \theta_{1} x_1^2 + \theta_{2} x_2^2 + \theta_{1,2} x_1 x_2 %+ \epsilon
 % $
@@ -331,22 +298,15 @@ Expectation of the (d/f)MEs; captures the \emph{global overall} effect.
 % %\theta_1 \left( (x_1 + h_1)^2 - x_1^2 \right) + \theta_{1,2} x_2 h_1 = h_{1}(2\theta_{1}x_{1}+\theta_{1}h_{1}+\theta_{1,2}x_{2})
 % $$
 % \end{itemize}
-\end{itemize}
-\begin{itemize}
 \item \textbf{Note:} fME is not scale-invariant -- halving the step size does not halve the effect.
-
-
 \item \textbf{Additive Recovery:} dME and fME isolate terms involving the target feat.
-\begin{itemize}
-\item \textbf{Example:} For $\widehat{f}(\xv) = a x_1 + b x_2$: 
+\begin{itemizeS}
+\item \textbf{Example:} For $\widehat{f}(\xv) = a x_1 + b x_2$:
 $\text{dME}_1(\xv) = a$, \quad $\text{fME}_1(\xv, h_1) = a h_1$
 \item Effects from additively linked features (e.g., $x_2$) are canceled.
 \item Enables focus on direct feature-specific influence in $\widehat{f}$.
-\end{itemize}
-
-\end{itemize}
-
-\end{frame}
+\end{itemizeS}
+\end{framei}
 
 % % Marginal Effects for Categorical Features
 % \begin{frame}{Marginal Effects for Categorical Features}
@@ -369,15 +329,14 @@ $\text{dME}_1(\xv) = a$, \quad $\text{fME}_1(\xv, h_1) = a h_1$
 % \end{frame}
 
 % Marginal Effects for Categorical Features
-\begin{frame}{ME for Categorical Features}
-\begin{itemize}
+\begin{framei}[align=top]{ME for Categorical Features}
 \item \textbf{Traditional Approach}:
-\begin{itemize}
-  \item Choose a baseline category for the categorical feature \(x_j\) \\
-  $\leadsto$ Either the observed value \(x_j\) or a fixed reference \(x_j^\text{ref}\)
-  \item Replace \(x_j\) with an alternative category \(x_j^\text{new}\)
-  \item Compute the change in prediction, keeping all other feat. \(\xv_{-j}\) fixed
-\end{itemize}
+\begin{itemizeS}
+\item Choose a baseline category for the categorical feature $x_j$ \\
+$\leadsto$ Either the observed value $x_j$ or a fixed reference $x_j^\text{ref}$
+\item Replace $x_j$ with an alternative category $x_j^\text{new}$
+\item Compute the change in prediction, keeping all other feat. $\xv_{-j}$ fixed
+\end{itemizeS}
 % \begin{itemize}
 % \item Estimate the change in prediction when a categorical feature switches from an original $x_j$ or a reference category $x_j^\text{ref}$ to another category $x_j^\text{new}$.
 % \item For each observation \(\xv\), hold \(\xv_{-j}\) fixed and vary \(x_j\) across levels.
@@ -388,26 +347,23 @@ $\text{dME}_1(\xv) = a$, \quad $\text{fME}_1(\xv, h_1) = a h_1$
 %   \item Compute prediction differences relative to a fixed reference category \(x_j^{\text{ref}}\).
 %   \item For each observation \(\xv\), compare predictions with \(x_j = x_j^{\text{ref}}\) (or using any other baseline category) versus \(x_j = x_j^{\text{new}}\) while holding \(\xv_{-j}\) fixed.
 % \end{itemize}
-
 \item \textbf{fME Definition for Categorical Features}:\\
-\medskip
-\centerline{$
-\text{fME}_j(\xv; x_j^\text{new}) = \widehat{f}(x_j^\text{new}, \xv_{-j}) - \widehat{f}(x_j, \xv_{-j})$}
-\medskip
-\begin{itemize}
-\item \(x_j\): original category of feature \(j\) in obs. \(\xv\) (or reference category $x_j^\text{ref}$)
-\item \(x_j^\text{new}\): new category to evaluate
-\item \(\xv_{-j}\): all other features held fixed
-\end{itemize}
-
+\spacer[0.25]
+$$
+\text{fME}_j(\xv; x_j^\text{new}) = \widehat{f}(x_j^\text{new}, \xv_{-j}) - \widehat{f}(x_j, \xv_{-j})
+$$
+\begin{itemizeS}
+\item $x_j$: original category of feature $j$ in obs. $\xv$ (or reference category $x_j^\text{ref}$)
+\item $x_j^\text{new}$: new category to evaluate
+\item $\xv_{-j}$: all other features held fixed
+\end{itemizeS}
 \item \textbf{Advantages}:
-\begin{itemize}
+\begin{itemizeS}
 \item Mirrors continuous feature fME: measures discrete change in pred.
 \item Any level can act as baseline - no fixed reference needed.
 %Avoids ambiguity from arbitrary reference-category baselines.
-\end{itemize}
-\end{itemize}
-\end{frame}
+\end{itemizeS}
+\end{framei}
 
 
 
@@ -427,12 +383,12 @@ $\text{dME}_1(\xv) = a$, \quad $\text{fME}_1(\xv, h_1) = a h_1$
 % \end{frame}
 
 
-\begin{frame}{Average Marginal Effects}
-
+\begin{framev}[align=top]{Average Marginal Effects}
 %\footnotesize
-
 \textbf{Definition (based on fMEs with step $\bm h_S$, can also be based on dMEs)}:
-$$\text{AME}_S = \frac{1}{n} \sum_{i=1}^n \big[\fh(\bm x_S^{(i)} + \bm h_S, \bm x_{-S}^{(i)}) - \fh(\bm x^{(i)})\big]$$
+$$
+\text{AME}_S = \frac{1}{n} \sum_{i=1}^n \big[\fh(\bm x_S^{(i)} + \bm h_S, \bm x_{-S}^{(i)}) - \fh(\bm x^{(i)})\big]
+$$
 %\begin{align*}
 %\text{AME}_S &= \frac{1}{n} \sum_{i=1}^n \big[\fh(\bm x_S^{(i)} + \bm h_S, \bm x_{-S}^{(i)}) - \fh(\bm x^{(i)})\big] & \text{Average across all obs. (global summary)}\\
 %\text{MEM}_S &= \fh(\bar{\bm x}_S + \bm h_S, \bar{\bm x}_{-S}) - \fh(\bar{\bm x}) & \text{Effect at sample mean (may be unrealistic)}\\
@@ -446,29 +402,26 @@ $$\text{AME}_S = \frac{1}{n} \sum_{i=1}^n \big[\fh(\bm x_S^{(i)} + \bm h_S, \bm 
 % \item \textbf{MER}: Effect at hand-picked “typical” profile.
 % \end{itemize}
 \textbf{Why they work in GLMs}:
-\begin{itemize}\setlength\itemsep{0.25em}
+\begin{itemizeM}
 \item Link function is monotonic $\Rightarrow$ direction of effect stable.
 \item Averaging gives sensible results (e.g., logit, probit).
-\end{itemize}
-
-\vspace{0.2em}
+\end{itemizeM}
+\spacer[0.25]
 \textbf{Why they fail on non-parametric models}:
-\begin{itemize}%\setlength\itemsep{0.25em}
+\begin{itemizeM}
 \item AMEs assume a consistent effect across the feature space.
 \item Non-parametric models can model complex, non-linear relationships.
 \item Averaging effects can obscure important heterogeneities.
-\end{itemize}
+\end{itemizeM}
 %\item Non-linear $\fh$ may flip sign, saturate, or interact \\$\Rightarrow$ AME $\approx$ 0 despite strong local effects.
 %\item MEM may use invalid input (e.g., "mean gender").
 %\item MER depends on arbitrary choice of profile.
 %\item \textbf{Takeaway:} Use \textbf{cAMEs}, \textbf{LLTRs}, and \textbf{NLMs} to respect heterogeneity.
 %\end{itemize}
-
-\vspace{0.2em}
-\textbf{Takeaway:} AMEs can be useful summaries for smooth, monotonic models.  
+\spacer[0.25]
+\textbf{Takeaway:} AMEs can be useful summaries for smooth, monotonic models.
 For black-boxes, use \textbf{local fMEs} and support them with non-linearity measure.
-
-\end{frame}
+\end{framev}
 
 
 % % Additive Recovery Property
@@ -572,7 +525,7 @@ For black-boxes, use \textbf{local fMEs} and support them with non-linearity mea
 
 %   \item \textbf{High-dimensional changes}: change several features at once (incl. categorical)\\
 %   $\leadsto$ Avoids dimensionality constraints from visualizations (PD/ICE)
-        
+
 %   \item \textbf{Model-faithful:}  
 %         Local to $\xv$; preserves interactions without assumptions.
 %    \item \textbf{Non-Linearity Measure (NLM)}: Complements ME values by quantifying how well a local linear approximation holds. High NLM value indicates that ME is locally reliable - something PD/ICE plots cannot quantify. 
@@ -590,76 +543,64 @@ For black-boxes, use \textbf{local fMEs} and support them with non-linearity mea
 % ---------------------------------------------------------------- %
 %  Slide – Why Marginal Effects still matter
 % ---------------------------------------------------------------- %
-\begin{frame}{Why Marginal Effects \emph{still} matter}
-
-\begin{itemize}\setlength\itemsep{0.55em}
+\begin{framev}[align=top]{Why Marginal Effects \emph{still} matter}
+\begin{itemizeM}
 % ----------------------------------------------------------------
 \item \textbf{Single, formal number:} One \alert{scalar} per observation; can be averaged (AME), reported with CIs, audited, stored easily.
-
 % ----------------------------------------------------------------
-\item \textbf{Multivariate changes}  
-      Simultaneously perturb multiple \emph{continuous/categ.} feat.
-       Still yields a scalar (unlike PD/ICE, which require multivar. plots).
+\item \textbf{Multivariate changes}
+Simultaneously perturb multiple \emph{continuous/categ.} feat.
+Still yields a scalar (unlike PD/ICE, which require multivar. plots).
       %No dimensionality issues from visualizations (PD/ICE).
-
 % ----------------------------------------------------------------
-\item \textbf{Model-faithful, assumption-light}  
-      Measured at the \emph{actual data point}.
-      Captures interactions, no indep. or surrogate-model assumptions (LIME).
-
+\item \textbf{Model-faithful, assumption-light}
+Measured at the \emph{actual data point}.
+Captures interactions, no indep. or surrogate-model assumptions (LIME).
 % ----------------------------------------------------------------
-\item \textbf{Non-Linearity Measure:}  
+\item \textbf{Non-Linearity Measure:}
 Quantifies how well local linear approximation holds (e.g., via a normalized squared deviation from the secant). \\
 $\leadsto$ Local reliability measure, something PD/ICE plots cannot quantify.
 % ----------------------------------------------------------------
-\item \textbf{Computationally cheap}  
-      Just two forward passes (or \(k\!-\!1\) for a \(k\)-level factor) per observation vs.\ grid\(\times n\) for PD/ICE.
-
-\end{itemize}
-
-\vspace{0.3em}
-\textbf{Conclusion:} 
+\item \textbf{Computationally cheap}
+Just two forward passes (or $k\!-\!1$ for a $k$-level factor) per observation vs.\ grid $\times n$ for PD/ICE.
+\end{itemizeM}
+\spacer[0.25]
+\textbf{Conclusion:}
 \begin{center}
-\textbf{Plots let you \emph{see} the landscape;\quad  
+\textbf{Plots let you \emph{see} the landscape;\quad
 ME give numbers you can \emph{use}.}
 \end{center}
-
-\end{frame}
+\end{framev}
 
 % --------------------------------------------------------------- %
 %  Slide – Clinician use-case: Marginal Effects vs ICE/PD
 % --------------------------------------------------------------- %
-\begin{frame}{Use-case: Scalar vs. Visual Estimation}
-
-\textbf{Setting:}  
+\begin{framev}[align=top]{Use-case: Scalar vs. Visual Estimation}
+\textbf{Setting:}\\
 A clinical model predicts heart attack risk from patient features, e.g., $x_1:$ systolic blood pressure (BP), $x_2:$ LDL cholesterol, $x_3:$ age, ...
-
-\vspace{0.5em}
+\\
+\spacer[0.25]
 \textbf{Clinician’s questions}
-\begin{itemize}\setlength\itemsep{0.3em}
-  \item \emph{"What if this patient’s systolic BP increases by 10 mmHg?"}
-  \item \emph{"What if BP increases by 10 mmHg \& LDL by 15 mg/dL?"}
-\end{itemize}
-
-\vspace{0.5em}
+\begin{itemizeM}
+\item \emph{"What if this patient’s systolic BP increases by 10 mmHg?"}
+\item \emph{"What if BP increases by 10 mmHg \& LDL by 15 mg/dL?"}
+\end{itemizeM}
+\spacer[0.25]
 \textbf{Route A – ICE / PD}
-\begin{itemize}
-  \item Plot prediction as a function of BP (1-D) or BP+LDL (2-D) on a grid.
+\begin{itemizeM}
+\item Plot prediction as a function of BP (1-D) or BP+LDL (2-D) on a grid.
   %Visualize effect along 1-D or 2-D feature grid.
-  \item Manual interpretation of change by looking at curve/surface.
-  \item[\(\rightarrow\)] Visual and local; limited to 1–2 features at a time.
-\end{itemize}
-
-\vspace{0.3em}
-\textbf{Route B – Forward Marginal Effect}: $\mathrm{fME}
-  = \widehat f(\xv + \mathbf{h}) - \widehat f(\xv)$
-\begin{itemize}
-  \item \textbf{1-D case:} \(\mathbf{h} = (10, 0, 0, \dots) \;\Rightarrow\;\) risk increases by \textbf{+3 \% points}
-  \item \textbf{2-D case:} \(\mathbf{h} = (10, 15, 0, \dots) \;\Rightarrow\;\) risk increases by \textbf{+4.1 \% points}
-  \item One scalar answer per query, extensible to higher dimensions.
-\end{itemize}
-
-\end{frame}
+\item Manual interpretation of change by looking at curve/surface.
+\item[$\rightarrow$] Visual and local; limited to 1–2 features at a time.
+\end{itemizeM}
+\spacer[0.25]
+\textbf{Route B – Forward Marginal Effect}: $\mathrm{fME} = \widehat f(\xv + \mathbf{h}) - \widehat f(\xv)$
+\begin{itemizeM}
+\item \textbf{1-D case:} $\mathbf{h} = (10, 0, 0, \dots) \;\Rightarrow\;$ risk increases by \textbf{+3 \% points}
+\item \textbf{2-D case:} $\mathbf{h} = (10, 15, 0, \dots) \;\Rightarrow\;$ risk increases by \textbf{+4.1 \% points}
+\item One scalar answer per query, extensible to higher dimensions.
+\end{itemizeM}
+\end{framev}
 
 % % ---------------------------------------------------------------- %
 % %  Slide 1 – Clinician use-case: two interpretation routes
@@ -740,26 +681,24 @@ A clinical model predicts heart attack risk from patient features, e.g., $x_1:$ 
 
 
 % Relation to ICE and PD
-\begin{frame}{Relation to ICE and PD}
-\begin{itemize}
+\begin{framei}[align=top]{Relation to ICE and PD}
 \item \textbf{Individual Conditional Expectation (ICE)}:
-\begin{itemize}
+\begin{itemizeS}
 \item Visualizes predictions for an obs. across a range of feature values.
 \item fME corresponds to vertical diff. between points on an ICE curve.
-\end{itemize}
+\end{itemizeS}
 \item \textbf{Partial Dependence (PD)}:
-\begin{itemize}
+\begin{itemizeS}
 \item Shows average predictions across a range of feature values.
 \item AME is equivalent to vertical differences on PD for linear models.
-\end{itemize}
+\end{itemizeS}
 \item \textbf{Advantages of fMEs}:
-\begin{itemize}
+\begin{itemizeS}
 \item Provide exact change in prediction.
 \item Applicable to high-dimensional feature changes.
 \item Quantifiable and not limited to visual interpretation.
-\end{itemize}
-\end{itemize}
-\end{frame}
+\end{itemizeS}
+\end{framei}
 
 
 

--- a/slides/feature-effects/slides08-resources-and-software.tex
+++ b/slides/feature-effects/slides08-resources-and-software.tex
@@ -1,17 +1,15 @@
-\documentclass[10pt,compress,t,notes=noshow, xcolor=table]{beamer}
-
+\documentclass[10pt,compress,t,notes=noshow,xcolor=table]{beamer}
 
 \input{../../style/preamble}
 \usepackage{siunitx}
 % Defines macros and environments
- 
+
 \input{../../latex-math/basic-math}
 \input{../../latex-math/basic-ml}
 
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
 
@@ -22,45 +20,39 @@ Further Resources and Software
 }{
 figure/01_bike_sharing_dataset_29_0.png
 }{
-
 \item Learn about further resources
 \item Get an overview of software packages in R and Python
-
 }
 
 
-\begin{frame}{Resources and Software:}
+\begin{framev}[align=top]{Resources and Software:}
 \textbf{Individual Conditional Expectation (ICE)}
-\begin{itemize}
-    \item The paper: \furtherreading{GOLDSTEIN2015}
-    \item Chapter in Interpretable Machine Learning book: \furtherreading{MOLNAR2025}
-    \item R packages: \furtherreading{IML}; \furtherreading{PDP}; \furtherreading{ICEBOX}
-    \item Python packages: \furtherreading{PIML}; \furtherreading{SKLEARN}
-\end{itemize}
-
-\medskip
-
+\begin{itemizeM}
+\item The paper: \furtherreading{GOLDSTEIN2015}
+\item Chapter in Interpretable Machine Learning book: \furtherreading{MOLNAR2025}
+\item R packages: \furtherreading{IML}; \furtherreading{PDP}; \furtherreading{ICEBOX}
+\item Python packages: \furtherreading{PIML}; \furtherreading{SKLEARN}
+\end{itemizeM}
+\spacer[0.25]
 \textbf{Partial Dependence (PD) plot}
-\begin{itemize}
-    \item Chapter in Interpretable Machine Learning book: \furtherreading{MOLNAR2025}
-    \item R packages: \furtherreading{IML}; \furtherreading{PDP}; \furtherreading{DALEX}
-    \item Python packages: \furtherreading{SKLEARN}; \furtherreading{EFFECTOR}; \furtherreading{PDPBOX}
-\end{itemize}
-
+\begin{itemizeM}
+\item Chapter in Interpretable Machine Learning book: \furtherreading{MOLNAR2025}
+\item R packages: \furtherreading{IML}; \furtherreading{PDP}; \furtherreading{DALEX}
+\item Python packages: \furtherreading{SKLEARN}; \furtherreading{EFFECTOR}; \furtherreading{PDPBOX}
+\end{itemizeM}
 \textbf{Accumulated Local Effect (ALE)}
-\begin{itemize}
-    \item The paper: \furtherreading{APLEY2020}
-    \item Chapter in Interpretable Machine Learning book: \furtherreading{MOLNAR2025}
-    \item R packages: \furtherreading{ALEPLOT}; \furtherreading{IML}
-    \item Python packages: \furtherreading{EFFECTOR}; \furtherreading{PIML}; \furtherreading{ALEPYTHON}; \furtherreading{ALIBI}
-\end{itemize}
-
+\begin{itemizeM}
+\item The paper: \furtherreading{APLEY2020}
+\item Chapter in Interpretable Machine Learning book: \furtherreading{MOLNAR2025}
+\item R packages: \furtherreading{ALEPLOT}; \furtherreading{IML}
+\item Python packages: \furtherreading{EFFECTOR}; \furtherreading{PIML}; \furtherreading{ALEPYTHON}; \furtherreading{ALIBI}
+\end{itemizeM}
 \textbf{Regional effect plots (REPID)}
-\begin{itemize}
-    \item The paper: \furtherreading{HERBINGER2022}
-    \item Codebase: \furtherreading{REPID}
-\end{itemize}
-\end{frame}
+\begin{itemizeM}
+\item The paper: \furtherreading{HERBINGER2022}
+\item Codebase: \furtherreading{REPID}
+\end{itemizeM}
+\end{framev}
 
 
 \endlecture


### PR DESCRIPTION
## Summary

Clean up the Feature Effects slide deck LaTeX source while preserving slide content and rendered output as closely as practical.

## Changes

- Refactor active slide source across `slides01` through `slides08` in `slides/feature-effects`.
- Normalize frames to project helpers such as `framev` / `framei` with explicit `align=top`.
- Replace raw Beamer layouts with project split helpers where appropriate.
- Normalize list environments to `itemizeM` / `itemizeS`.
- Replace manual vertical spacing commands with `\spacer[...]`.
- Use project image helpers where suitable and keep paths relative to the slide files.
- Clean up title metadata and remove redundant active `\date{}` declarations.
- Preserve commented-out slide content.

## Scope

Changed files:

- `slides/feature-effects/slides01-fe-intro.tex`
- `slides/feature-effects/slides02-fe-ice.tex`
- `slides/feature-effects/slides03-fe-pdp.tex`
- `slides/feature-effects/slides04-fe-pdp-comments.tex`
- `slides/feature-effects/slides05-fe-ale-intro.tex`
- `slides/feature-effects/slides06-fe-ale.tex`
- `slides/feature-effects/slides07-fe-marginal-effects.tex`
- `slides/feature-effects/slides08-resources-and-software.tex`
