### PR TITLE
(refactor slides): Cleanup feature importance

### DIFF
--- a/slides/feature-importance/slides01-fi-intro.tex
+++ b/slides/feature-importance/slides01-fi-intro.tex
@@ -9,7 +9,6 @@
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 %\bibliography{feature-importance}
 
 \begin{document}
@@ -39,57 +38,51 @@ figure_man/feature-importance.png
 	
 	% ------------------------------------------------------------------------------
 
-\begin{frame}{Motivation}
-\begin{itemize}
-  \item<1-3> \textbf{Feature effects} describe how a feature $x_j$ influences the prediction $\hat{y}$
+\begin{framei}[align=top]{Motivation}
+\item<1-3> \textbf{Feature effects} describe how a feature $x_j$ influences the prediction $\hat{y}$
   %describe the relationship of features $x$ with the prediction $\yh$
-  \begin{itemize}
-    \item requires one plot per feature (e.g., PDPs, ALEs)
-    \item purely model-based; ignores true target $y$ %does not take the true target $y$ into account
-  \end{itemize}
-  \item<2-3> \textbf{Feature importance} quantifies how much each $x_j$ contributes to prediction error%methods quantify the relevance of features w.r.t. prediction performance
-  \begin{itemize}
-    \item condenses information into one number per feature
-    \item typically compares prediction errors (involves $y$) with/without feature
+\begin{itemizeS}
+\item requires one plot per feature (e.g., PDPs, ALEs)
+\item purely model-based; ignores true target $y$ %does not take the true target $y$ into account
+\end{itemizeS}
+\item<2-3> \textbf{Feature importance} quantifies how much each $x_j$ contributes to prediction error%methods quantify the relevance of features w.r.t. prediction performance
+\begin{itemizeS}
+\item condenses information into one number per feature
+\item typically compares prediction errors (involves $y$) with/without feature
     % \item condensed to one number per feature
     % \item provides insight into the relationship with $y$
-  \end{itemize}
-  \item<3> \textbf{Clarification:} By \emph{feature importance}, we mean \emph{loss-based} methods that assess a feature's impact via changes in \emph{prediction error}. \\
-  $\leadsto$
-  Other notions exist (e.g., variance-based methods; see \furtherreading{GREENWELL2020}).
+\end{itemizeS}
+\item<3> \textbf{Clarification:} By \emph{feature importance}, we mean \emph{loss-based} methods that assess a feature's impact via changes in \emph{prediction error}. \\
+$\leadsto$
+Other notions exist (e.g., variance-based methods; see \furtherreading{GREENWELL2020}).
   %\textbf{N.B.}: 
   %Here, we use the term feature importance to describe loss-based feature importance methods. In the literature, you may find other notions of ``feature importance'' (e.g., variance-based methods derived from feature effect methods, see also \furtherreading{GREENWELL2020})
-\end{itemize}
-\end{frame}
+\end{framei}
 
-\begin{frame}{Example}
 
-Feature importance provides a condensed summary of feature relevance \\w.r.t. performance
-
-\medskip
-
-\begin{itemize}
-    \item Fit random forest on bike sharing data
-    \item Left: Feature importance ranking by permutation feature importance (PFI)
-    \item Right: Feature effects for all features
-\end{itemize}
-
-\centering
-\begin{columns}[c, totalwidth=\textwidth]
-  \begin{column}{0.37\textwidth}
-\includegraphics[width=.98\linewidth]{figure_man/bike_pfi}
-\end{column}
-  \begin{column}{0.63\textwidth}
-  \includegraphics[width=\linewidth]{figure_man/bike_pdp+ice}
-\end{column}
-\end{columns}
+\begin{framev}[align=top]{Example}
+Feature importance provides a condensed summary of feature relevance \\
+w.r.t. performance \\
+\spacer[0.25]
+\begin{itemizeM}
+\item Fit random forest on bike sharing data
+\item Left: Feature importance ranking by permutation feature importance (PFI)
+\item Right: Feature effects for all features
+\end{itemizeM}
+\spacer[0.25]
+\splitVTT[0.37]{
+\spacer[0]
+\imageC[0.98]{figure_man/bike_pfi}
+}{
+\spacer[0]
+\imageC{figure_man/bike_pdp+ice}
+}
 % \begin{center}
 %   \begin{figure}
 %   \includegraphics[width=0.55\linewidth]{figure_man/bike_pdp+ice} \hfill \includegraphics[width=0.35\linewidth]{figure_man/bike_pfi}
 % \end{figure}
 % \end{center}
-
-\end{frame}
+\end{framev}
 
 % \begin{frame}{Feature Importance Scheme}
 % Loss-based feature importance methods are often based on two concepts
@@ -105,58 +98,49 @@ Feature importance provides a condensed summary of feature relevance \\w.r.t. pe
 % \end{frame}
 
 
-\begin{frame}{Feature Importance - Differences \furtherreading{EWALD2024}}
-Many loss-based feature importance methods exist, which mainly differ in
-
-\medskip
-
+\begin{framev}[align=top]{Feature Importance - Differences \furtherreading{EWALD2024}}
+Many loss-based feature importance methods exist, which mainly differ in \\
+\spacer[0.25]
 \textbf{(1) How they ``remove'' or ``perturb'' the feature of interest (FOI) $X_j$}
-\begin{itemize}
-  \item \textbf{Remove $X_j$ and refit:} Drop the $X_j$ and retrain model without it %(LOCO)
-  \item \textbf{Perturb $X_j$:} Replace $X_j$ by $\tilde X_j$ sampled from  
-        \textit{marginal}/\textit{conditional} distrib. % (PFI/CFI)
-  \item \textbf{Marginalize $X_j$:} integrate out $X_j$ via  
-        \textit{marginal} or \textit{conditional} distribution %(mSAGE/cSAGE)
-\end{itemize}
-
-\pause\medskip
-
+\begin{itemizeM}
+\item \textbf{Remove $X_j$ and refit:} Drop the $X_j$ and retrain model without it %(LOCO)
+\item \textbf{Perturb $X_j$:} Replace $X_j$ by $\tilde X_j$ sampled from \textit{marginal}/\textit{conditional} distrib. % (PFI/CFI)
+\item \textbf{Marginalize $X_j$:} integrate out $X_j$ via \textit{marginal} or \textit{conditional} distribution %(mSAGE/cSAGE)
+\end{itemizeM}
+\pause
+\spacer[0.25]
 \textbf{(2) How they compare model performance before and after feat. removal}
-\begin{itemize}
-     \item \textbf{Compare ``reduced model'' without FOI vs. full model}: \\
-     Measure drop in performance when FOI is ``removed'' \\
-    $\leadsto$ Similar idea as backward feature elimination  % (LOCO, PFI, CFI)
+\begin{itemizeM}
+\item \textbf{Compare ``reduced model'' without FOI vs. full model}: \\
+Measure drop in performance when FOI is ``removed'' \\
+$\leadsto$ Similar idea as backward feature elimination  % (LOCO, PFI, CFI)
      %(backward feature elimination)%\\
      %$\leadsto$ Leave-one-covariate out (LOCO)
-    \item \textbf{Compare ``empty model'' (no features) vs. model with only FOI}: \\
-    Measure gain in performance when only FOI is used \\
-    $\leadsto$ Similar idea as forward feature selection %(LOCI)%\\
+\item \textbf{Compare ``empty model'' (no features) vs. model with only FOI}: \\
+Measure gain in performance when only FOI is used \\
+$\leadsto$ Similar idea as forward feature selection %(LOCI)%\\
      %$\leadsto$ Leave-one-covariate in (LOCI)
-    \item \textbf{Compare models with/without FOI across different feature sets}: \\
-    Measure average contrib. when FOI joins any feat. set (Shapley-based) %(cSAGE, mSAGE)%\\
+\item \textbf{Compare models with/without FOI across different feature sets}: \\
+Measure average contrib. when FOI joins any feat. set (Shapley-based) %(cSAGE, mSAGE)%\\
      %$\leadsto$ Shapley Additive Global Importance (SAGE)
   % \item \emph{Reduced vs. full model:} performance drop when $X_j$ is removed %(LOCO, PFI, CFI)
   % \item \emph{FOI only vs. empty model:} performance gain when only the feature is used %(LOCI)
   % \item \emph{Across all coalitions:} average contribution over every subset 
   % %(mSAGE, cSAGE)
-\end{itemize}
-
-\pause \medskip
-
+\end{itemizeM}
+\pause
+\spacer[0.25]
 \textit{Depending on the different removal/perturbation and comparison strategies, feat. imp. methods provide insight into different aspects of model and data.}
-\end{frame}
+\end{framev}
 
 
-\begin{frame}{Potential Interpretation Goals}
-
-Feature importance methods provide condensed insights, but only into specific aspects of model and data. Interpretation goals often differ and typically address non-overlapping questions (except for special cases).
-
-\lz 
-
+\begin{framev}[align=top]{Potential Interpretation Goals}
+Feature importance methods provide condensed insights, but only into specific aspects of model and data.
+Interpretation goals often differ and typically address non-overlapping questions (except for special cases). \\
+\spacer[0.5]
 For example, one may be interested in getting insight into whether the ...
-
 \begin{enumerate}
-    \item[(1)] feature $x_j$ is causal for the prediction?
+\item[(1)] feature $x_j$ is causal for the prediction?
     % \only<2>{\begin{itemize}
     %   \item Changing feature value $x_j$ has an effect on prediction $\yh = \fh(x)$
     %   \item In LM: non-zero coefficient, in ML: present feature effect
@@ -170,72 +154,70 @@ For example, one may be interested in getting insight into whether the ...
     %       %$\leadsto$ not causal for the ground truth $y$
     %   \end{itemize}
     % \end{itemize}}
-    \item[(2)] feature $x_j$ contains prediction-relevant information about $y$?
-    \item[(3)] model requires access to $x_j$ to achieve its prediction performance?
+\item[(2)] feature $x_j$ contains prediction-relevant information about $y$?
+\item[(3)] model requires access to $x_j$ to achieve its prediction performance?
 \end{enumerate}
-\end{frame}
+\end{framev}
 
 
-\begin{frame}{Example: Causal for the prediction (1)}
+\begin{framev}[align=top]{Example: Causal for the prediction (1)}
 A feature may be causal for $\yh$ (1) without containing prediction-relevant information about $y$ (2)
-\begin{columns}[T, totalwidth = \textwidth]
-  \begin{column}{0.52\linewidth}
+\spacer[0.5]
+\splitVTT[0.49]{
+\spacer[0]
 \resizebox{\linewidth}{!}{%
-  \begin{tikzpicture}[thick, scale=1.1, every node/.style={scale=1, line width=0.25mm, black, fill=white}]
+\begin{tikzpicture}[thick, scale=1.1, every node/.style={scale=1, line width=0.25mm, black, fill=white}]
 		%
-		\node[draw, ellipse, scale=0.7] (x7) at (0, 2) {contacts};
-		\node[draw, ellipse, scale=0.7] (x0) at (0, 1) {trust};
-		\node[draw, ellipse, scale=0.7] (x1) at (0, 0) {vaccinated};
-		\node[draw, ellipse, scale=0.7] (x4) at (0, -1) {test};
+\node[draw, ellipse, scale=0.7] (x7) at (0, 2) {contacts};
+\node[draw, ellipse, scale=0.7] (x0) at (0, 1) {trust};
+\node[draw, ellipse, scale=0.7] (x1) at (0, 0) {vaccinated};
+\node[draw, ellipse, scale=0.7] (x4) at (0, -1) {test};
 		%\node[draw, ellipse, scale=0.7] (x5) at (0, -2) {compliance};
-		\node[draw, ellipse, scale=0.7] (y) at (-1.5,-.5) {$Y$: COVID risk};
-		\node[draw, ellipse, scale=0.7] (x6) at (0, -2) {noise};
-		\draw[dashed,gray] (-2.6,-2.5) -- (1,-2.5) -- (1,2.5) -- (-2.6,2.5) -- cycle;
-		\node[scale=0.7] (dots) at (-0.75,-2.75) {data level};
-		\draw[->] (x0) -- (x1);
-		\draw[->] (x1) -- (y);
-		\draw[->] (y) -- (x4);
+\node[draw, ellipse, scale=0.7] (y) at (-1.5,-.5) {$Y$: COVID risk};
+\node[draw, ellipse, scale=0.7] (x6) at (0, -2) {noise};
+\draw[dashed,gray] (-2.6,-2.5) -- (1,-2.5) -- (1,2.5) -- (-2.6,2.5) -- cycle;
+\node[scale=0.7] (dots) at (-0.75,-2.75) {data level};
+\draw[->] (x0) -- (x1);
+\draw[->] (x1) -- (y);
+\draw[->] (y) -- (x4);
 		%\draw[->] (x5) -- (x4);
-		\draw[->] (x7) -- (y);
+\draw[->] (x7) -- (y);
 		%\draw[-] (xd) -- (y);
 		
-		\node[draw, ellipse, scale=0.7] (ux7) at (2, 2) {\texttt{cnt}};
-		\node[draw, ellipse, scale=0.7] (ux0) at (2, 1) {\texttt{trust}};
-		\node[draw, ellipse, scale=0.7, fill=orange] (ux1) at (2, 0) {\texttt{vac}};
-		\node[draw, ellipse, scale=0.7, fill=orange] (ux4) at (2, -1) {\texttt{test}};
+\node[draw, ellipse, scale=0.7] (ux7) at (2, 2) {\texttt{cnt}};
+\node[draw, ellipse, scale=0.7] (ux0) at (2, 1) {\texttt{trust}};
+\node[draw, ellipse, scale=0.7, fill=orange] (ux1) at (2, 0) {\texttt{vac}};
+\node[draw, ellipse, scale=0.7, fill=orange] (ux4) at (2, -1) {\texttt{test}};
 		%\node[draw, ellipse, scale=0.7, fill=orange] (ux5) at (2,-2) {\texttt{cmpl}};
-        \node[draw, ellipse, scale=0.7, fill=orange] (ux6) at (2,-2) {\texttt{noise}};
-		\draw[dashed,gray] (1.25,-2.5) -- (3.3,-2.5) -- (3.3,2.5) -- (1.25,2.5) -- cycle;
-		\node[scale=0.7] (dots) at (2.3,-2.75) {model level};
-		\draw[->, dotted] (x1) -- (ux1);
-		\draw[->, dotted] (x4) -- (ux4);
-		\draw[->, dotted] (x0) -- (ux0);
+\node[draw, ellipse, scale=0.7, fill=orange] (ux6) at (2,-2) {\texttt{noise}};
+\draw[dashed,gray] (1.25,-2.5) -- (3.3,-2.5) -- (3.3,2.5) -- (1.25,2.5) -- cycle;
+\node[scale=0.7] (dots) at (2.3,-2.75) {model level};
+\draw[->, dotted] (x1) -- (ux1);
+\draw[->, dotted] (x4) -- (ux4);
+\draw[->, dotted] (x0) -- (ux0);
 		%\draw[->, dotted] (x5) -- (ux5);
-		\draw[->, dotted] (x6) -- (ux6);
-		\draw[->, dotted] (x7) -- (ux7);
+\draw[->, dotted] (x6) -- (ux6);
+\draw[->, dotted] (x7) -- (ux7);
 		
-		\node[draw, circle, scale=0.7] (yhat) at (3, -.5) {$\hat{Y}$};
-		\draw[->] (ux1) -- (yhat);
-		\draw[->] (ux4) -- (yhat);
+\node[draw, circle, scale=0.7] (yhat) at (3, -.5) {$\hat{Y}$};
+\draw[->] (ux1) -- (yhat);
+\draw[->] (ux4) -- (yhat);
 		%\draw[->] (ux5) -- (yhat);
-		\draw[->] (ux6) -- (yhat);
+\draw[->] (ux6) -- (yhat);
 \end{tikzpicture}
 }
-  \end{column}
+}{
   %\hspace{0.2cm}
-  \begin{column}{0.55\linewidth}
-
-  \textit{Example:} overfitting due to noisy features
-  \pause
-    \begin{itemize}
-      \item All features used by the model are of interest
-      \item Here: Model uses feature \code{noise}, although it does not contain prediction-relevant information about $y$ (data level)
-      \item[$\Rightarrow$] Overfitted models may use many noise features which are deemed relevant on model level (but not on data level)
-  \end{itemize}
-  \end{column}
-\end{columns}
-
-\end{frame}
+\spacer[0.25]
+\textit{Example:} overfitting due to noisy features
+\pause
+\begin{itemizeM}
+\item All features used by the model are of interest
+\item Here: Model uses feature \code{noise}, although it does not contain prediction-relevant information about $y$ (data level)
+\item[$\Rightarrow$] Overfitted models may use many noise features which are deemed relevant on model level (but not on data level)
+\end{itemizeM}
+}
+\end{framev}
 
 
 % \begin{frame}{Potential Interpretation Goals}
@@ -267,11 +249,11 @@ A feature may be causal for $\yh$ (1) without containing prediction-relevant inf
 
 
 
-\begin{frame}{Example: Prediction-relevant information (2)}
-
-  A feature may contain prediction-relevant information (2) without causing the prediction (1)
-\begin{columns}[T, totalwidth=\textwidth]
-  \begin{column}{0.52\textwidth}
+\begin{framev}[align=top]{Example: Prediction-relevant information (2)}
+A feature may contain prediction-relevant information (2) without causing the prediction (1)
+\spacer[0.5]
+\splitVTT[0.49]{
+\spacer[0]
 %   \begin{figure}
 %   \begin{tikzpicture}[thick, scale=1.1, every node/.style={scale=1, line width=0.25mm, black, fill=white}]
 % 		%
@@ -314,106 +296,101 @@ A feature may be causal for $\yh$ (1) without containing prediction-relevant inf
 % \end{tikzpicture}
 % \end{figure} 
 \resizebox{\linewidth}{!}{%
-  \begin{tikzpicture}[thick, scale=1.1, every node/.style={scale=1, line width=0.25mm, black, fill=white}]
-		%
-		\node[draw, ellipse, scale=0.7, fill=orange] (x7) at (0, 2) {contacts};
-		\node[draw, ellipse, scale=0.7, fill=orange] (x0) at (0, 1) {trust};
-		\node[draw, ellipse, scale=0.7, fill=orange] (x1) at (0, 0) {vaccinated};
-		\node[draw, ellipse, scale=0.7, fill=orange] (x4) at (0, -1) {test};
-		%\node[draw, ellipse, scale=0.7] (x5) at (0, -2) {compliance};
-		\node[draw, ellipse, scale=0.7] (y) at (-1.5,-.5) {$Y$: COVID risk};
-		\node[draw, ellipse, scale=0.7] (x6) at (0, -2) {noise};
-		\draw[dashed,gray] (-2.6,-2.5) -- (1,-2.5) -- (1,2.5) -- (-2.6,2.5) -- cycle;
-		\node[scale=0.7] (dots) at (-0.75,-2.75) {data level};
-		\draw[->] (x0) -- (x1);
-		\draw[->] (x1) -- (y);
-		\draw[->] (y) -- (x4);
-		%\draw[->] (x5) -- (x4);
-		\draw[->] (x7) -- (y);
-		%\draw[-] (xd) -- (y);
-		
-		\node[draw, ellipse, scale=0.7] (ux7) at (2, 2) {\texttt{cnt}};
-		\node[draw, ellipse, scale=0.7] (ux0) at (2, 1) {\texttt{trust}};
-		\node[draw, ellipse, scale=0.7] (ux1) at (2, 0) {\texttt{vac}};
-		\node[draw, ellipse, scale=0.7] (ux4) at (2, -1) {\texttt{test}};
-		%\node[draw, ellipse, scale=0.7] (ux5) at (2,-2) {\texttt{cmpl}};
-        \node[draw, ellipse, scale=0.7] (ux6) at (2,-2) {\texttt{noise}};
-		\draw[dashed,gray] (1.25,-2.5) -- (3.3,-2.5) -- (3.3,2.5) -- (1.25,2.5) -- cycle;
-		\node[scale=0.7] (dots) at (2.3,-2.75) {model level};
-		\draw[->, dotted] (x1) -- (ux1);
-		\draw[->, dotted] (x4) -- (ux4);
-		\draw[->, dotted] (x0) -- (ux0);
-		%\draw[->, dotted] (x5) -- (ux5);
-		\draw[->, dotted] (x6) -- (ux6);
-		\draw[->, dotted] (x7) -- (ux7);
-		
-		\node[draw, circle, scale=0.7] (yhat) at (3, -.5) {$\hat{Y}$};
-		\draw[->] (ux1) -- (yhat);
-		\draw[->] (ux4) -- (yhat);
-		%\draw[->] (ux5) -- (yhat);
-		\draw[->] (ux6) -- (yhat);
+\begin{tikzpicture}[thick, scale=1.1, every node/.style={scale=1, line width=0.25mm, black, fill=white}]
+			%
+\node[draw, ellipse, scale=0.7, fill=orange] (x7) at (0, 2) {contacts};
+\node[draw, ellipse, scale=0.7, fill=orange] (x0) at (0, 1) {trust};
+\node[draw, ellipse, scale=0.7, fill=orange] (x1) at (0, 0) {vaccinated};
+\node[draw, ellipse, scale=0.7, fill=orange] (x4) at (0, -1) {test};
+			%\node[draw, ellipse, scale=0.7] (x5) at (0, -2) {compliance};
+\node[draw, ellipse, scale=0.7] (y) at (-1.5,-.5) {$Y$: COVID risk};
+\node[draw, ellipse, scale=0.7] (x6) at (0, -2) {noise};
+\draw[dashed,gray] (-2.6,-2.5) -- (1,-2.5) -- (1,2.5) -- (-2.6,2.5) -- cycle;
+\node[scale=0.7] (dots) at (-0.75,-2.75) {data level};
+\draw[->] (x0) -- (x1);
+\draw[->] (x1) -- (y);
+\draw[->] (y) -- (x4);
+			%\draw[->] (x5) -- (x4);
+\draw[->] (x7) -- (y);
+			%\draw[-] (xd) -- (y);
+\node[draw, ellipse, scale=0.7] (ux7) at (2, 2) {\texttt{cnt}};
+\node[draw, ellipse, scale=0.7] (ux0) at (2, 1) {\texttt{trust}};
+\node[draw, ellipse, scale=0.7] (ux1) at (2, 0) {\texttt{vac}};
+\node[draw, ellipse, scale=0.7] (ux4) at (2, -1) {\texttt{test}};
+			%\node[draw, ellipse, scale=0.7] (ux5) at (2,-2) {\texttt{cmpl}};
+\node[draw, ellipse, scale=0.7] (ux6) at (2,-2) {\texttt{noise}};
+\draw[dashed,gray] (1.25,-2.5) -- (3.3,-2.5) -- (3.3,2.5) -- (1.25,2.5) -- cycle;
+\node[scale=0.7] (dots) at (2.3,-2.75) {model level};
+\draw[->, dotted] (x1) -- (ux1);
+\draw[->, dotted] (x4) -- (ux4);
+\draw[->, dotted] (x0) -- (ux0);
+			%\draw[->, dotted] (x5) -- (ux5);
+\draw[->, dotted] (x6) -- (ux6);
+\draw[->, dotted] (x7) -- (ux7);
+\node[draw, circle, scale=0.7] (yhat) at (3, -.5) {$\hat{Y}$};
+\draw[->] (ux1) -- (yhat);
+\draw[->] (ux4) -- (yhat);
+			%\draw[->] (ux5) -- (yhat);
+\draw[->] (ux6) -- (yhat);
 \end{tikzpicture}
 }
-  \end{column}
+}{
+\spacer[0.25]
   %\hspace{0.2cm}
-  \begin{column}{0.51\textwidth}
-  \textit{Example:} underfitting, model multiplicity
+\textit{Example:} underfitting, model multiplicity
   %\lz
-  \pause
-      \begin{itemize}
-      \item All prediction-relevant features for $y$ are of interest
-      \item Example: All features that are directly or indirectly (i.e., via another feature) connected to $y$ 
-      \item[$\Rightarrow$] Underfitted models may ignore prediction-relevant features such as \code{contacts} here
-  \end{itemize}
-  \end{column}
-\end{columns}
-\end{frame}
+\pause
+\begin{itemizeM}
+\item All prediction-relevant features for $y$ are of interest
+\item Example: All features that are directly or indirectly (i.e., via another feature) connected to $y$
+\item[$\Rightarrow$] Underfitted models may ignore prediction-relevant features such as \code{contacts} here
+\end{itemizeM}
+}
+\end{framev}
 
 
-\begin{frame}{Example: Requires Access to Feature (3)}
-  A feature may contain prediction-relevant information (2), without the model requiring access to the feature for (optimal) prediction performance (3)
-
-\begin{columns}[T, totalwidth=\textwidth]
-  \begin{column}{0.52\textwidth}
-  \resizebox{\linewidth}{!}{%
-  \begin{tikzpicture}[thick, scale=1.1, every node/.style={scale=1, line width=0.25mm, black, fill=white}]
-		%
-		\node[draw, ellipse, scale=0.7, fill=orange] (x7) at (0, 2) {contacts};
-		\node[draw, ellipse, scale=0.7] (x0) at (0, 1) {trust};
-		\node[draw, ellipse, scale=0.7, fill=orange] (x1) at (0, 0) {vaccinated};
-		\node[draw, ellipse, scale=0.7, fill=orange] (x4) at (0, -1) {test};
-		%\node[draw, ellipse, scale=0.7] (x5) at (0, -2) {compliance};
-		\node[draw, ellipse, scale=0.7] (y) at (-1.5,-.5) {$Y$: COVID risk};
-		\node[draw, ellipse, scale=0.7] (x6) at (0, -2) {noise};
-		\draw[dashed,gray] (-2.6,-2.5) -- (1,-2.5) -- (1,2.5) -- (-2.6,2.5) -- cycle;
-		\node[scale=0.7] (dots) at (-0.75,-2.75) {data level};
-		\draw[->] (x0) -- (x1);
-		\draw[->] (x1) -- (y);
-		\draw[->] (y) -- (x4);
-		%\draw[->] (x5) -- (x4);
-		\draw[->] (x7) -- (y);
-		%\draw[-] (xd) -- (y);
-		
-		\node[draw, ellipse, scale=0.7] (ux7) at (2, 2) {\texttt{cnt}};
-		\node[draw, ellipse, scale=0.7] (ux0) at (2, 1) {\texttt{trust}};
-		\node[draw, ellipse, scale=0.7] (ux1) at (2, 0) {\texttt{vac}};
-		\node[draw, ellipse, scale=0.7] (ux4) at (2, -1) {\texttt{test}};
-		%\node[draw, ellipse, scale=0.7] (ux5) at (2,-2) {\texttt{cmpl}};
-        \node[draw, ellipse, scale=0.7] (ux6) at (2,-2) {\texttt{noise}};
-		\draw[dashed,gray] (1.25,-2.5) -- (3.3,-2.5) -- (3.3,2.5) -- (1.25,2.5) -- cycle;
-		\node[scale=0.7] (dots) at (2.3,-2.75) {model level};
-		\draw[->, dotted] (x1) -- (ux1);
-		\draw[->, dotted] (x4) -- (ux4);
-		\draw[->, dotted] (x0) -- (ux0);
-		%\draw[->, dotted] (x5) -- (ux5);
-		\draw[->, dotted] (x6) -- (ux6);
-		\draw[->, dotted] (x7) -- (ux7);
-		
-		\node[draw, circle, scale=0.7] (yhat) at (3, -.5) {$\hat{Y}$};
-		\draw[->] (ux1) -- (yhat);
-		\draw[->] (ux4) -- (yhat);
-		%\draw[->] (ux5) -- (yhat);
-		\draw[->] (ux6) -- (yhat);
+\begin{framev}[align=top]{Example: Requires Access to Feature (3)}
+A feature may contain prediction-relevant information (2), without the model requiring access to the feature for (optimal) prediction performance (3)
+\spacer[0.5]
+\splitVTT[0.49]{
+\spacer[0]
+\resizebox{\linewidth}{!}{%
+\begin{tikzpicture}[thick, scale=1.1, every node/.style={scale=1, line width=0.25mm, black, fill=white}]
+			%
+\node[draw, ellipse, scale=0.7, fill=orange] (x7) at (0, 2) {contacts};
+\node[draw, ellipse, scale=0.7] (x0) at (0, 1) {trust};
+\node[draw, ellipse, scale=0.7, fill=orange] (x1) at (0, 0) {vaccinated};
+\node[draw, ellipse, scale=0.7, fill=orange] (x4) at (0, -1) {test};
+			%\node[draw, ellipse, scale=0.7] (x5) at (0, -2) {compliance};
+\node[draw, ellipse, scale=0.7] (y) at (-1.5,-.5) {$Y$: COVID risk};
+\node[draw, ellipse, scale=0.7] (x6) at (0, -2) {noise};
+\draw[dashed,gray] (-2.6,-2.5) -- (1,-2.5) -- (1,2.5) -- (-2.6,2.5) -- cycle;
+\node[scale=0.7] (dots) at (-0.75,-2.75) {data level};
+\draw[->] (x0) -- (x1);
+\draw[->] (x1) -- (y);
+\draw[->] (y) -- (x4);
+			%\draw[->] (x5) -- (x4);
+\draw[->] (x7) -- (y);
+			%\draw[-] (xd) -- (y);
+\node[draw, ellipse, scale=0.7] (ux7) at (2, 2) {\texttt{cnt}};
+\node[draw, ellipse, scale=0.7] (ux0) at (2, 1) {\texttt{trust}};
+\node[draw, ellipse, scale=0.7] (ux1) at (2, 0) {\texttt{vac}};
+\node[draw, ellipse, scale=0.7] (ux4) at (2, -1) {\texttt{test}};
+			%\node[draw, ellipse, scale=0.7] (ux5) at (2,-2) {\texttt{cmpl}};
+\node[draw, ellipse, scale=0.7] (ux6) at (2,-2) {\texttt{noise}};
+\draw[dashed,gray] (1.25,-2.5) -- (3.3,-2.5) -- (3.3,2.5) -- (1.25,2.5) -- cycle;
+\node[scale=0.7] (dots) at (2.3,-2.75) {model level};
+\draw[->, dotted] (x1) -- (ux1);
+\draw[->, dotted] (x4) -- (ux4);
+\draw[->, dotted] (x0) -- (ux0);
+			%\draw[->, dotted] (x5) -- (ux5);
+\draw[->, dotted] (x6) -- (ux6);
+\draw[->, dotted] (x7) -- (ux7);
+\node[draw, circle, scale=0.7] (yhat) at (3, -.5) {$\hat{Y}$};
+\draw[->] (ux1) -- (yhat);
+\draw[->] (ux4) -- (yhat);
+			%\draw[->] (ux5) -- (yhat);
+\draw[->] (ux6) -- (yhat);
 \end{tikzpicture}
 }
 %   \begin{figure}
@@ -457,58 +434,53 @@ A feature may be causal for $\yh$ (1) without containing prediction-relevant inf
 % 		\draw[->] (ux6) -- (yhat);
 % \end{tikzpicture}
 % \end{figure} 
-  \end{column}
+}{
+\spacer[0.25]
   %\hspace{0.2cm}
-  \begin{column}{0.48\textwidth}
-
-   \textit{Example:} correlations, confounding
-  
-  \pause
-      \begin{itemize}
-      \item All unique prediction-relevant features for $y$ are of interest
-      \item Example: All features that are directly connected to $y$
-      \item[$\Rightarrow$] \code{trust} and \code{vaccinated} may be correlated but only \code{vaccinated} is directly connected to $y$
-  \end{itemize}
-  \end{column}
-\end{columns}  
-\end{frame}
+\textit{Example:} correlations, confounding
+\pause
+\begin{itemizeM}
+\item All unique prediction-relevant features for $y$ are of interest
+\item Example: All features that are directly connected to $y$
+\item[$\Rightarrow$] \code{trust} and \code{vaccinated} may be correlated but only \code{vaccinated} is directly connected to $y$
+\end{itemizeM}
+}
+\end{framev}
 
 
-\begin{frame}{Potential Interpretation Goals}
-
-
+\begin{framev}[align=top]{Potential Interpretation Goals}
 For example, one may be interested in getting insight into whether the ...
-
 \begin{enumerate}
-   \item[(1)] feature $x_j$ is causal for the prediction?
-          \begin{itemize}
-          \item A symptom may help predict a disease ($\leadsto$ causal for $\hat{y}$) %A disease symptom may be used in a model to predict disease status \\
-          %$\leadsto$ causal for prediction $\yh$
-          \item Intervening on symptom may not affect disease ($\leadsto$ not causal for $y$)
-          %But intervening on disease symptom does not have an effect on the disease \\
-          %$\leadsto$ not causal for the ground truth $y$
-      \end{itemize}
-    \item[(2)] feature $x_j$ contains prediction-relevant information about $y$?
-    \begin{itemize}
-      \item $x_j$ helps predict $y$ (e.g., conditional expectation) w.r.t. performance 
-      %, as measured by the difference in expected loss
-      %%\item e.g. when $\E[y|x_j] \neq \E[y]$ for models that minimize MSE
-      %\item feature selection terminology: \textit{weak relevance} \furtherreading{PELLET2008}
-      \item If $x_j \indep y$, then $\E[y|x_j] = \E[y]$ and $x_j$ and $y$ have 0 mutual info.\\ %and therefore cannot contain 
-      $\leadsto$ $x_j$ carries no prediction-relevant information
-    \end{itemize}
-    \item[(3)] model requires access to $x_j$ to achieve its prediction performance?
-    \begin{itemize}
-      \item $x_{j}$ helps predict $y$ w.r.t. performance, compared to using only $x_{-j}$  %, as measured by the difference in expected loss
-      %%\item e.g. when $\E[y|x_{-j}] \neq \E[y|x_j, x_{-j}]$ for models that minimize MSE
-      %\item feature selection terminology: \textit{strong relevance} \furtherreading{PELLET2008}
-      \item If $x_j \indep y | x_{-j}$, then $\E[y|x_{-j}] = \E[y|x_j, x_{-j}]$ \\
-      $\leadsto$ $x_j$ does not contribute unique prediction-relevant information about $y$
-      \item \textbf{Note:} A model may rely on features that can be replaced with others, e.g., if $\E[y \mid x_1] \neq \E[y]$ and $\E[y \mid x_1] = \E[y \mid x_1, x_2]$, a random forest may ignore $x_1$ in splitting and rely on $x_2$ instead (despite $x_1$ being informative).
-      %\textbf{Note:} A model may rely on features that can be replaced with others, e.g., a random forest fitted on data with $\E[y|x_1] \neq \E[y]$ and $\E[y|x_1] = \E[y|x_1, x_2]$ where $x_1$ was not used as split variable may rely on $x_2$ %was not sampled as potential split variable may rely on $x_2$.
-    \end{itemize}
+\item[(1)] feature $x_j$ is causal for the prediction?
+\begin{itemizeS}
+\item A symptom may help predict a disease ($\leadsto$ causal for $\hat{y}$) %A disease symptom may be used in a model to predict disease status \\
+	          %$\leadsto$ causal for prediction $\yh$
+\item Intervening on symptom may not affect disease ($\leadsto$ not causal for $y$)
+	          %But intervening on disease symptom does not have an effect on the disease \\
+	          %$\leadsto$ not causal for the ground truth $y$
+\end{itemizeS}
+\item[(2)] feature $x_j$ contains prediction-relevant information about $y$?
+\begin{itemizeS}
+\item $x_j$ helps predict $y$ (e.g., conditional expectation) w.r.t. performance
+	      %, as measured by the difference in expected loss
+	      %%\item e.g. when $\E[y|x_j] \neq \E[y]$ for models that minimize MSE
+	      %\item feature selection terminology: \textit{weak relevance} \furtherreading{PELLET2008}
+\item If $x_j \indep y$, then $\E[y|x_j] = \E[y]$ and $x_j$ and $y$ have 0 mutual info.\\ %and therefore cannot contain
+$\leadsto$ $x_j$ carries no prediction-relevant information
+\end{itemizeS}
+\item[(3)] model requires access to $x_j$ to achieve its prediction performance?
+\begin{itemizeS}
+\item $x_j$ helps predict $y$ w.r.t. performance, compared to using only $x_{-j}$  %, as measured by the difference in expected loss
+	      %%\item e.g. when $\E[y|x_{-j}] \neq \E[y|x_j, x_{-j}]$ for models that minimize MSE
+	      %\item feature selection terminology: \textit{strong relevance} \furtherreading{PELLET2008}
+\item If $x_j \indep y | x_{-j}$, then $\E[y|x_{-j}] = \E[y|x_j, x_{-j}]$ \\
+\spacer[0]
+$\leadsto$ $x_j$ does not contribute unique prediction-relevant information about $y$
+\item \textbf{Note:} A model may rely on features that can be replaced with others, e.g., if $\E[y \mid x_1] \neq \E[y]$ and $\E[y \mid x_1] = \E[y \mid x_1, x_2]$, a random forest may ignore $x_1$ in splitting and rely on $x_2$ instead (despite $x_1$ being informative).
+	      %\textbf{Note:} A model may rely on features that can be replaced with others, e.g., a random forest fitted on data with $\E[y|x_1] \neq \E[y]$ and $\E[y|x_1] = \E[y|x_1, x_2]$ where $x_1$ was not used as split variable may rely on $x_2$ %was not sampled as potential split variable may rely on $x_2$.
+\end{itemizeS}
 \end{enumerate}
-\end{frame}
+\end{framev}
 
 
 % \begin{frame}{Potential Interpretation Goals}

--- a/slides/feature-importance/slides02-fi-pfi.tex
+++ b/slides/feature-importance/slides02-fi-pfi.tex
@@ -6,13 +6,11 @@
 \input{../../latex-math/ml-interpretable.tex}
 
 % Defines macros and environments
- 
 
 
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 %\bibliography{feature-importance}
 %\usepackage{Sweave}
@@ -28,18 +26,18 @@ figure_man/feature-importance.png
 \item Understand how PFI is computed
 \item Understanding strengths and weaknesses
 }
-    	
+
 	% Set style/preamble.Rnw as parent.
-	
+
 	% Load all R packages and set up knitr
-	
-	% This file loads R packages, configures knitr options and sets preamble.Rnw as 
+
+% This file loads R packages, configures knitr options and sets preamble.Rnw as
 	% parent file
 	% IF YOU MODIFY THIS, PLZ ALSO MODIFY setup.Rmd ACCORDINGLY...
-	
+
 	% Defines macros and environments
 
-	
+
 	% ------------------------------------------------------------------------------
 
 % \begin{frame}{Permutation Feature Importance Idea \furtherreading{BREIMAN2001}}
@@ -68,44 +66,35 @@ figure_man/feature-importance.png
 
 
 
-\begin{frame}{Motivation for PFI}
-
-
-\begin{itemize}
-  \item<1-> \textbf{Goal:} Assess how important feature(s) $X_S$ are for predictive performance of a \textbf{fixed trained model} $\fh$ on a given dataset $\D$
-  \item<1-> \textbf{Idea:} Estimate performance change when $X_S$ is "made uninformative"
-  \item<2-> \textbf{Question:} Can we make $X_S$ uninformative by removing it from  model?\\
-  $\leadsto$ No, $\fh$ was trained with $X_S$; retraining without $X_S$ gives a  different model
-  %$\fh$ is already trained using $X_S$, i.e., we cannot remove $X_S$ without retraining
-  %\item \textbf{Solution:} \textbf{Perturb $X_S$} by replacing $x_S$ with a \textbf{random permutation} $\tilde{x}_S$\\
+\begin{framei}[align=top]{Motivation for PFI}
+\item<1-> \textbf{Goal:} Assess how important feature(s) $X_S$ are for predictive performance of a \textbf{fixed trained model} $\fh$ on a given dataset $\D$
+\item<1-> \textbf{Idea:} Estimate performance change when $X_S$ is "made uninformative"
+\item<2-> \textbf{Question:} Can we make $X_S$ uninformative by removing it from model?\\
+$\leadsto$ No, $\fh$ was trained with $X_S$; retraining without $X_S$ gives a different model
+%$\fh$ is already trained using $X_S$, i.e., we cannot remove $X_S$ without retraining
+%\item \textbf{Solution:} \textbf{Perturb $X_S$} by replacing $x_S$ with a \textbf{random permutation} $\tilde{x}_S$\\
 %$\leadsto$ Breaks dependence with $y$, preserves marginal $\mathbb{P}(X_S)$
-  \item<3-> 
+\item<3->
 \textbf{Solution:} Simulate feature removal by replacing $X_S$ with a perturbed version $\tilde{X}_S$ that is independent of $(X_{-S}, Y)$ but preserves distrib. $\mathbb{P}(X_S)$\\
-  $\leadsto$ Compare {\color{blue}baseline predictions $\fh(X)$} with {\color{red}perturbed predictions $\fh(\tilde{X}_S, X_{-S})$}
-  
-  
+$\leadsto$ Compare {\color{blue}baseline predictions $\fh(X)$} with {\color{red}perturbed predictions $\fh(\tilde{X}_S, X_{-S})$}
 %\textbf{Solution:} "Destroy" information of $X_S$ by replacing it with a perturbed $\Tilde{X}_{S}$ (i.i.d. copy of $X_S$ independent of $(X_{-S},Y)$)
 %Estimate the added predictive value of feature(s) $X_S$ for a given trained model $\fh$, test data $\D$, test data $\D$ where $X_S$ was replaced by $\Tilde{X}_{S}$ by:
 %and compare {\color{red}reduced model where $X_S$ is made uninformative $\fh(\Tilde{X}_{S}, X_{-S})$} vs. {\color{blue}full model $\fh(X)$}:
-
-\[
+$$
 \text{PFI}_S :=
- {\color{red}\underbrace{\mathbb{E}\Big[L\big(\fh(\tilde{X}_S, X_{-S}), Y\big)\Big]}_{\text{risk after "destroying" }X_S}}
- -
- {\color{blue}\underbrace{\mathbb{E}\Big[L\big(\fh(X), Y\big)\Big]}_{\text{baseline risk}}},
-\]
+{\color{red}\underbrace{\mathbb{E}\Big[L\big(\fh(\tilde{X}_S, X_{-S}), Y\big)\Big]}_{\text{risk after "destroying" }X_S}}
+-
+{\color{blue}\underbrace{\mathbb{E}\Big[L\big(\fh(X), Y\big)\Big]}_{\text{baseline risk}}},
+$$
 %where $(X,Y)\sim\mathcal{P}$ and
 %$\tilde{X}_S$ is an i.i.d. copy of $X_S$ independent of $(X_{-S},Y)$\\
 %$\rightarrow$ breaks associations between $X_S$ and $Y$ while preserving the marginal $\mathbb{P}(X_S)$
-  \item<3-> \textbf{How to perturb $X_S$?}
-  \begin{itemize}
-    \item Add random noise: distorts $\mathbb{P}(X_S)$ (not used)
-    \item Permutation: preserves marginal $\mathbb{P}(X_S)$, breaks dependence with $Y$ (used)
-  \end{itemize}
-
-\end{itemize}
-
-\end{frame}
+\item<3-> \textbf{How to perturb $X_S$?}
+\begin{itemizeS}
+\item Add random noise: distorts $\mathbb{P}(X_S)$ (not used)
+\item Permutation: preserves marginal $\mathbb{P}(X_S)$, breaks dependence with $Y$ (used)
+\end{itemizeS}
+\end{framei}
 
 
 % \begin{frame}{Permutation Feature Importance (PFI) \furtherreading{BREIMAN2001}}
@@ -126,36 +115,31 @@ figure_man/feature-importance.png
 % $\rightarrow$ breaks associations between $X_S$ and $Y$ while preserving the marginal $\mathbb{P}(X_S)$
 % \end{frame}
 
-\begin{frame}{Permutation Feature Importance (PFI) \furtherreading{BREIMAN2001}}
+\begin{framev}[align=top]{Permutation Feature Importance (PFI) \furtherreading{BREIMAN2001}}
 \textbf{Sample estimator (using independent test set $\D=\{(\xv^{(i)},y^{(i)})\}_{i=1}^{n}$)}
-
-\begin{itemize}
-  \item Measure error {\color{blue}\textbf{with feat. values $x_S$}} and {\color{red}\textbf{with permuted feat. values $\pert{x}{}{}_S$}} 
-  \item Repeat permutation (e.g., $m$ times) and average difference of both errors: 
-
+\begin{itemizeM}
+\item Measure error {\color{blue}\textbf{with feat. values $x_S$}} and {\color{red}\textbf{with permuted feat. values $\pert{x}{}{}_S$}}
+\item Repeat permutation (e.g., $m$ times) and average difference of both errors:
 $$
 \widehat{PFI}_S = \tfrac{1}{m}  \textstyle\sum\nolimits_{k = 1}^{m} \big[ \riske (\fh, {\color{red}\pert{\D}{S}{}_{(k)}}) - \riske (\fh, {\color{blue}\D}) \big]
 %, \quad \riske(\fh, \D) = \frac{1}{n} \sum\limits_{(x, y) \in \D}  L(\fh(x), y)
 $$
-
-\begin{itemize}
-  \item $\D^{(k)}_{\,S}$: dataset with column(s) $x_S$ are \textbf{permuted} once (in repetition\ $k$)  
-  \item $\riske(\fh, \D) = \frac{1}{n} \sum\nolimits_{(x, y) \in \D}  L(\fh(x), y)$: Measures performance of $\fh$ using $\D$
-  \item Average over $m$ permutations to reduce Monte-Carlo variance
-\end{itemize}
-\end{itemize}
-
-\medskip
-
+\begin{itemizeS}
+\item $\D^{(k)}_{\,S}$: dataset with column(s) $x_S$ are \textbf{permuted} once (in repetition\ $k$)
+\item $\riske(\fh, \D) = \frac{1}{n} \sum\nolimits_{(x, y) \in \D}  L(\fh(x), y)$: Measures performance of $\fh$ using $\D$
+\item Average over $m$ permutations to reduce Monte-Carlo variance
+\end{itemizeS}
+\end{itemizeM}
+\spacer[0.25]
 \textbf{Example} of permuting feature $x_S$ with $S = \{1\}$ and $m=6$ permutations:
-
-\centering 
-\includegraphics[width=0.9\textwidth]{figure_man/permuted-fv.pdf}\\
-{\scriptsize
+{\centering
+\image[0.9]{figure_man/permuted-fv.pdf}\\
+\begin{scriptsize}
 Note: $S$ refers to a subset of features, here $|S|=1$ to measure impact of permuting $x_1$ on performance
 %$S$ refers to a subset of features (here: $|S|=1$). We assess the impact of permuting $x_S$ on model performance.
-}
-\end{frame}
+\end{scriptsize}
+\par}
+\end{framev}
 
 
 % \begin{frame}{Permutation Feature Importance (PFI) \furtherreading{BREIMAN2001}}
@@ -241,96 +225,85 @@ Note: $S$ refers to a subset of features, here $|S|=1$ to measure impact of perm
 
 
 
-\begin{frame}{Permutation Feature Importance}
-
-  \only<1-4>{$\hspace{30pt}{\color{white}\riske(\fh, {\color{red}\pert{\D}{S}{}_{(k)}}) - \riske(\fh, {\color{blue}\D})}$}%
-  \only<5-6>{$\hspace{30pt}\riske(\fh, {\color{red}\pert{\D}{S}{}_{(k)}}) - \riske(\fh, {\color{blue}\D})$}%
+\begin{framev}[align=top]{Permutation Feature Importance}
+\only<1-4>{$\hspace{30pt}{\color{white}\riske(\fh, {\color{red}\pert{\D}{S}{}_{(k)}}) - \riske(\fh, {\color{blue}\D})}$}%
+\only<5-6>{$\hspace{30pt}\riske(\fh, {\color{red}\pert{\D}{S}{}_{(k)}}) - \riske(\fh, {\color{blue}\D})$}%
 % $\scriptstyle\riske(\fh, \D) =$ \scalebox{0.7}{$\frac{1}{n} \sum\nolimits_{(x, y) \in \D}$} $\scriptstyle L(\fh(x), y)$}
 %   \only<5-6>{$\hspace{36pt}{\color{white}\riske(\fh, {\color{red}\pert{\D}{S}{}_{(k)}}) - \riske(\fh, {\color{blue}\D})}$}
-  
-{\centering
-  \only<1>{\includegraphics[page=2, trim=0pt 5pt 0 66pt, clip, width=0.9\textwidth]{figure_man/pfi_demo2}}%
-  \only<2>{\includegraphics[page=3, trim=0pt 5pt 0 66pt, clip, width=0.9\textwidth]{figure_man/pfi_demo2}}%
-  \only<3>{\includegraphics[page=4, trim=0pt 5pt 0 66pt, clip, width=0.9\textwidth]{figure_man/pfi_demo2}}%
-  \only<4>{\includegraphics[page=5, trim=0pt 5pt 0 66pt, clip, width=0.9\textwidth]{figure_man/pfi_demo2}}%
-  \only<5>{\includegraphics[page=6, trim=0pt 5pt 0 66pt, clip, width=0.9\textwidth]{figure_man/pfi_demo2}}%
-  \only<6>{\includegraphics[page=7, trim=0pt 5pt 0 66pt, clip, width=0.9\textwidth]{figure_man/pfi_demo2}}%
-}
 
-  \begin{itemize}
-    \only<1-2>{\item[1.]\textbf{Perturbation:} Sample feature values from the distribution of $x_S$ ($P(X_S)$). \newline 
-    $\Rightarrow$ Randomly permute feature $x_S$ \\
-    $\Rightarrow$ Replace $x_S$ with permuted feat. $\pert{x}{}{}_S$ and create data $\pert{\D}{S}{}$ containing $\pert{x}{}{}_S$}%
-    \only<2>{\item[2.] \textbf{Prediction:} Make predictions for both data, i.e., $\D$ and $\pert{\D}{S}{}$}%
-    \only<3->{\item[3.] \textbf{Aggregation:}}%
-      \begin{itemize}
-        \item<3-> Compute the loss for each observation in both data sets%
-        \item<4-> Take the difference of both losses $\Delta L$ for each observation%
-        \item<5-> Average this change in loss across all observations%
-        \only<5>{\\ Note: Same as computing $\riske$ on both data sets and \\taking difference}%
-        \item<6-> Repeat perturbation and average over multiple repetitions%
-      \end{itemize}
-    % \only<3-4>{\item[3.] \textbf{Aggregation:}
-    %   \begin{itemize}
-    %     \item Compute the loss for each observation in both data sets.
-    %   \end{itemize}}
-    % \only<5>{\item[3.] \textbf{Aggregation:}
-    %   \begin{itemize}
-    %     \item Compute the loss for each observation in both data sets.
-    %   \item Take the difference of both losses $\Delta L$ for each observation.
-    %   \end{itemize}}
-    %  \only<6>{\item[3.] \textbf{Aggregation:}
-    %   \begin{itemize}
-    %     \item Compute the loss for each observation in both data sets.
-    %     \item Take the difference of both losses $\Delta L$ for each observation.
-    %     \item Average this change in loss across all observations.
-    %   \end{itemize}}
-    % \only<7>{\item[3.] \textbf{Aggregation:}
-    %   \begin{itemize}
-    %     \item Compute the loss for each observation in both data sets.
-    %     \item Take the difference of both losses $\Delta L$ for each observation.
-    %     \item Average this change in loss across all observations.
-    %     \item Also, average over multiple repetitions, if available.
-    %   \end{itemize}}
-  \end{itemize}
-\end{frame}
+\only<1>{\includegraphics[page=2, trim=0pt 5pt 0 66pt, clip, width=0.9\textwidth]{figure_man/pfi_demo2}}%
+\only<2>{\includegraphics[page=3, trim=0pt 5pt 0 66pt, clip, width=0.9\textwidth]{figure_man/pfi_demo2}}%
+\only<3>{\includegraphics[page=4, trim=0pt 5pt 0 66pt, clip, width=0.9\textwidth]{figure_man/pfi_demo2}}%
+\only<4>{\includegraphics[page=5, trim=0pt 5pt 0 66pt, clip, width=0.9\textwidth]{figure_man/pfi_demo2}}%
+\only<5>{\includegraphics[page=6, trim=0pt 5pt 0 66pt, clip, width=0.9\textwidth]{figure_man/pfi_demo2}}%
+\only<6>{\includegraphics[page=7, trim=0pt 5pt 0 66pt, clip, width=0.9\textwidth]{figure_man/pfi_demo2}}%
 
-\begin{frame}{Example: Bike Sharing Dataset}
+\begin{itemizeM}
+\only<1-2>{\item[1.]\textbf{Perturbation:} Sample feature values from the distribution of $x_S$ ($P(X_S)$). \newline
+$\Rightarrow$ Randomly permute feature $x_S$ \\
+$\Rightarrow$ Replace $x_S$ with permuted feat. $\pert{x}{}{}_S$ and create data $\pert{\D}{S}{}$ containing $\pert{x}{}{}_S$}%
+\only<2>{\item[2.] \textbf{Prediction:} Make predictions for both data, i.e., $\D$ and $\pert{\D}{S}{}$}%
+\only<3->{\item[3.] \textbf{Aggregation:}}%
+\begin{itemizeS}
+\item<3-> Compute the loss for each observation in both data sets%
+\item<4-> Take the difference of both losses $\Delta L$ for each observation%
+\item<5-> Average this change in loss across all observations%
+\only<5>{\\ Note: Same as computing $\riske$ on both data sets and \\taking difference}%
+\item<6-> Repeat perturbation and average over multiple repetitions%
+\end{itemizeS}
+% \only<3-4>{\item[3.] \textbf{Aggregation:}
+%   \begin{itemize}
+%     \item Compute the loss for each observation in both data sets.
+%   \end{itemize}}
+% \only<5>{\item[3.] \textbf{Aggregation:}
+%   \begin{itemize}
+%     \item Compute the loss for each observation in both data sets.
+%   \item Take the difference of both losses $\Delta L$ for each observation.
+%   \end{itemize}}
+%  \only<6>{\item[3.] \textbf{Aggregation:}
+%   \begin{itemize}
+%     \item Compute the loss for each observation in both data sets.
+%     \item Take the difference of both losses $\Delta L$ for each observation.
+%     \item Average this change in loss across all observations.
+%   \end{itemize}}
+% \only<7>{\item[3.] \textbf{Aggregation:}
+%   \begin{itemize}
+%     \item Compute the loss for each observation in both data sets.
+%     \item Take the difference of both losses $\Delta L$ for each observation.
+%     \item Average this change in loss across all observations.
+%     \item Also, average over multiple repetitions, if available.
+%   \end{itemize}}
+\end{itemizeM}
+\end{framev}
 
-\begin{center}
-\includegraphics[width=\textwidth]{figure_man/bike-sharing02.png}
-\end{center}
 
+\begin{framev}[align=top]{Example: Bike Sharing Dataset}
+\imageC{figure_man/bike-sharing02.png}
 \textbf{Interpretation:}
+\begin{itemizeM}
+\item \code{yr} and \code{temp} are most important feats using mean absolute error (MAE)
+%Features such as weekday also contribute to the performance.
+\item Destroying info. about \code{yr} by permuting it increases MAE of model by 816
+\item Error bars show 5\% and 95\% quantiles over multiple permutations
+\end{itemizeM}
+\end{framev}
 
-\begin{itemize}
- \item \code{yr} and \code{temp} are most important feats using mean absolute error (MAE)
- %Features such as weekday also contribute to the performance.
- \item Destroying info. about \code{yr} by permuting it increases MAE of model by 816
- \item Error bars show 5\% and 95\% quantiles over multiple permutations
-\end{itemize}
-\end{frame}
 
-\begin{frame}{Comments on PFI}
- \begin{itemize}[<+->]
- \itemsep1em
-  \item Interpretation: Increase in error when feature's information is destroyed
-  \item Results can be unreliable due to random permutations \\
-  $\Rightarrow$ Solution: Average results over multiple repetitions
-  \item Permuting features despite correlation/dependence with other features can lead to unrealistic combinations of feature values 
-  \\$\leadsto$ Extrapolation issue % (since $\P(x_j,x_{-j}) \neq \P(x_j) \P(x_{-j})$)\\
-  \item PFI automatically includes importance of interaction effects with other features \\
-  $\Rightarrow$ Permuting $x_j$ also destroys interactions with permuted feature\\
-  $\Rightarrow$ PFI score contains importance of all interactions with permuted feature %Not only importance of permuted feature is contained but also importance of all interactions with that feature
-  \item Interpretation of PFI depends on whether training or test data is used
- \end{itemize}
-\end{frame}
+\begin{framei}[align=top]{Comments on PFI}
+\item<+-> Interpretation: Increase in error when feature's information is destroyed
+\item<+-> Results can be unreliable due to random permutations \\
+$\Rightarrow$ Solution: Average results over multiple repetitions
+\item<+-> Permuting features despite correlation/dependence with other features can lead to unrealistic combinations of feature values\\
+$\leadsto$ Extrapolation issue % (since $\P(x_j,x_{-j}) \neq \P(x_j) \P(x_{-j})$)\\
+\item<+-> PFI automatically includes importance of interaction effects with other features \\
+$\Rightarrow$ Permuting $x_j$ also destroys interactions with permuted feature\\
+$\Rightarrow$ PFI score contains importance of all interactions with permuted feature %Not only importance of permuted feature is contained but also importance of all interactions with that feature
+\item<+-> Interpretation of PFI depends on whether training or test data is used
+\end{framei}
 
 %TODO: Simplify example
-\begin{frame}{Comments on PFI - Extrapolation}
- 
+\begin{framev}[align=top]{Comments on PFI - Extrapolation}
 % %\textbf{Example:} Let $y = x_3 + \epsilon_y$ with $\epsilon_y \sim N(0, 0.1)$ where $x_1$, $x_2 := x_1 + \epsilon_1$ are highly correlated ($x_1 \sim N(0,1), \epsilon_1 \sim N(0, 0.01)$). Let $x_3, x_4 \sim N(0,1)$ be noisy features are independent.
- 
 %  \textbf{Example:} Let $y = x_3 + \epsilon_y$ with $\epsilon_y \sim N(0, 0.1)$ where $x_1 :=  \epsilon_1$, $x_2 := x_1 + \epsilon_2$ are highly correlated ($\epsilon_1 \sim N(0,1), \epsilon_2 \sim N(0, 0.01)$) and $x_3 := \epsilon_3$, $x_4 := \epsilon_4$,  with $\epsilon_3, \epsilon_4 \sim N(0,1)$. All noise terms are independent.
 %  Fitting a LM yields $\fh(\xv) \approx 0.3 x_1 - 0.3 x_2 + x_3$.
 % \pause
@@ -351,114 +324,98 @@ Note: $S$ refers to a subset of features, here $|S|=1$ to measure impact of perm
 % since $0.3 x_1 - 0.3 x_2 \approx 0$ \\
 % $\Rightarrow$ PFI evaluates model on unrealistic obs. outside $\P(\xv)$ $\leadsto$ $x_1$, $x_2$ are considered relevant (PFI $> 0$)
 % %$\Rightarrow$ Since PFI evaluates the model on unrealistic observations, the features $x_1$ and $x_2$ are nevertheless considered relevant
-
-
 \textbf{Example:} Let $y = x_3 + \epsilon_y$, with $\epsilon_y \sim \mathcal{N}(0, 0.1)$.
-
-\begin{itemize}
-  \item $x_1 := \epsilon_1$, $x_2 := x_1 + \epsilon_2$; highly correlated  
-        ($\epsilon_1 \sim \mathcal{N}(0,1)$, $\epsilon_2 \sim \mathcal{N}(0, 0.01)$)
-  \item $x_3 := \epsilon_3$, $x_4 := \epsilon_4$, with $\epsilon_3, \epsilon_4 \sim \mathcal{N}(0,1)$; all noise terms $\epsilon_j$ are indep.
-  \item Fitting a linear model yields $\hat{f}(\xv) \approx 0.3 x_1 - 0.3 x_2 + x_3$
-\end{itemize}
-
+\begin{itemizeS}
+\item $x_1 := \epsilon_1$, $x_2 := x_1 + \epsilon_2$; highly correlated ($\epsilon_1 \sim \mathcal{N}(0,1)$, $\epsilon_2 \sim \mathcal{N}(0, 0.01)$)
+\item $x_3 := \epsilon_3$, $x_4 := \epsilon_4$, with $\epsilon_3, \epsilon_4 \sim \mathcal{N}(0,1)$; all noise terms $\epsilon_j$ are indep.
+\item Fitting a linear model yields $\hat{f}(\xv) \approx 0.3 x_1 - 0.3 x_2 + x_3$
+\end{itemizeS}
 \pause
-\centerline{\includegraphics[width=\linewidth]{figure_man/pfi_hexbin_extrapolation.pdf}}
-
-Hexbin plot of $(x_1, x_2)$ before (left) and after (center) permuting $x_1$;  
+{\centering
+\image[0.9]{figure_man/pfi_hexbin_extrapolation.pdf}
+\par}
+Hexbin plot of $(x_1, x_2)$ before (left) and after (center) permuting $x_1$;
 \\PFI scores (right).
+\pause
+\begin{itemizeS}
+\item[$\Rightarrow$] $x_1, x_2$ cancel in $\hat{f}$ since $x_1 \approx x_2$, hence $0.3 x_1 - 0.3 x_2 \approx 0$ \\$\leadsto$ should be irrelevant
+\item[$\Rightarrow$] Permuting $x_1$ breaks joint structure $\leadsto$ unrealistic inputs
+\item[$\Rightarrow$] $PFI > 0$ due to extrapolation (PFI evaluates model on unrealistic inputs)\\ $\leadsto$ $x_1, x_2$ are misleadingly considered relevant
+\end{itemizeS}
+\end{framev}
+
+
+\begin{framev}[align=top]{Comments on PFI - Interactions}
+\textbf{Example:} Let $x_1, \dots, x_4$ be independently and uniformly sampled from $\{-1, 1\}$ and
+$$y:= x_1 x_2 + x_3 + \epsilon_Y \text{ with } \epsilon_Y \sim N(0, 1)$$
+\splitVTT[0.5]{
+Fitting a LM yields $\fh(x) \approx x_1 x_2 + x_3$.\\
+\spacer[0.25]
 
 \pause
-
-\begin{itemize}
-  \item[$\Rightarrow$] $x_1, x_2$ cancel in $\hat{f}$ since $x_1 \approx x_2$, hence $0.3 x_1 - 0.3 x_2 \approx 0$ \\$\leadsto$ should be irrelevant
-  \item[$\Rightarrow$] Permuting $x_1$ breaks joint structure $\leadsto$ unrealistic inputs
-  \item[$\Rightarrow$] $PFI > 0$ due to extrapolation (PFI evaluates model on unrealistic inputs)\\ $\leadsto$ $x_1, x_2$ are misleadingly considered relevant
-\end{itemize}
-
-\end{frame}
-
-
-
-
-\begin{frame}{Comments on PFI - Interactions}
-
-\textbf{Example:} Let $x_1, \dots, x_4$ be independently and uniformly sampled from $\{-1, 1\}$ and 
-$$y:= x_1 x_2 + x_3 + \epsilon_Y \text{ with } \epsilon_Y \sim N(0, 1)$$
-
-\begin{columns}[T, totalwidth = \textwidth]
-\begin{column}{0.5\textwidth}
-
-Fitting a LM yields $\fh(x) \approx x_1 x_2 + x_3$.\\
-\lz\pause
 Although $x_3$ alone contributes as much to the prediction as $x_1$ and $x_2$ jointly, all three are considered equally relevant.\\
-\lz
+\spacer[0.25]
+
 $\Rightarrow$ PFI does not fairly attribute the performance to the individual features.
+}{
+\spacer[0]
+{\centering
+\image{figure_man/pfi_interactions.pdf}
+\par}
+}
+\end{framev}
 
-\end{column}
-\begin{column}{0.5\textwidth}
-\centering
-  \includegraphics[width=\linewidth]{figure_man/pfi_interactions.pdf}
-\end{column}
-\end{columns}
 
-
-\end{frame}
-
-\begin{frame}{Comments on PFI - Train vs. Test data}
-
+\begin{framev}[align=top]{Comments on PFI - Train vs. Test data}
 \textbf{Example:} % $x_1, \dots, x_{20}, y$ are independently sampled from $\mathcal{U} (-10, 10)$. An \texttt{xgboost} model with default hyperparameters is fit on a small training set of $50$ observations. The model overfits heavily.\\
-
-\begin{itemize}
-  \item $x_1, \dots, x_{20}, y$ are independently sampled from $\mathcal{U} (-10, 10)$
-  \item Train set: $n = 50$ (intentionally small) and large test set
-  \item Model: \texttt{xgboost} with default settings (overfits strongly)
-\end{itemize}
-
+\begin{itemizeM}
+\item $x_1, \dots, x_{20}, y$ are independently sampled from $\mathcal{U} (-10, 10)$
+\item Train set: $n = 50$ (intentionally small) and large test set
+\item Model: \texttt{xgboost} with default settings (overfits strongly)
+\end{itemizeM}
 %\begin{figure}
-  \includegraphics[width=0.9\linewidth]{figure_man/pfi_test_vs_train.pdf}\\
-  %\caption{While PFI on test data considers all features to be irrelevant, PFI on train data exposes the features on which the model overfitted.}
-  %\caption{PFI on test data detects no relevant features. \\PFI on training data highlights features the model overfitted to.}
-\textbf{Observation:} 
-\begin{itemize}
-    \item PFI on train data highlights features that the model overfitted to.
-    \item PFI on test data detects no relevant features.
-\end{itemize} 
+{\centering
+\image[0.9]{figure_man/pfi_test_vs_train.pdf}\\
+\par}
+%\caption{While PFI on test data considers all features to be irrelevant, PFI on train data exposes the features on which the model overfitted.}
+%\caption{PFI on test data detects no relevant features. \\PFI on training data highlights features the model overfitted to.}
+\textbf{Observation:}
+\begin{itemizeM}
+\item PFI on train data highlights features that the model overfitted to.
+\item PFI on test data detects no relevant features.
+\end{itemizeM}
 %\end{figure}
 \pause
-\medskip
-
-\textbf{Why?} $PFI \neq 0$ if permuting a feature breaks a dependency the model relies on. 
+\spacer[0.25]
+\textbf{Why?} $PFI \neq 0$ if permuting a feature breaks a dependency the model relies on.
 Model overfits due to spurious feature-target dependencies in train that vanish on test.\\
 $\Rightarrow$ To find features that help the model to generalize, compute PFI on test data.
 %\textbf{Why?} PFI can only be nonzero if the permutation breaks a dependence in the data. Spurious feature-target dependencies overfit train data but vanish on test data.%help the model perform well on train data but are not present in the test data.
 %\\
 %$\Rightarrow$ If you are interested in which features help the model to generalize, apply PFI on test data.
-  
-\end{frame}
+\end{framev}
 
-\begin{frame}{Implications of PFI}
 
+\begin{framev}[align=top]{Implications of PFI}
 Can we get insight into whether the ...
-
 \begin{enumerate}
-    \item<1-> feature $x_j$ is causal for the prediction?
-    \begin{itemize}
-      \item $PFI_j \neq 0$ $\Rightarrow$ model relies on $x_j$
-      %(contraposition does not hold, see training vs. test data example)
-      \item As the train vs. test data example shows, the converse does not hold
-    \end{itemize}
-    \item<2-> feature $x_j$ contains prediction-relevant information?
-    \begin{itemize}
-      \item $PFI_j \neq 0$ $\Rightarrow$ $x_{j}$ is dependent on $y$, $x_{-j}$, or both (due to extrapolation) 
-      \item $x_{j}$ is not exploited by model (regardless of its usefulness for $y$) \\$\Rightarrow$ $PFI_j = 0$  %irrespective of whether the feature is useful or not
-    \end{itemize}
-    \item<3-> model requires access to $x_j$ to achieve its prediction performance?    
-    \begin{itemize}
-      \item As shown by the extrapolation example, such insight is not possible
-\end{itemize}
+\item<1-> feature $x_j$ is causal for the prediction?
+\begin{itemizeS}
+\item $PFI_j \neq 0$ $\Rightarrow$ model relies on $x_j$
+%(contraposition does not hold, see training vs. test data example)
+\item As the train vs. test data example shows, the converse does not hold
+\end{itemizeS}
+\item<2-> feature $x_j$ contains prediction-relevant information?
+\begin{itemizeS}
+\item $PFI_j \neq 0$ $\Rightarrow$ $x_{j}$ is dependent on $y$, $x_{-j}$, or both (due to extrapolation)
+\item $x_{j}$ is not exploited by model (regardless of its usefulness for $y$) \\$\Rightarrow$ $PFI_j = 0$  %irrespective of whether the feature is useful or not
+\end{itemizeS}
+\item<3-> model requires access to $x_j$ to achieve its prediction performance?
+\begin{itemizeS}
+\item As shown by the extrapolation example, such insight is not possible
+\end{itemizeS}
 \end{enumerate}
-\end{frame}
+\end{framev}
 
 
 % \begin{frame}{Testing Importance (PIMP) \furtherreading{ALTMANN2010}}

--- a/slides/feature-importance/slides03-fi-cfi.tex
+++ b/slides/feature-importance/slides03-fi-cfi.tex
@@ -6,11 +6,10 @@
 \input{../../latex-math/ml-interpretable.tex}
 
 % Defines macros and environments
- 
+
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 %\bibliography{feature-importance}
 
 \begin{document}
@@ -49,36 +48,31 @@ figure_man/feature-importance.png
 %TODO: Conditioning on everything is not a good idea: CFI=0 for highly correlated variables? Other examples? Relative Importance (Gunnar)?
 
 % CFI IDEA
-\begin{frame}{CFI Motivation}
-
+\begin{framev}[align=top]{CFI Motivation}
 \begin{itemize}[<+->]
-    \item \textbf{PFI Idea:} Replace feature(s) $X_S$ with perturbed $\tilde X_S$ to preserve marginal distr. $\P(X_S)$ so that $\tilde X_S \indep Y$ (indep.), e.g., by random permutations
-    \item \textbf{Problem:} Breaks not only association between $X_S$ and $Y$ (what we want) but also between $X_S$, $X_{-S}$ $\Rightarrow$ $\P(X_S, X_{-S}) \neq \P(\tilde X_S, X_{-S})$ (extrapolation)
-    \item \textbf{CFI Idea:} Replace feature(s) $X_S$ with perturbed $\tilde X_S$ to preserve joint distr. so that $\P(X_S, X_{-S}) = \P(\tilde X_S, X_{-S})$ (no extrapolation) while still $\tilde X_S \indep Y$
-    %Sample $X_S$ from conditional dist. $\P(X_S|X_{-S})$ to preserve joint dist., i.e., $\P(X_S|X_{-S}) \P(X_{-S}) = \P(X_S, X_{-S})$
+\item \textbf{PFI Idea:} Replace feature(s) $X_S$ with perturbed $\tilde X_S$ to preserve marginal distr. $\P(X_S)$ so that $\tilde X_S \indep Y$ (indep.), e.g., by random permutations
+\item \textbf{Problem:} Breaks not only association between $X_S$ and $Y$ (what we want) but also between $X_S$, $X_{-S}$ $\Rightarrow$ $\P(X_S, X_{-S}) \neq \P(\tilde X_S, X_{-S})$ (extrapolation)
+\item \textbf{CFI Idea:} Replace feature(s) $X_S$ with perturbed $\tilde X_S$ to preserve joint distr. so that $\P(X_S, X_{-S}) = \P(\tilde X_S, X_{-S})$ (no extrapolation) while still $\tilde X_S \indep Y$
+%Sample $X_S$ from conditional dist. $\P(X_S|X_{-S})$ to preserve joint dist., i.e., $\P(X_S|X_{-S}) \P(X_{-S}) = \P(X_S, X_{-S})$
 \end{itemize}
 %\\
 %\lz
 %\\
 %\lz
-
-\medskip
-
+\spacer[0.25]
 \visible<4>{
-\textbf{Example:} Conditional permutation scheme 
-
+\textbf{Example:} Conditional permutation scheme\\
+\spacer[0.25]
 \textbf{Black dots:} $X_2 \sim \mathcal{U}(0,1)$ and 
-$X_1 \sim \mathcal{N}(0,1)$ (if $X_2 < 0.5$) or $\mathcal{N}(4,4)$ \\(if $ X_2 \geq 0.5$)
-
-\medskip
-
-\begin{columns}[T, totalwidth = \textwidth]
-\begin{column}{0.43\textwidth}
-
-\includegraphics[width=\linewidth]{figure_man/conditional_sampling.pdf}
-\centerline{\furtherreading{MOLNAR2020}}
-\end{column}
-\begin{column}{0.56\textwidth}
+$X_1 \sim \mathcal{N}(0,1)$ (if $X_2 < 0.5$) or $\mathcal{N}(4,4)$ \\(if $ X_2 \geq 0.5$)\\
+\spacer[0.25]
+\splitVTT[0.43]{
+\spacer[0]
+\image{figure_man/conditional_sampling.pdf}
+\begin{center}
+\furtherreading{MOLNAR2020}
+\end{center}
+}{
 %\begin{itemize}
 % $X_2 \sim U(0,1)$ and 
 % \begin{align*}
@@ -87,42 +81,34 @@ $X_1 \sim \mathcal{N}(0,1)$ (if $X_2 < 0.5$) or $\mathcal{N}(4,4)$ \\(if $ X_2 \
 % N(4, 4), \text{else}
 % \end{cases}
 %\end{align*}
-    %\item 
-    \textbf{Left:} For $X_2<0.5$, permuting $X_1$ (crosses) preserves marginal (but not joint) distrib. \\
-    $\leadsto$ Bottom: Marginal density of $X_1$
-    
-    \medskip 
-    
-    %\item 
-    \textbf{Right:} Permuting $X_1$ within subgroups $X_2<0.5$ \& $X_2\geq 0.5$ reduces extrapolation\\
-    $\leadsto$ Bottom: $X_1$-density cond. on groups
-    %\item \textbf{Bottom left:} Marginal density of $X_1$
-    %\item \textbf{Bottom right:} Densities of $X_1$ conditional on the groups
+%\item
+\textbf{Left:} For $X_2<0.5$, permuting $X_1$ (crosses) preserves marginal (but not joint) distrib. \\
+$\leadsto$ Bottom: Marginal density of $X_1$\\
+\spacer[0.25]
+%\item
+\textbf{Right:} Permuting $X_1$ within subgroups $X_2<0.5$ \& $X_2\geq 0.5$ reduces extrapolation\\
+$\leadsto$ Bottom: $X_1$-density cond. on groups
+%\item \textbf{Bottom left:} Marginal density of $X_1$
+%\item \textbf{Bottom right:} Densities of $X_1$ conditional on the groups
 %\end{itemize}
-\end{column}
-\end{columns}
+}
 %$X_2 \sim U(0,1)$ and $X_1 \sim N(0, 1)$ if $X_2<0.5$, else $X_1 \sim N(4,4)$ (black dots)
 }
-\end{frame}
+\end{framev}
 
 
 %TODO: Changed in PFI slides? Also change here!
 % RECAP EXTRAPOLATION
-\begin{frame}{Recall: Extrapolation in PFI}
-
- \textbf{Recall:} 
- Let $y = x_3 + \epsilon_y$, with $\epsilon_y \sim \mathcal{N}(0, 0.1)$.
-
-\begin{itemize}
-  \item $x_1 := \epsilon_1$, $x_2 := x_1 + \epsilon_2$; highly correlated  
-        ($\epsilon_1 \sim \mathcal{N}(0,1)$, $\epsilon_2 \sim \mathcal{N}(0, 0.01)$)
-  \item $x_3 := \epsilon_3$, $x_4 := \epsilon_4$, with $\epsilon_3, \epsilon_4 \sim \mathcal{N}(0,1)$; all noise terms $\epsilon_j$ are indep.
-  \item Fitting a linear model yields $\hat{f}(\xv) \approx 0.3 x_1 - 0.3 x_2 + x_3$
-\end{itemize}
-
- % \textbf{Example:} Let $y = x_3 + \epsilon_y$ with $\epsilon_y \sim N(0, 0.1)$ where $x_1 :=  \epsilon_1$, $x_2 := x_1 + \epsilon_2$ are highly correlated ($\epsilon_1 \sim N(0,1), \epsilon_2 \sim N(0, 0.01)$) and $x_3 := \epsilon_3$, $x_4 := \epsilon_4$,  with $\epsilon_3, \epsilon_4 \sim N(0,1)$. All noise terms are independent.
- % Fitting a LM yields $\fh(\xv) \approx 0.3 x_1 - 0.3 x_2 + x_3$.
-
+\begin{framev}[align=top]{Recall: Extrapolation in PFI}
+\textbf{Recall:}
+Let $y = x_3 + \epsilon_y$, with $\epsilon_y \sim \mathcal{N}(0, 0.1)$.
+\begin{itemizeM}
+\item $x_1 := \epsilon_1$, $x_2 := x_1 + \epsilon_2$; highly correlated ($\epsilon_1 \sim \mathcal{N}(0,1)$, $\epsilon_2 \sim \mathcal{N}(0, 0.01)$)
+\item $x_3 := \epsilon_3$, $x_4 := \epsilon_4$, with $\epsilon_3, \epsilon_4 \sim \mathcal{N}(0,1)$; all noise terms $\epsilon_j$ are indep.
+\item Fitting a linear model yields $\hat{f}(\xv) \approx 0.3 x_1 - 0.3 x_2 + x_3$
+\end{itemizeM}
+% \textbf{Example:} Let $y = x_3 + \epsilon_y$ with $\epsilon_y \sim N(0, 0.1)$ where $x_1 :=  \epsilon_1$, $x_2 := x_1 + \epsilon_2$ are highly correlated ($\epsilon_1 \sim N(0,1), \epsilon_2 \sim N(0, 0.01)$) and $x_3 := \epsilon_3$, $x_4 := \epsilon_4$,  with $\epsilon_3, \epsilon_4 \sim N(0,1)$. All noise terms are independent.
+% Fitting a LM yields $\fh(\xv) \approx 0.3 x_1 - 0.3 x_2 + x_3$.
 % %\begin{figure}
 % % \hfill
 % %   \includegraphics[width=0.3\linewidth]{figure_man/pfi_hexbin_pre.pdf}\hfill
@@ -137,25 +123,21 @@ $X_1 \sim \mathcal{N}(0,1)$ (if $X_2 < 0.5$) or $\mathcal{N}(4,4)$ \\(if $ X_2 \
 % $\Rightarrow$ $x_1$ and $x_2$ should be irrelevant for the prediction $\fh(\xv)$ for $\{\xv: \P(\xv) > 0\}$ as $0.3 x_1 - 0.3 x_2 \approx 0$ \\
 % $\Rightarrow$ PFI evaluates model on unrealistic obs. outside $\P(\xv)$ $\leadsto$ $x_1$ and $x_2$ are considered relevant
 % %$\Rightarrow$ Since PFI evaluates the model on unrealistic observations, the features $x_1$ and $x_2$ are nevertheless considered relevant
-
-\centerline{\includegraphics[width=\linewidth]{figure_man/pfi_hexbin_extrapolation.pdf}}
-
+\image{figure_man/pfi_hexbin_extrapolation.pdf}
 Hexbin plot of $(x_1, x_2)$ before (left) and after (center) permuting $x_1$;  
 \\PFI scores (right).
+\begin{itemizeS}
+\item[$\Rightarrow$] $x_1, x_2$ cancel in $\hat{f}$ and should be irrelevant
+\item[$\Rightarrow$] But PFI evaluates model on unrealistic inputs (caused by permutation)\\
+$\leadsto$ $PFI > 0$ for $x_1, x_2$ due to extrapolation\\
+$\leadsto$ $x_1, x_2$ are misleadingly considered relevant
+\end{itemizeS}
+\end{framev}
 
-\begin{itemize}
-  \item[$\Rightarrow$] $x_1, x_2$ cancel in $\hat{f}$ and should be irrelevant
-  \item[$\Rightarrow$] But PFI evaluates model on unrealistic inputs (caused by permutation)\\
-  $\leadsto$ $PFI > 0$ for $x_1, x_2$ due to extrapolation\\
-  $\leadsto$ $x_1, x_2$ are misleadingly considered relevant
-\end{itemize}
- \end{frame}
 
-
- 
 %  % CONDITIONAL SAMPLING PRESERVES THE JOINT
 %  \begin{frame}{Conditional Sampling preserves the Joint}
- 
+
 %  Let $\pert{x}{S}{-S} = (\pert{x}{S}{-S}_S, x_{-S})$ be the feature vector where feature values $x_S$ were replaced with an independent sample from $\P(x_S|x_{-S})$ while all other remaining feature values $x_{-S}$ stay the same. %We partition $\pert{x}{S}{-S}$ into $(\pert{x}{S}{-S}_S, x_{-S})$ containing features indexed by $S$ and the remaining features by $-S$). 
 %  Using the definition of conditional probability:
 % %
@@ -174,32 +156,26 @@ Hexbin plot of $(x_1, x_2)$ before (left) and after (center) permuting $x_1$;
 
 
 % CFI DEFINITION
-\begin{frame}{CFI \furtherreading{STROBL2008} \furtherreading{HOOKER2021}}
-\normalsize
-
+\begin{framev}[align=top]{CFI \furtherreading{STROBL2008} \furtherreading{HOOKER2021}}
 %  {\color{blue}\textbf{with feat. values $x_S$}} and {\color{red}\textbf{with permuted feat. values $\pert{x}{}{}_S$}} 
 CFI for $X_S$ using test data $\D$:
-\begin{itemize}
-  \item Measure the error \color{blue}\textbf{with unperturbed features $x_S$}\color{black}.
-  \item Measure the error \textbf{\color{red}with perturbed feature values $\pert{x}{}{}_S \sim \P(X_S|X_{-S})$} 
-  %\color{black} $\pert{x}{S}{-S}$, where $\pert{x}{S}{-S}_S \sim \P(x_S|x_{-S})$
-  \item Repeat perturbing $X_S$ (e.g., $m$ times) and avg. difference of both errors: 
+\begin{itemizeM}
+\item Measure the error {\color{blue}\textbf{with unperturbed features $x_S$}}.
+\item Measure the error \textbf{\color{red}with perturbed feature values $\pert{x}{}{}_S \sim \P(X_S|X_{-S})$}
+%\color{black} $\pert{x}{S}{-S}$, where $\pert{x}{S}{-S}_S \sim \P(x_S|x_{-S})$
+\item Repeat perturbing $X_S$ (e.g., $m$ times) and avg. difference of both errors:
 $$\widehat{CFI}_S = \tfrac{1}{m} \textstyle\sum\nolimits_{k = 1}^{m} \riske (\fh, {\color{red}\pert{\D}{S}{-S}_{(k)}}) - \riske (\fh, {\color{blue}\D})$$
-\end{itemize}
-
-Here, $\pert{\D}{S}{-S}$ denotes data, where $x_S$ values are conditionally resampled given $x_{-S}$.
-
-\medskip
+\end{itemizeM}
+Here, $\pert{\D}{S}{-S}$ denotes data, where $x_S$ values are conditionally resampled given $x_{-S}$.\\
+\spacer[0.25]
 \textbf{Illustrative example:} Conditional permutation when $X_{-S}$ is categorical:
-
-\begin{columns}[T, onlytextwidth]
-\scriptsize
-    \begin{column}{0.5\textwidth}
-    \centering
-    \textbf{Original Data}
-    
-    \rowcolors{2}{white}{gray!10}
-    \begin{tabular}{ccc}
+\spacer[0.5]
+\begin{scriptsize}
+\splitVTT[0.5]{
+\centering
+\textbf{Original Data}\\
+\rowcolors{2}{white}{gray!10}
+\begin{tabular}{ccc}
 \toprule
 ID & $X_{-S}$ & $X_S$ \\
 \midrule
@@ -212,14 +188,12 @@ ID & $X_{-S}$ & $X_S$ \\
 6 & \cellcolor{red!10}B & \cellcolor{red!10}6.2 \\
 \bottomrule
 \end{tabular}
-    \end{column}
-    
-    \begin{column}{0.5\textwidth}
-    \centering
-    \textbf{Permuted Conditionally on $X_{-S}$}
-
-    \rowcolors{2}{white}{gray!10}
-    \begin{tabular}{ccc}
+\spacer[0.25]
+}{
+\centering
+\textbf{Permuted Conditionally on $X_{-S}$}\\
+\rowcolors{2}{white}{gray!10}
+\begin{tabular}{ccc}
 \toprule
 ID & $X_{-S}$ & $X_S$ \\
 \midrule
@@ -232,108 +206,104 @@ ID & $X_{-S}$ & $X_S$ \\
 6 & \cellcolor{red!10}B & \cellcolor{red!10}5.4 \\
 \bottomrule
 \end{tabular}
-    \end{column}
-\end{columns}
-
-
-\medskip
-{
-Here, $X_S$ is permuted \textit{within} each group of $X_{-S}$ to preserve $\mathbb{P}(X_S, X_{-S})$.
+\spacer[0.25]
 }
+\end{scriptsize}
+\spacer[0.5]
 
+Here, $X_S$ is permuted \textit{within} each group of $X_{-S}$ to preserve $\mathbb{P}(X_S, X_{-S})$.
 %\footnote[frame]{\fullcite{Strobl2008}}
-
-\end{frame}
+\end{framev}
 
 
 %TODO: What is meant by "mechanistically"?
 % INTERPRETATION OF CFI
-\begin{frame}{Implications of CFI \furtherreading{KNIGET2020}}
-
+\begin{framev}[align=top]{Implications of CFI \furtherreading{KNIGET2020}}
 \textbf{Interpretation:} Due to the conditional sampling w.r.t. all other features, CFI quantifies a feature's unique contribution to the model performance.\\
-\lz\pause
+\spacer[0.25]
+\pause
 \textbf{Entanglement with data:}
-\begin{itemize}
-  \item If feat $x_S$ does not contrib. unique information about $y$, i.e., $x_S \indep y | x_{-S}$\\
-  $\Rightarrow$ CFI $= 0$
-  \item Why? Under the conditional indep. 
-  $\P(\pert{X}{}{}_S, X_{-S}, Y) = \P(X_S, X_{-S}, Y)$
-  %$\P(\pert{x}{S}{-S}, y) = \P(x,y)$
-  \\
-  $\leadsto$ no prediction-relevant information is destroyed by permutation of $x_S$ conditional on $x_{-S}$
-\end{itemize}
-\lz\pause
+\begin{itemizeM}
+\item If feat $x_S$ does not contrib. unique information about $y$, i.e., $x_S \indep y | x_{-S}$\\
+$\Rightarrow$ CFI $= 0$
+\item Why? Under the conditional indep.
+$\P(\pert{X}{}{}_S, X_{-S}, Y) = \P(X_S, X_{-S}, Y)$
+%$\P(\pert{x}{S}{-S}, y) = \P(x,y)$
+\\
+$\leadsto$ no prediction-relevant information is destroyed by permutation of $x_S$ conditional on $x_{-S}$
+\end{itemizeM}
+\spacer[0.25]
+\pause
 \textbf{Entanglement with model:}
-\begin{itemize}
-  \item If the model does not use a feature $\Rightarrow$ CFI $= 0$
-  \item Why? Then the prediction is not affected by any perturbation of the feat\\
-  $\leadsto$ model performance does not change after conditional permutation
-  %(and consequently the performance is invariant).
-\end{itemize}
-
+\begin{itemizeM}
+\item If the model does not use a feature $\Rightarrow$ CFI $= 0$
+\item Why? Then the prediction is not affected by any perturbation of the feat\\
+$\leadsto$ model performance does not change after conditional permutation
+%(and consequently the performance is invariant).
+\end{itemizeM}
 %\footnote[frame]{\fullcite{konig_relative_2021}}
-\end{frame}
+\end{framev}
 
 
 % IMPLICATIONS OF CFI
-\begin{frame}{Implications of CFI}
-
+\begin{framev}[align=top]{Implications of CFI}
 Can we gain insight into whether ...
-
 \begin{enumerate}
-    \item<1-3> the feature $x_j$ is causal for the prediction?
-    \begin{itemize}
-      \item $CFI_j \neq 0$ $\Rightarrow$ model relies on $x_j$ \\(converse does not hold, see next slide)
-    \end{itemize}
-    \item<2-3> the variable $x_j$ contains prediction-relevant information?
-    \begin{itemize}
-      \item If $x_j \not \indep y$ but $x_j \indep y | x_{-j}$ (e.g., $x_j$ and $x_{-j}$ share information) \\$\Rightarrow$ $CFI_j = 0$
-      \item  $x_{j}$ is not exploited by model (regardless of its usefulness for $y$) \\$\Rightarrow$ $CFI_j = 0$
-      %\item If a feature is not exploited by the model, CFI is zero, irrespective of whether the feature is useful or not.
-    \end{itemize}
-    \item<3> Does the model need access to $x_j$ to achieve its prediction performance?
-\begin{itemize}
-      \item $CFI_j \neq 0 \Rightarrow$ $x_j$ contributes unique information (meaning $x_j \not \indep y | x_{-j}$)
-      %Nonzero CFI implies that the feature contributes unique information (meaning $x_S \not \indep y | x_{-S}$).
-      \item Only uncovers the relationships that were exploited by the model
-    \end{itemize}
+\item<1-3> the feature $x_j$ is causal for the prediction?
+\begin{itemizeS}
+\item $CFI_j \neq 0$ $\Rightarrow$ model relies on $x_j$ \\(converse does not hold, see next slide)
+\end{itemizeS}
+\item<2-3> the variable $x_j$ contains prediction-relevant information?
+\begin{itemizeS}
+\item If $x_j \not \indep y$ but $x_j \indep y | x_{-j}$ (e.g., $x_j$ and $x_{-j}$ share information) \\$\Rightarrow$ $CFI_j = 0$
+\item $x_j$ is not exploited by model (regardless of its usefulness for $y$) \\$\Rightarrow$ $CFI_j = 0$
+%\item If a feature is not exploited by the model, CFI is zero, irrespective of whether the feature is useful or not.
+\end{itemizeS}
+\item<3> Does the model need access to $x_j$ to achieve its prediction performance?
+\begin{itemizeS}
+\item $CFI_j \neq 0 \Rightarrow$ $x_j$ contributes unique information (meaning $x_j \not \indep y | x_{-j}$)
+%Nonzero CFI implies that the feature contributes unique information (meaning $x_S \not \indep y | x_{-S}$).
+\item Only uncovers the relationships that were exploited by the model
+\end{itemizeS}
 \end{enumerate}
-\end{frame}
+\end{framev}
+
 
 %TODO: Better example? 
 % RECAP EXTRAPOLATION
-\begin{frame}{Extrapolation: Compare PFI and CFI }
-
+\begin{framev}[align=top]{Extrapolation: Compare PFI and CFI}
 \textbf{Recall:} Let $y = x_3 + \epsilon_y$, with $\epsilon_y \sim \mathcal{N}(0, 0.1)$.
-
-\begin{itemize}
-  \item $x_1 := \epsilon_1$, $x_2 := x_1 + \epsilon_2$; highly correlated  
-        ($\epsilon_1 \sim \mathcal{N}(0,1)$, $\epsilon_2 \sim \mathcal{N}(0, 0.01)$)
-  \item $x_3 := \epsilon_3$, $x_4 := \epsilon_4$, with $\epsilon_3, \epsilon_4 \sim \mathcal{N}(0,1)$; all noise terms $\epsilon_j$ are indep.
-  \item Fitting a linear model yields $\hat{f}(\xv) \approx 0.3 x_1 - 0.3 x_2 + x_3$
-\end{itemize} 
- % \textbf{Example:} Let $y = x_3 + \epsilon_y$ with $\epsilon_Y \sim N(0, 0.1)$ where $x_1 :=  \epsilon_1$, $x_2 := x_1 + \epsilon_2$ are highly correlated ($\epsilon_1 \sim N(0,1), \epsilon_2 \sim N(0, 0.01)$) and $x_3 := \epsilon_3$, $x_4 := \epsilon_4$,  with $\epsilon_3, \epsilon_4 \sim N(0,1)$. All noise terms are independent.
- % Fitting a LM yields $\fh(\xv) \approx 0.3 x_1 - 0.3 x_2 + x_3$.%\\
- %
+\begin{itemizeM}
+\item $x_1 := \epsilon_1$, $x_2 := x_1 + \epsilon_2$; highly correlated ($\epsilon_1 \sim \mathcal{N}(0,1)$, $\epsilon_2 \sim \mathcal{N}(0, 0.01)$)
+\item $x_3 := \epsilon_3$, $x_4 := \epsilon_4$, with $\epsilon_3, \epsilon_4 \sim \mathcal{N}(0,1)$; all noise terms $\epsilon_j$ are indep.
+\item Fitting a linear model yields $\hat{f}(\xv) \approx 0.3 x_1 - 0.3 x_2 + x_3$
+\end{itemizeM}
+% \textbf{Example:} Let $y = x_3 + \epsilon_y$ with $\epsilon_Y \sim N(0, 0.1)$ where $x_1 :=  \epsilon_1$, $x_2 := x_1 + \epsilon_2$ are highly correlated ($\epsilon_1 \sim N(0,1), \epsilon_2 \sim N(0, 0.01)$) and $x_3 := \epsilon_3$, $x_4 := \epsilon_4$,  with $\epsilon_3, \epsilon_4 \sim N(0,1)$. All noise terms are independent.
+% Fitting a LM yields $\fh(\xv) \approx 0.3 x_1 - 0.3 x_2 + x_3$.%\\
+%
 \begin{figure}
 %\hfill
-  \includegraphics[width=0.3\linewidth]{figure_man/pfi_hexbin_pre.pdf}\hfill
-  \includegraphics[width=0.7\linewidth]{figure_man/cfi_pfi.pdf} %\hfill
-  \caption{Density plot for $x_1, x_2$ before permuting $x_1$ (left). PFI and CFI (right).}
+\splitVCompact{0.28}{0.65}{
+\image{figure_man/pfi_hexbin_pre.pdf}
+\spacer[0]
+}{
+\image{figure_man/cfi_pfi.pdf}
+\spacer[0]
+}
+\caption{Density plot for $x_1, x_2$ before permuting $x_1$ (left). PFI and CFI (right).}
 \end{figure}
 % 
 %$\Rightarrow$ $x_1$ and $x_2$ are irrelevant for the prediction for $x: \P(x) > 0$ \\
 %$\Rightarrow$ Since PFI evaluates the model on unrealistic observations, the features $x_1$ and $x_2$ are nevertheless considered relevant \\
-\begin{itemize}
-    \item $x_1$ and $x_2$ cancel in $\fh(\xv)$ and should be irrelevant for the prediction
-    \item PFI evaluates model on unrealistic obs. \\$\leadsto$ $x_1$, $x_2$ appear relevant (PFI $> 0$) 
-    \item CFI evaluates model on realistic obs. (due to conditional sampling) \\
+\begin{itemizeS}
+\item $x_1$ and $x_2$ cancel in $\fh(\xv)$ and should be irrelevant for the prediction
+\item PFI evaluates model on unrealistic obs. \\$\leadsto$ $x_1$, $x_2$ appear relevant (PFI $> 0$)
+\item CFI evaluates model on realistic obs. (due to conditional sampling) \\
 $\leadsto$ $x_1$, $x_2$ appear irrelevant (CFI $= 0$)
-\end{itemize}
+\end{itemizeS}
 % $\fh(\xv)$ for $\{\xv: \P(\xv) > 0\}$ as $0.3 x_1 - 0.3 x_2 \approx 0$ \\
 %$\Rightarrow$ Since $x_1$ can be reconstructed from $x_2$ and vice versa, CFI considers $x_1$ and $x_2$ to be irrelevant
-
- \end{frame}
+\end{framev}
 
 % \begin{frame}{Bibliography}
 %   \printbibliography

--- a/slides/feature-importance/slides04-fi-sage.tex
+++ b/slides/feature-importance/slides04-fi-sage.tex
@@ -4,7 +4,7 @@
 \input{../../latex-math/basic-math}
 \input{../../latex-math/basic-ml}
 % Defines macros and environments
- 
+
 \newcommand{\Sm}{S_m}%{Pre(\tau,j)} % S(\tau,j)
 \newcommand{\Smj}{\Sm \cup \{j\}}
 \newcommand{\minusSmj}{- \{\Sm \cup \{j\} \} }
@@ -18,7 +18,6 @@
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 %\bibliography{feature-importance}
 %\usepackage{Sweave}
@@ -39,345 +38,312 @@ figure_man/feature-importance.png
 \item Marginal and Conditional SAGE
 }
 	% Set style/preamble.Rnw as parent.
-	
+
 	% Load all R packages and set up knitr
-	
+
 	% This file loads R packages, configures knitr options and sets preamble.Rnw as 
 	% parent file
 	% IF YOU MODIFY THIS, PLZ ALSO MODIFY setup.Rmd ACCORDINGLY...
-	
+
 	% Defines macros and environments
-	
+
 	% ------------------------------------------------------------------------------
 
 % CHALLENGE
-\begin{frame}{Challenge: Fair Attribution of Importance}
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.54\textwidth}
-\textbf{Recap:} 
-\begin{itemize}
-\item Data: $x_1, \dots, x_4$ uniformly sampled from $[-1, 1]$ 
+\begin{framev}[align=top]{Challenge: Fair Attribution of Importance}
+\splitVTT[0.54]{
+\textbf{Recap:}
+\begin{itemizeM}
+\item Data: $x_1, \dots, x_4$ uniformly sampled from $[-1, 1]$
 \item DGP: $y:= x_1 x_2 + x_3 + \epsilon_Y$ with $\epsilon_Y \sim N(0, 1)$
 \item Model: $\fh(x) \approx x_1 x_2 + x_3$
-\end{itemize}
-
-\lz
-
+\end{itemizeM}
+\spacer[0.5]
 Although $x_3$ alone contributes as much to the prediction as $x_1$ and $x_2$ jointly, all three are considered equally relevant by PFI.
-\end{column}
-\begin{column}{0.45\textwidth}
-\centering
-  \includegraphics[width=\linewidth]{figure_man/pfi_interactions.pdf}
-\end{column}
-\end{columns}
-\lz
-\textbf{Reason:} PFI assesses importance given that all remaining features are preserved. If we first permute $x_1$ and then $x_2$, permutation of $x_2$ would have no effect on the performance (and vice versa).
-\end{frame}
-
-
-
-\begin{frame}{SAGE Idea \furtherreading{COVERT2020}
+}{
+\spacer[0]
+\image{figure_man/pfi_interactions.pdf}
+\spacer[0]
 }
 
+\spacer[0.5]
+\textbf{Reason:} PFI assesses importance given that all remaining features are preserved. If we first permute $x_1$ and then $x_2$, permutation of $x_2$ would have no effect on the performance (and vice versa).
+\end{framev}
+
+
+\begin{framev}[align=top]{SAGE Idea \furtherreading{COVERT2020}}
 \textbf{SAGE:} %Leverage game-theoretic 
 Use Shapley values to compute a fair attribution of importance (via model performance)\\
-\lz
-
-\textbf{Idea:} 
-\begin{itemize}
-    \item Feature importance attribution can be regarded as cooperative game \\
-    $\leadsto$ features jointly contribute to achieve a certain model performance
-    \item Players: features
-    \item Payoff to be fairly distributed: model performance
-    \item Surplus contribution of a feature depends on the coalition of features that are already accessible by the model
-\end{itemize}
+\spacer[0.25]
+\textbf{Idea:}
+\begin{itemizeM}
+\item Feature importance attribution can be regarded as cooperative game \\
+$\leadsto$ features jointly contribute to achieve a certain model performance
+\item Players: features
+\item Payoff to be fairly distributed: model performance
+\item Surplus contribution of a feature depends on the coalition of features that are already accessible by the model
+\end{itemizeM}
 %, where each feature is a player and model performance is the payoff. The surplus contribution of a feature depends on the coalition of features that are already in the room.\\
 %\pause
-\lz
-
-\textbf{Note:} 
-\begin{itemize}
-    \item Similar idea (called SFIMP) was proposed in \furtherreading{CASALICCHIO2018}
-    \item Definition based on model refits was proposed in context of feature selection in \furtherreading{COHEN2007}
-\end{itemize}
-
+\spacer[0.25]
+\textbf{Note:}
+\begin{itemizeM}
+\item Similar idea (called SFIMP) was proposed in \furtherreading{CASALICCHIO2018}
+\item Definition based on model refits was proposed in context of feature selection in \furtherreading{COHEN2007}
+\end{itemizeM}
 %$\Rightarrow$ Global feature importance technique\\
 %$\Rightarrow$ Compute approximate Shapley values $\phi_j$ using appropriate value function 
 %\lz
 %$\Rightarrow$ SAGE translates SHAP into a global feature importance technique\\
 %\lz
 %In order to compute SAGE, approximate Shapley values $\phi_j$ as for SHAP, replacing SHAP value functions with SAGE value functions.\\
-\lz
-
+\spacer[0.25]
 %\footnote[frame]{\fullcite{NEURIPS2020_c7bf0b7c}}
-  
-\end{frame}
+\end{framev}
 
 
 % SAGE IDEA
-\begin{frame}{SAGE - Value function}
-  
- \textbf{Removal Idea:} %To deprive the model of the non-coalition features $-S$, 
- To deprive information of the non-coalition features $-S$ from the model, marginalize the prediction function over feats $-S$ to be ``dropped''.
-
-$$\fh_S(x_S) = \E[\fh(x) | X_S = x_S]$$
-
+\begin{framev}[align=top]{SAGE - Value function}
+\textbf{Removal Idea:} %To deprive the model of the non-coalition features $-S$,
+To deprive information of the non-coalition features $-S$ from the model, marginalize the prediction function over feats $-S$ to be ``dropped''.
+$$
+\fh_S(x_S) = \E[\fh(x) | X_S = x_S]
+$$
 %\lz
-
 %\footnote[frame]{\fullcite{NEURIPS2020_c7bf0b7c}}
-
 %For SAGE, value functions quantify the predictive power of a coalition $S$ in terms of reduction in risk over the mean prediction.\\
 \pause
-\lz
-
-\textbf{SAGE value function:}  $$v_{\fh}(S) = \risk(\fh_{\emptyset}) - \risk(\fh_{S}), \text{ where } \risk(\fh_{S}) = \E_{Y, X_S}[L(y, \fh_S(x_S))]$$
+\spacer[0.25]
+\textbf{SAGE value function:}
+$$
+v_{\fh}(S) = \risk(\fh_{\emptyset}) - \risk(\fh_{S}), \text{ where } \risk(\fh_{S}) = \E_{Y, X_S}[L(y, \fh_S(x_S))]
+$$
 $\leadsto$ Quantify the predictive power of a coalition $S$ in terms of reduction in risk \\
 $\leadsto$ Risk of predictor $\fh_S(x_S)$ is compared to the risk of the mean prediction $\fh_{\emptyset}$
-
-
 \pause
-\lz
 
-\textbf{Surplus contribution of feature $x_j$ over coalition $x_S$:}  
-$$v_{\fh}(S \cup \{j\}) - v_{\fh}(S) = \risk(\fh_{S})-\risk(\fh_{S \cup \{j\}})$$
+\spacer[0.5]
+\textbf{Surplus contribution of feature $x_j$ over coalition $x_S$:}
+$$
+v_{\fh}(S \cup \{j\}) - v_{\fh}(S) = \risk(\fh_{S}) - \risk(\fh_{S \cup \{j\}})
+$$
 $\leadsto$ Quantifies the added value of feature $j$ when it is added to coalition $S$
+\end{framev}
 
 
-\end{frame}
-
-\begin{frame}{SAGE - marginal and cond. sampling}
-
+\begin{framev}[align=top]{SAGE - marginal and cond. sampling}
 When computing the marginalized prediction $\fh_S(x_S)$, the ``dropped'' features can be sampled from \\
-\begin{itemize}
+\begin{itemizeM}
 \item the marginal distribution $\P(x_{-S})$ $\Rightarrow$ marginal SAGE
 \item the conditional distribution $\P(x_{-S}|x_S)$ $\Rightarrow$ conditional SAGE
-\end{itemize}
-
+\end{itemizeM}
 %\lz\pause
-
 %Interpretation of SAGE value functions differs, depending on whether conditional or marginal sampling is used.
-
-\lz\pause
-
+\spacer[0.25]
+\pause
 \textbf{Interpretation marginal sampling:} $v(S)$ quantifies the reliance of the model on features $x_S$
-\begin{itemize}
-  \item %features $x_S$ not being causal for the prediction is a sufficient condition for $v(S) = 0$
-  features $x_S$ not being causal for the prediction $\Rightarrow$ $v(S) = 0$
-\end{itemize}
-
-\lz\pause
-
+\begin{itemizeM}
+\item %features $x_S$ not being causal for the prediction is a sufficient condition for $v(S) = 0$
+features $x_S$ not being causal for the prediction $\Rightarrow$ $v(S) = 0$
+\end{itemizeM}
+\spacer[0.25]
+\pause
 \textbf{Interpretation conditional sampling}: $v(S)$ quantifies whether variables $x_S$ contain prediction-relevant information (e.g. $y \not \indep x_S$) that is (directly or indirectly) exploited by the model
-\begin{itemize}
-  \item %features $x_S$ not being causal for the prediction is not a sufficient condition for $v(S) = 0$
-  features $x_S$ not being causal for the prediction $\not \Rightarrow$ $v(S) = 0$
-  \begin{itemize}
-      \item e.g., if $x_1$ and $x_2$ are perfectly correlated, even if only $x_1$ has a nonzero coefficient, both are considered equally important
-      % (see omitted variable bias as in M-plots)
-  \end{itemize}
-  \item under model optimality, links to mutual information or the conditional variance exist
-\end{itemize}
+\begin{itemizeM}
+\item %features $x_S$ not being causal for the prediction is not a sufficient condition for $v(S) = 0$
+features $x_S$ not being causal for the prediction $\not \Rightarrow$ $v(S) = 0$
+\begin{itemizeS}
+\item e.g., if $x_1$ and $x_2$ are perfectly correlated, even if only $x_1$ has a nonzero coefficient, both are considered equally important
+% (see omitted variable bias as in M-plots)
+\end{itemizeS}
+\item under model optimality, links to mutual information or the conditional variance exist
+\end{itemizeM}
+\end{framev}
 
-\end{frame}
 
-
-\begin{frame}{SAGE - marginal and cond. sampling}
-
+\begin{framev}[align=top]{SAGE - marginal and cond. sampling}
 \textbf{Example:}
 %$x_1 = \epsilon_1$, $x_2 = x_1 + \epsilon_2$, $x_3 = x_2 + \epsilon_3$, $y = x_3 + \epsilon_y$ with $\epsilon_j$ independent noise terms (causal DAG: $x_1 \rightarrow x_2 \rightarrow x_3 \rightarrow y$). Assume fitting LM yields $\fh \approx 0.95 x_3 + 0.05 x_2$. 
 %
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.4\textwidth}
-\begin{itemize}
-    \item $y = x_3 + \epsilon_y$\\ $x_1 = \epsilon_1$\\ $x_2 = x_1 + \epsilon_2$\\ $x_3 = x_2 + \epsilon_3$ (all $\epsilon_j$ i.i.d.)
-    \item Causal DAG: $x_1 \rightarrow x_2 \rightarrow x_3 \rightarrow y$
-    \item Fitted LM: $\fh \approx 0.95 x_3 + 0.05 x_2$
-\end{itemize}
-\end{column}
+\splitVTT[0.4]{
+\spacer[0.6]
+\begin{itemizeM}
+\item $y = x_3 + \epsilon_y$\\ $x_1 = \epsilon_1$\\ $x_2 = x_1 + \epsilon_2$\\ $x_3 = x_2 + \epsilon_3$ (all $\epsilon_j$ i.i.d.)
+\item Causal DAG: $x_1 \rightarrow x_2 \rightarrow x_3 \rightarrow y$
+\item Fitted LM: $\fh \approx 0.95 x_3 + 0.05 x_2$
+\end{itemizeM}
+}{
 \pause
-\begin{column}{0.6\textwidth}
-\centerline{\includegraphics[width=\linewidth]{figure_man/sage_variants}}
-\end{column}
-\end{columns}
-\lz
-\begin{itemize}
-    \item Marginal $v(j)$ are only nonzero for features that are used by $\fh$
-    \item Conditional $v(j)$ are also nonzero for features that are not used by $\fh$ (e.g., due to correlation)
-    \item For conditional value function $v$, the difference $v(-j \cup j) - v(-j)$ quantifies the unique contribution of $x_j$ over remaining features $x_{-j}$\\
-    $\Rightarrow$ Since $y \indep x_1, x_2 | x_3$, only $v(\{1,2,3\}) - v(\{1, 2\})$ is nonzero (i.e., for feature $j = 3$)
-\end{itemize}
+\spacer[0]
+\image{figure_man/sage_variants}
+\spacer[0]
+}
+\spacer[0.25]
+\begin{itemizeM}
+\item Marginal $v(j)$ are only nonzero for features that are used by $\fh$
+\item Conditional $v(j)$ are also nonzero for features that are not used by $\fh$ (e.g., due to correlation)
+\item For conditional value function $v$, the difference $v(-j \cup j) - v(-j)$ quantifies the unique contribution of $x_j$ over remaining features $x_{-j}$\\
+$\Rightarrow$ Since $y \indep x_1, x_2 | x_3$, only $v(\{1,2,3\}) - v(\{1, 2\})$ is nonzero (i.e., for feature $j = 3$)
+\end{itemizeM}
+\end{framev}
 
-\end{frame}
 
-
-\begin{frame}{SAGE value functions vs. SAGE values}
-
+\begin{framev}[align=top]{SAGE value functions vs. SAGE values}
 \textbf{SAGE value function $v(S)$}: measure contribution of a specific feature set over the empty coalition
-
-\lz\pause
-
+\spacer[0.5]
+\pause
+ 
 \textbf{SAGE values $\phi_j$}: fair attribution of importance
-\begin{itemize}
-    \item can be computed by averaging the contribution of $x_j$ over all feat orderings
-    %\item for feature permutation $\pi$ and the corresponding feature ordering $(x_{\pi(1)}, \dots, x_{phi(d)})$, for feature $x_j$ the coalition $S(j; \pi)$ is defined as the set of features preceding $x_j$, i.e. $S(j; \pi) := \{i : \pi(i) < \pi(j)\}$
-    %\item the contribution of $j$ in an ordering $\pi$ is given as $v(j \cup S(j; \pi)) - v(S(j; \pi))$
-    \item for feature permutation $\tau$, the contribution of $j$ in the set $\Stau$ is given as $v(\Stauj) - v(\Stau)$\\
-    Note: $\Stau$ is the set of features preceding $j$ in permutation $\tau$
-\end{itemize}
-
-\lz\pause
+\begin{itemizeM}
+\item can be computed by averaging the contribution of $x_j$ over all feat orderings
+%\item for feature permutation $\pi$ and the corresponding feature ordering $(x_{\pi(1)}, \dots, x_{phi(d)})$, for feature $x_j$ the coalition $S(j; \pi)$ is defined as the set of features preceding $x_j$, i.e. $S(j; \pi) := \{i : \pi(i) < \pi(j)\}$
+%\item the contribution of $j$ in an ordering $\pi$ is given as $v(j \cup S(j; \pi)) - v(S(j; \pi))$
+\item for feature permutation $\tau$, the contribution of $j$ in the set $\Stau$ is given as $v(\Stauj) - v(\Stau)$\\
+Note: $\Stau$ is the set of features preceding $j$ in permutation $\tau$
+\end{itemizeM}
+\spacer[0.5]
+\pause
 
 \textbf{SAGE value approximation:} Average over the contributions for $M$ randomly sampled permutations
+$$
+\phi_j = \frac{1}{M} \sum_{m=1}^M v(\Stauj) - v(\Stau)
+$$
+\end{framev}
 
-\begin{align*}
-    \phi_j = \frac{1}{M} \sum_{m=1}^M v(\Stauj) - v(\Stau)
-\end{align*}
-    
-\end{frame}
 
-\begin{frame}{Interaction Example Revisited}
-
+\begin{framev}[align=top]{Interaction Example Revisited}
 \textbf{Recap:} Data: $x_1, \dots, x_4$ uniformly sampled from $\{-1, 1\}$ and $y:= x_1 x_2 + x_3 + \epsilon_Y$ with $\epsilon_Y \sim N(0, 1)$. Model: $\fh(x) \approx x_1 x_2 + x_3$.\\
 %
-\begin{figure}
-  \includegraphics[width=0.65\linewidth]{figure_man/sage_pfi_interactions}
-\end{figure}
+\imageC[0.65]{figure_man/sage_pfi_interactions}
 %
-\begin{itemize}
-    \item PFI regards $x_1, x_2$ to be equally important as $x_3$
-    \item Marginal SAGE fairly divides the contribution of the interaction $x_1$ and $x_2$
-\end{itemize}
+\begin{itemizeM}
+\item PFI regards $x_1, x_2$ to be equally important as $x_3$
+\item Marginal SAGE fairly divides the contribution of the interaction $x_1$ and $x_2$
+\end{itemizeM}
+\end{framev}
 
-\end{frame}
 
-
-\begin{frame}{SAGE Loss functions}
-
+\begin{framev}[align=top]{SAGE Loss functions}
 When the loss-optimal model $f^*$ is inspected using \textit{conditional-sampling} based SAGE value functions, interesting links exist.
+\spacer[0.5]
+\pause
 
-\lz\pause
-\textbf{For cross-entropy loss:} 
-  \begin{itemize}
-      \item value function is the mutual information:  $v_{f^*}(S) = I(y;x_S)$
-      \item surplus contribution of a feature $x_j$ is the conditional mutual information: $v_{f^*}(S \cup \{j\}) - v_{f^*}(S) = I(y,x_i|x_S)$
-  \end{itemize}
+\textbf{For cross-entropy loss:}
+\begin{itemizeM}
+\item value function is the mutual information: $v_{f^*}(S) = I(y;x_S)$
+\item surplus contribution of a feature $x_j$ is the conditional mutual information: $v_{f^*}(S \cup \{j\}) - v_{f^*}(S) = I(y,x_i|x_S)$
+\end{itemizeM}
+\spacer[0.5]
+\pause
 
-\lz\pause
-
-\textbf{For MSE loss:} 
-    \begin{itemize}
-    \item value function is the expected reduction in variance given knowledge of the features $x_S$: $v_{f^*}(S) = Var(y) - \E[Var(y|x_S)]$
-    \item surplus contribution is the respective reduction over $x_S$:
-    $v_{f^*}(S \cup \{j\}) - v_{f^*}(S) = \E[Var(y|x_S)] - \E[Var(y|x_{S \cup {j}})]$
-    \end{itemize}
-    
-\end{frame}
+\textbf{For MSE loss:}
+\begin{itemizeM}
+\item value function is the expected reduction in variance given knowledge of the features $x_S$: $v_{f^*}(S) = Var(y) - \E[Var(y|x_S)]$
+\item surplus contribution is the respective reduction over $x_S$:
+$v_{f^*}(S \cup \{j\}) - v_{f^*}(S) = \E[Var(y|x_S)] - \E[Var(y|x_{S \cup \{j\}})]$
+\end{itemizeM}
+\end{framev}
 
 
-\begin{frame}{Implications marginal SAGE values}
-
+\begin{framev}[align=top]{Implications marginal SAGE values}
 Can we gain insight into whether the ...
-
 \begin{enumerate}
-    \item<1> feature $x_j$ is causal for the prediction?    \begin{itemize}
-      \item for all coalitions $S$, $v(j \cup S) - v(S)$ can only be nonzero if $x_j \rightarrow \fh(x)$ (as for PFI)\\
-      $\leadsto$ $\phi_j$ is only nonzero if $x_j$ is causal for the prediction
-      \item $v(j \cup S) - v(S)$ may be zero due to indep. $x_j \indep y | x_S$ (as for PFI)\\
-      $\leadsto$ $\phi_j$ may be zero although the feature is causal for the prediction
-    \end{itemize}
-    \item<2> feature $x_j$ contains prediction-relevant information about $y$?
-    \begin{itemize}
-      \item value functions may be nonzero despite independence due to extrapolation (as for PFI)\\
-      $\leadsto$ $\phi_j$ may be nonzero without $x_j$ being dependent with $y$
-      \item value functions may be zero despite $x_j$ containing prediction-relevant information due to underfitting (as for PFI)\\
-      $\leadsto$ $\phi_j$ may be zero although prediction-relevant information contained
-    \end{itemize}
-    \item<3> model requires access to $x_j$ to achieve its prediction performance?    
-    \begin{itemize}
-      \item like PFI, in general marginal value functions do not allow insight into unique contribution $\leadsto$ no insight from $\phi_j$
-    \end{itemize}
+\item<1> feature $x_j$ is causal for the prediction?
+\begin{itemizeS}
+\item for all coalitions $S$, $v(j \cup S) - v(S)$ can only be nonzero if $x_j \rightarrow \fh(x)$ (as for PFI)\\
+$\leadsto$ $\phi_j$ is only nonzero if $x_j$ is causal for the prediction
+\item $v(j \cup S) - v(S)$ may be zero due to indep. $x_j \indep y | x_S$ (as for PFI)\\
+$\leadsto$ $\phi_j$ may be zero although the feature is causal for the prediction
+\end{itemizeS}
+\item<2> feature $x_j$ contains prediction-relevant information about $y$?
+\begin{itemizeS}
+\item value functions may be nonzero despite independence due to extrapolation (as for PFI)\\
+$\leadsto$ $\phi_j$ may be nonzero without $x_j$ being dependent with $y$
+\item value functions may be zero despite $x_j$ containing prediction-relevant information due to underfitting (as for PFI)\\
+$\leadsto$ $\phi_j$ may be zero although prediction-relevant information contained
+\end{itemizeS}
+\item<3> model requires access to $x_j$ to achieve its prediction performance?
+\begin{itemizeS}
+\item like PFI, in general marginal value functions do not allow insight into unique contribution $\leadsto$ no insight from $\phi_j$
+\end{itemizeS}
 \end{enumerate}
-
-\end{frame}
+\end{framev}
 %
-\begin{frame}{Implications conditional SAGE values}
-
+\begin{framev}[align=top]{Implications conditional SAGE values}
 Can we gain insight into whether the ...
-
 \begin{enumerate}
-    \item<1> feature $\xj$ is causal for the prediction?
-    \begin{itemize}
-      \item value funcs may be nonzero although feature is not directly used by $\fh$\\
-      $\leadsto$ nonzero $\phi_j$ does not imply $\xj \rightarrow \hat{y}$
-      \item value functions may be zero although feature may be used by the model, e.g. if feature is independent with $y$ and all other features \\ $\leadsto$ zero $\phi_j$ does not imply $\xj \not \rightarrow \hat{y}$
-    \end{itemize}
-    \item<2> feature $\xj$ contains prediction-relevant information about $y$?
-    \begin{itemize}
-      \item e.g. for cross-entropy optimal $\fh$, $v(j)$ measures mutual info. $I(y;x_j)$
-      $\leadsto$ prediction-relevance implies nonzero $\phi_j$
-      \item $x_j \indep y$ does not imply $x_j \indep y | x_S$ and consequently does not imply $v(j \cup S) - v(S) = 0$
-      $\leadsto$ $\phi_j$ may be nonzero although $\xj \indep y$
+\item<1> feature $\xj$ is causal for the prediction?
+\begin{itemizeS}
+\item value funcs may be nonzero although feature is not directly used by $\fh$\\
+$\leadsto$ nonzero $\phi_j$ does not imply $\xj \rightarrow \hat{y}$
+\item value functions may be zero although feature may be used by the model, e.g. if feature is independent with $y$ and all other features \\
+$\leadsto$ zero $\phi_j$ does not imply $\xj \not \rightarrow \hat{y}$
+\end{itemizeS}
+\item<2> feature $\xj$ contains prediction-relevant information about $y$?
+\begin{itemizeS}
+\item e.g. for cross-entropy optimal $\fh$, $v(j)$ measures mutual info. $I(y;x_j)$
+$\leadsto$ prediction-relevance implies nonzero $\phi_j$
+\item $x_j \indep y$ does not imply $x_j \indep y | x_S$ and consequently does not imply $v(j \cup S) - v(S) = 0$
+$\leadsto$ $\phi_j$ may be nonzero although $\xj \indep y$
     %   \item $x_j \indep y$ in general does not imply $x_j \indep y | x_S$ and consequently does not imply that $v(j \cup S) - v(S) = 0$\\
     %   $\leadsto$ $\phi_j$ may be nonzero although $\xj \indep y$
-    \end{itemize}
-    \item<3> model requires access to $x_j$ to achieve its prediction performance?  
-    \begin{itemize}
-        \item e.g. for cross-entropy optimal $\fh$, surplus contrib. $v(j \cup -j) - v(-j)$ captures the conditional mutual information $I(y;x_j|x_{-j})$\\
-        $\leadsto$ $\phi_j$ is nonzero for features with unique contribution
-        \item $x_j \indep y | x_{-j}$ does not imply $x_j \indep y | x_S$ (cond. w.r.t. to arbitrary coalitions $S$)\\
-        $\leadsto$ $\phi_j$ may be nonzero although feature has no unique contrib.
-    \end{itemize}
+\end{itemizeS}
+\item<3> model requires access to $x_j$ to achieve its prediction performance?
+\begin{itemizeS}
+\item e.g. for cross-entropy optimal $\fh$, surplus contrib. $v(j \cup -j) - v(-j)$ captures the conditional mutual information $I(y;x_j|x_{-j})$\\
+$\leadsto$ $\phi_j$ is nonzero for features with unique contribution
+\item $x_j \indep y | x_{-j}$ does not imply $x_j \indep y | x_S$ (cond. w.r.t. to arbitrary coalitions $S$)\\
+$\leadsto$ $\phi_j$ may be nonzero although feature has no unique contrib.
+\end{itemizeS}
 \end{enumerate}
-
-\end{frame}
+\end{framev}
 
 % \begin{frame}
 %   \printbibliography
 % \end{frame}
 
-\begin{frame}{Deep dive: Shapley axioms for SAGE}
-
+\begin{framev}[align=top]{Deep dive: Shapley axioms for SAGE}
 The Shapley axioms can be translated into properties of SAGE. The interpretation depends on whether conditional or marginal sampling is used.
 %
 \begin{table}
-  \centering
-  \begin{tabular}{l | l }
-  Shapley property $\implies$ & conditional SAGE property \\
-  \hline
-  efficiency & $\sum_{i=1}^p \phi_j(v) = \risk(\fh_\emptyset) - \risk(\fh)$\\ % \hline
-  symmetry & $x_j = x_i \implies \phi_i = \phi_j$ \\ 
-  linearity & $\phi_j$ expectation of per-instance\\
-  & conditional SHAP applied to model loss\\ %\hline
-  monotonicity & given models $f, f'$, if  $\forall S:$\\
-  &$v_f(S \cup j) - v_f(S) \geq v_{f'}(S \cup j) - v_{f'}(S)$ \\
-  &then $\phi_j(v_f) \geq \phi_j(v_{f'})$\\ %\hline
-  dummy & if $\forall S: \fh(x) \indep x_j | x_S \Rightarrow \phi_j = 0$
-  \end{tabular}
+\centering
+\begin{tabular}{l | l }
+Shapley property $\implies$ & conditional SAGE property \\
+\hline
+efficiency & $\sum_{i=1}^p \phi_j(v) = \risk(\fh_\emptyset) - \risk(\fh)$\\ % \hline
+symmetry & $x_j = x_i \implies \phi_i = \phi_j$ \\
+linearity & $\phi_j$ expectation of per-instance\\
+& conditional SHAP applied to model loss\\ %\hline
+monotonicity & given models $f, f'$, if  $\forall S:$\\
+&$v_f(S \cup j) - v_f(S) \geq v_{f'}(S \cup j) - v_{f'}(S)$ \\
+&then $\phi_j(v_f) \geq \phi_j(v_{f'})$\\ %\hline
+dummy & if $\forall S: \fh(x) \indep x_j | x_S \Rightarrow \phi_j = 0$
+\end{tabular}
 \end{table}
+\end{framev}
 
-\end{frame}
 
-\begin{frame}{Deep dive: Shapley axioms for SAGE}
+\begin{framev}[align=top]{Deep dive: Shapley axioms for SAGE}
 %
 The Shapley axioms can be translated into properties of SAGE. The interpretation depends on whether conditional or marginal sampling is used.
 %
 \begin{table}
-  \centering
-  \begin{tabular}{l | l }
-  Shapley property $\implies$ & marginal SAGE property \\
-  \hline
-  efficiency & $\sum_{i=1}^p \phi_j(v) = \risk(\fh_\emptyset) - \risk(\fh)$\\
-  symmetry & no intelligible implication \\
-  linearity & $\phi_j$ expecation of per-instance\\
-  & marginal SHAP applied to model loss\\
-  monotonicity & given models $f, f'$, if  $\forall S:$\\
-  &$v_f(S \cup j) - v_f(S) \geq v_{f'}(S \cup j) - v_{f'}(S)$ \\
-  &then $\phi_j(v_f) \geq \phi_j(v_{f'})$\\
-  dummy & model invariant to $x_j \Rightarrow \phi_j = 0$\\
-  \end{tabular}
+\centering
+\begin{tabular}{l | l }
+Shapley property $\implies$ & marginal SAGE property \\
+\hline
+efficiency & $\sum_{i=1}^p \phi_j(v) = \risk(\fh_\emptyset) - \risk(\fh)$\\
+symmetry & no intelligible implication \\
+linearity & $\phi_j$ expecation of per-instance\\
+& marginal SHAP applied to model loss\\
+monotonicity & given models $f, f'$, if  $\forall S:$\\
+&$v_f(S \cup j) - v_f(S) \geq v_{f'}(S \cup j) - v_{f'}(S)$ \\
+&then $\phi_j(v_f) \geq \phi_j(v_{f'})$\\
+dummy & model invariant to $x_j \Rightarrow \phi_j = 0$\\
+\end{tabular}
 \end{table}
 %
-\end{frame}
+\end{framev}
 
 \endlecture
 \end{document}

--- a/slides/feature-importance/slides05-fi-loco.tex
+++ b/slides/feature-importance/slides05-fi-loco.tex
@@ -4,11 +4,10 @@
 \input{../../latex-math/basic-math}
 \input{../../latex-math/basic-ml}
 % Defines macros and environments
- 
+
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 %\bibliography{feature-importance}
 
@@ -55,101 +54,88 @@ figure_man/feature-importance.png
 
 % \end{frame}
 
-\begin{frame}{LOCO \furtherreading{LEI2018} \furtherreading{TIBSHIRANI2018}}
+\begin{framev}[align=top]{LOCO \furtherreading{LEI2018} \furtherreading{TIBSHIRANI2018}}
 % citation of the original LOCO paper
 %
-\textbf{LOCO idea:} Remove the feature from data, refit model on reduced data, and measure the loss in performance compared to model fitted on complete data. %Remove the feature from the dataset and refit the model on the reduced dataset. The performance loss compared to the full model is interpreted as feature importance.
-
-\pause\medskip
-
+\textbf{LOCO idea:} Remove the feature from data, refit model on reduced data, and measure the loss in performance compared to model fitted on complete data.\\ %Remove the feature from the dataset and refit the model on the reduced dataset. The performance loss compared to the full model is interpreted as feature importance.
+\pause
+\spacer[0.25]
 %\textbf{Definition:} Given train and test data $\Dtrain, \Dtest \subseteq \D$, for learner $\ind$ and model $\fh = \ind(\Dtrain)$. Then LOCO for a feature $j \in \pset$ can be computed as follows:
-\textbf{Definition:} Given train and test data $\Dtrain, \Dtest \subseteq \D$, a learner $\ind$, and model $\fh := \ind(\Dtrain)$, the LOCO importance for feat $j \in \pset$ is computed by:
-
-\medskip
-
-  \begin{enumerate}
-    \item Learn model on ${\Dtrain}_{,-j}$ where feature $x_j$ was removed, i.e. $\fh_{-j} = \ind({\Dtrain}_{,-j})$\pause
-    \item Compute the difference in local $L_1$ loss for each element in $\Dtest$, i.e. $\Delta_j^{(i)} = \left  |y^{(i)} - \fh_{-j}(x_{-j}^{(i)}) \right | - \left |y^{(i)} - \fh(x^{(i)}) \right | $ with $i \in \Dtest$\pause
-    \item Compute importance score by $\text{LOCO}_j = \text{med} \left ( \Delta_j  \right )$
-  \end{enumerate}
-
-\medskip\pause
-
+\textbf{Definition:} Given train and test data $\Dtrain, \Dtest \subseteq \D$, a learner $\ind$, and model $\fh := \ind(\Dtrain)$, the LOCO importance for feat $j \in \pset$ is computed by:\\
+\spacer[0.25]
+\begin{enumerate}
+\item Learn model on ${\Dtrain}_{,-j}$ where feature $x_j$ was removed, i.e. $\fh_{-j} = \ind({\Dtrain}_{,-j})$
+\pause
+\item Compute the difference in local $L_1$ loss for each element in $\Dtest$, i.e. $\Delta_j^{(i)} = |y^{(i)} - \fh_{-j}(x_{-j}^{(i)})| - |y^{(i)} - \fh(x^{(i)})|$ with $i \in \Dtest$
+\pause
+\item Compute importance score by $\text{LOCO}_j = \text{med}(\Delta_j)$
+\end{enumerate}
+\spacer[0.25]
+\pause
 The method can be generalized to other loss functions and aggregations. If we use mean instead of median we can rewrite LOCO as
 %
-$$ \text{LOCO}_j = \riske(\fh_{-j}) - \riske(\fh).$$
+$$
+\text{LOCO}_j = \riske(\fh_{-j}) - \riske(\fh)
+$$
 %\footnote[frame]{\fullcite{lei_distribution-free_2018}\\ \fullcite{tibshirani_loco_2018}}
-\end{frame}
+\end{framev}
 
-\begin{frame}{Bike Sharing Example}
+
+\begin{framev}[align=top]{Bike Sharing Example}
 %
-\begin{figure}
-  \centering
-  \includegraphics[width=\textwidth]{figure_man/bike_sharing_loco.pdf}
+\image{figure_man/bike_sharing_loco.pdf}
 %\caption{A random forest with default hyperparameters was fit on $70\%$ of the bike sharing data (training set) to optimize MSE. Then LOCO was computed for all features on the test data. The temperature is the most important feature. Without access to \texttt{temp}, the MSE increases by approx. $140,000$.}
-\end{figure}
 %
  %\textbf{Interpretation:} $\text{LOCO}_j$ quantifies how important variable $x_j$ is to the generalization performance of the learner on $\Dtrain$.\\
 %
-\begin{itemize}
-  \item Trained random forest (default hyperparams) on 70\% of bike sharing data
-  \item Performance measure: mean squared error (MSE)
-  \item Computed LOCO on test set for all features, measuring increase in MSE
-  \item \texttt{temp} was most important: removal increased MSE by approx. $140.000$
-\end{itemize}
+\begin{itemizeS}
+\item Trained random forest (default hyperparams) on 70\% of bike sharing data
+\item Performance measure: mean squared error (MSE)
+\item Computed LOCO on test set for all features, measuring increase in MSE
+\item \texttt{temp} was most important: removal increased MSE by approx. $140.000$
+\end{itemizeS}
+\end{framev}
 
-\end{frame}
 
-\begin{frame}{Interpretation of LOCO}
-
+\begin{framev}[align=top]{Interpretation of LOCO}
 \textbf{Interpretation:} LOCO estimates the generalization error of the learner on a reduced dataset $\D_{-j}$.\\
-\lz
+\spacer[0.25]
 Can we get insight into whether the ...
 \begin{enumerate}
-    \item feature $x_j$ is causal for the prediction $\yh$?
-    \begin{itemize}
-      \item In general, no, also because we refit the model (counterexample on the next slide)
-    \end{itemize}
-    \item feature $x_j$ contains prediction-relevant information?
-    \begin{itemize}
-      \item In general, no (counterexample on the next slide)
-    \end{itemize}
-    \item model requires access to $x_j$ to achieve its prediction performance?
-    \begin{itemize}
-      \item Approximately, it provides insight into whether the \textit{learner} requires access to $x_j$
-    \end{itemize}
+\item feature $x_j$ is causal for the prediction $\yh$?
+\begin{itemizeS}
+\item In general, no, also because we refit the model (counterexample on the next slide)
+\end{itemizeS}
+\item feature $x_j$ contains prediction-relevant information?
+\begin{itemizeS}
+\item In general, no (counterexample on the next slide)
+\end{itemizeS}
+\item model requires access to $x_j$ to achieve its prediction performance?
+\begin{itemizeS}
+\item Approximately, it provides insight into whether the \textit{learner} requires access to $x_j$
+\end{itemizeS}
 \end{enumerate}
-\end{frame}
-
-\begin{frame}{Interpretation of LOCO}
+\end{framev}
 
 
-
+\begin{framev}[align=top]{Interpretation of LOCO}
 % x1 = rnorm(n, mean=0, sd = 5)
 % x2 = rnorm(n, mean=0, sd = 0.1) + x1
 % x3 = rnorm(n, mean=0, sd = 5)
 % y = rnorm(n, mean = 0, sd = 2) + x3 + x2
-
 \textbf{Example:} Sample $1000$ observations with
-\begin{itemize}
-    \item $x_1, x_3 \sim N(0, 5)$,  $x_2 = x_1 + \epsilon_2$ with $\epsilon_2 \sim N(0, 0.1)$
-    \item $y = x_2 + x_3 + \epsilon$ with $\epsilon \sim N(0, 2)$
-    \item Trained LM: $\fh(x) = -0.02 - 1.02 x_1 + 2.05 x_2 + 0.98 x_3$
-\end{itemize}
-
+\begin{itemizeM}
+\item $x_1, x_3 \sim N(0, 5)$, $x_2 = x_1 + \epsilon_2$ with $\epsilon_2 \sim N(0, 0.1)$
+\item $y = x_2 + x_3 + \epsilon$ with $\epsilon \sim N(0, 2)$
+\item Trained LM: $\fh(x) = -0.02 - 1.02 x_1 + 2.05 x_2 + 0.98 x_3$
+\end{itemizeM}
 %Sample $1000$ observations with $x_1, x_3 \sim N(0, 5), x_2 = x_1 + \epsilon_2$ with $\epsilon_2 \sim N(0, 0.1)$ and $y = x_2 + x_3 + \epsilon$ with $\epsilon \sim N(0, 2)$.
-
 \pause
-
-\begin{columns}[c, totalwidth=\textwidth]
-\begin{column}{0.42\textwidth}
-\includegraphics[width=\linewidth]{figure_man/simulation_loco_corr.pdf}\\
+\splitVCC[0.42]{
+\image{figure_man/simulation_loco_corr.pdf}\\
 \centerline{Correlation matrix}
-
-\end{column}
-\begin{column}{0.58\textwidth}
-\centering
-\includegraphics[width=0.9\linewidth]{figure_man/simulation_loco}\\
+}{
+\imageC[0.9]{figure_man/simulation_loco}
 LOCO importance from LM trained on 70\% of data, evaluated on remaining 30\%
 %LOCO importance of LM fitted on 70\% of the data computed on 30\% remaining observations
 %\begin{figure}
@@ -170,43 +156,42 @@ LOCO importance from LM trained on 70\% of data, evaluated on remaining 30\%
 % \includegraphics[width=\linewidth]{figure_man/simulation_loco}
 %\hfill
 %\end{figure}
-
 %Linear Gaussian data generating process with correlation matrix as depicted left.
 %A linear model was fit with $\fh(x) = -0.09 - 0.86 x_1 + 1.86 x_2 + 0.96 x_3$.\\
+}
+\spacer[0.25]
+\pause
 
-\end{column}
-\end{columns}
-
-\lz\pause
-
-$\Rightarrow$ We cannot infer (1) from LOCO (e.g. $\text{LOCO}_2 \approx 0$ but coef. of $x_2$ is $2.05$)\\\pause
-$\Rightarrow$ We also can't infer (2), e.g., $Cor(x_2, y) = 0.68$ but $\text{LOCO}_2 \approx 0$\\\pause
-$\Rightarrow$ We can get insight into (3): $x_2$, $x_1$ highly corr. with $\text{LOCO}_1 = \text{LOCO}_2  \approx 0$ \\
+$\Rightarrow$ We cannot infer (1) from LOCO (e.g. $\text{LOCO}_2 \approx 0$ but coef. of $x_2$ is $2.05$)\\
+\pause
+$\Rightarrow$ We also can't infer (2), e.g., $Cor(x_2, y) = 0.68$ but $\text{LOCO}_2 \approx 0$\\
+\pause
+$\Rightarrow$ We can get insight into (3): $x_2$, $x_1$ highly corr. with $\text{LOCO}_1 = \text{LOCO}_2 \approx 0$ \\
 \phantom{$\Rightarrow$} $\leadsto$ $x_2$ and $x_1$ take each others place if one of them is left out (unlike $x_3$)
 %As $x_2$ and $x_1$ are highly correlated, they can take each others place, which is not the case for $x_3$.
-\end{frame}
+\end{framev}
 
 %TODO: Why only?
-\begin{frame}{Pros and Cons}
-  Pros:
-  \begin{itemize}
-    \item Requires (only?) one refitting step per feature for evaluation
-    \item Easy to implement
-    \item Testing framework available in \furtherreading{LEI2018}
-  \end{itemize}
+\begin{framev}[align=top]{Pros and Cons}
+Pros:
+\begin{itemizeM}
+\item Requires (only?) one refitting step per feature for evaluation
+\item Easy to implement
+\item Testing framework available in \furtherreading{LEI2018}
+\end{itemizeM}
 %
-  Cons:
-  \begin{itemize}
-    \item Provides insight into a learner on specific data, not a specific model\\
-    $+$ for algorithm-level insight\\
-    $-$ for model-specific insights
-    %Does not provide insight into a specific model, but rather a learner on a specific dataset
-    \item Model training is a random process and LOCO estimates can be noisy\\
-    $\leadsto$ Limits inference on model and data, or multiple refittings necessary?
-    \item Requires re-fitting the learner for each feature\\
-    $\leadsto$ Computationally intensive compared to PFI
-  \end{itemize}
-\end{frame}
+Cons:
+\begin{itemizeM}
+\item Provides insight into a learner on specific data, not a specific model\\
+$+$ for algorithm-level insight\\
+$-$ for model-specific insights
+%Does not provide insight into a specific model, but rather a learner on a specific dataset
+\item Model training is a random process and LOCO estimates can be noisy\\
+$\leadsto$ Limits inference on model and data, or multiple refittings necessary?
+\item Requires re-fitting the learner for each feature\\
+$\leadsto$ Computationally intensive compared to PFI
+\end{itemizeM}
+\end{framev}
 
 %\begin{frame}{Bibliography}
 %  \printbibliography


### PR DESCRIPTION
## Summary

Clean up the Feature Importance slide deck LaTeX source while preserving slide content and rendered output as closely as practical.

## Changes

- Refactor active slide source across `slides01` through `slides05` in `slides/feature-importance`.
- Normalize frames to project helpers such as `framev` / `framei` with explicit `align=top`.
- Replace raw Beamer layouts with project split helpers where appropriate.
- Normalize list environments to `itemizeM` / `itemizeS`.
- Replace manual vertical spacing commands with `\spacer[...]`.
- Use project image helpers where suitable and keep paths relative to the slide files.
- Clean up title metadata and remove redundant active `\date{}` declarations.
- Preserve commented-out slide content.

## Scope

Changed files:

- `slides/feature-effects/slides01-fi-intro.tex`
- `slides/feature-effects/slides02-fi-pfi`
- `slides/feature-effects/slides03-fi-cfi.tex`
- `slides/feature-effects/slides04-fi-sage.tex`
- `slides/feature-effects/slides05-fi-loco.tex`
