### PR TITLE
refactor(slides): clean up interpretable models slides

### DIFF
--- a/slides/interpretable-models/slides01-im-motivation.tex
+++ b/slides/interpretable-models/slides01-im-motivation.tex
@@ -1,14 +1,13 @@
-\documentclass[10pt,compress,t,notes=noshow, xcolor=table]{beamer}
+\documentclass[10pt,compress,t,notes=noshow,xcolor=table]{beamer}
 
 \input{../../style/preamble}
 % Defines macros and environments
- 
+
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
-\begin{document} 
+\begin{document}
 
 \titlemeta{
 Interpretable Models 1
@@ -22,211 +21,187 @@ figure/whitebox
 \item Advantages and disadvantages of interpretable models
 }
 
-
-\begin{frame}{Motivation}
+\begin{framev}[align=top]{Motivation}
 %Achieving interpretability by using interpretable models is the most straightforward approach
 %\bigskip
-\begin{columns}[T, totalwidth = \textwidth]
-    \begin{column}{0.58\textwidth}
-    \begin{itemize}
-        %\item Obtaining interpretations by using interpretable models is the easiest and least error-prone approach
-       \item Achieving interpretability by using interpretable models is the most straightforward approach
-         \item Classes of models deemed interpretable:
-   \begin{itemize}
-  \footnotesize
-  \item (Generalized) linear models (LM, GLM)
-  \item Generalized additive models (GAM)
-  \item Decision trees
-  \item Rule-based learning
-  \item Model-based / component-wise boosting
-  \item ...
-\end{itemize}
-    \end{itemize}
-    
-
-    \end{column}
-    \begin{column}{0.42\textwidth}  %%<--- here
-    \centering
-  \includegraphics[width = 0.8\textwidth]{figure/main_effect_lm_temp.pdf}
-  \begin{center}
-    $\leadsto$ LM provides straightforward interpretation
-  \end{center}
-
-    \end{column}
-\end{columns}
-
-\begin{itemize}
- \item Often there is a trade-off between interpretability and model performance 
-        %(but not always)
-\end{itemize}
+\splitVTT[0.58]{
+\spacer[0.6]
+\begin{itemizeM}
+%\item Obtaining interpretations by using interpretable models is the easiest and least error-prone approach
+\item Achieving interpretability by using interpretable models is the most straightforward approach
+\item Classes of models deemed interpretable:
+\begin{itemizeS}[small]
+\item (Generalized) linear models (LM, GLM)
+\item Generalized additive models (GAM)
+\item Decision trees
+\item Rule-based learning
+\item Model-based / component-wise boosting
+\item ...
+\end{itemizeS}
+\end{itemizeM}
+}{
+\spacer[0]
+\imageC[0.8]{figure/main_effect_lm_temp.pdf}
 \centering
-\includegraphics[width=0.55\textwidth]{figure/performance_vs_interpretability.pdf}
-    % Quelle: https://docs.google.com/presentation/d/12ZPrTjBKEUT-7drdyUJCQGK0oHVDtYIVd2_6byE62f0/edit?usp=sharing
-\end{frame}
+$\leadsto$ LM provides straightforward interpretation
+\par
+}
+\begin{itemizeM}
+\item Often there is a trade-off between interpretability and model performance
+%(but not always)
+\end{itemizeM}
+\imageC[0.55]{figure/performance_vs_interpretability.pdf}
+% Quelle: https://docs.google.com/presentation/d/12ZPrTjBKEUT-7drdyUJCQGK0oHVDtYIVd2_6byE62f0/edit?usp=sharing
+\end{framev}
 
-\begin{frame}{Advantages}
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.8\textwidth}
-    \begin{itemize}[<+->]
-    \itemsep1em
-        \item Interpretable models are transparent by design, making many model-agnostic explanation methods unnecessary\\
-        %For inherently interpretable models some additional model-agnostic interpretation methods not required \\
-        $\leadsto$ Eliminates an extra source of estimation error
-        \item They often have few hyperparameters and are structurally simple (e.g., linear, additive, sparse, monotonic)\\
-        $\leadsto$ Easy to train, fast to tune, straightforward to explain
-        % \item Interpretable models often simple \\
-        % $\leadsto$ training time is fairly small
-        % \item Some interpretable models estimate monotonic effects \\
-        % %the monotonicity constraint \\
-        % $\leadsto$ Simple to explain as larger feature values always lead to higher (or smaller) outcomes (e.g., GLMs)
-        \item Many people are familiar with simple interpretable models \\
-        $\leadsto$ Increases trust, facilitates communication of results
-        %\item Implementations are available in many programming languages \\
-        %$\leadsto$ Simple models are easier to deploy in practice or implement from scratch
-    \end{itemize}
-\end{column}
-\begin{column}{0.2\textwidth}
-    \begin{center}
-        \begin{tikzpicture}[scale=0.6, transform shape]
-        \usetikzlibrary{arrows}
-            \usetikzlibrary{shapes}
-            \tikzset{treenode/.style={draw, circle, font=\small}}
-            \tikzset{line/.style={draw, thick}}
-            \node [treenode, draw=red] (a0) {$a_0$};
-            \node [treenode, below=0.75cm of a0, xshift=-1cm]  (a1) {$a_1$};
-            \node [treenode, draw=red, below=0.75cm of a0, xshift=1cm]  (a2) {$a_2$};
-     
-            \node [treenode, draw=red, below=0.75cm of a2, xshift=-1cm] (a3) {$a_3$};
-            \node [treenode, below=0.75cm of a2, xshift=1cm]  (a4) {$a_4$};
-     
-            \node [treenode, below=0.75cm of a3, xshift=-1cm] (a5) {$a_5$};
-            \node [treenode, below=0.75cm of a3, xshift=1cm]  (a6) {$a_6$};
-     
-            \path [line] (a0.south) -- + (0,-0.4cm) -| (a1.north) node [midway, above] {$x_1<0.3$};
-            \path [line] (a0.south) -- +(0,-0.4cm) -|  (a2.north) node [midway, above] {$x_1\geq0.3$};
-     
-            \path [line] (a2.south) -- + (0,-0.4cm) -| (a3.north) node [midway, above] {$x_1<0.6$};;
-            \path [line] (a2.south) -- +(0,-0.4cm) -|  (a4.north) node [midway, above] {$x_1\geq0.6$};
-     
-          
-            \path [line] (a3.south) -- + (0,-0.4cm) -| (a5.north) node [midway, above] {$x_2<0.2$};;
-            \path [line] (a3.south) -- +(0,-0.4cm) -|  (a6.north) node [midway, above] {$x_2\geq0.2$};
-     
-        \end{tikzpicture}
-        
-        \vspace{0.5cm}
-        
-        \includegraphics<2->[width = \textwidth]{figure/main_effect_lm_temp.pdf}
-    \end{center}
-\end{column}
-\end{columns}
-\end{frame}
 
-\begin{frame}{Disadvantages \& Limitations}
-\begin{columns}[totalwidth=\textwidth]
-\begin{column}{0.8\textwidth}
-    \begin{itemize}%[<+->]
-    \itemsep1em
-        \item<1-> Often require assumptions about data / model structure \\%Often certain assumptions about data / model structure required\\
-        $\leadsto$ If assumptions are wrong, models may perform bad 
-        %\item In high-dimensional settings, it may not be feasible to find and define all feature relationships
-        %\item If the wrong assumptions are made, interpretable models may have a bad predictive performance
-        %\pause
-        \item<2-> Interpretable models may also be hard to interpret, e.g.:
-    \begin{itemize}
-        \item LM with lots of features and interactions 
-        \item Decision trees with huge tree depth
-    \end{itemize}
-    \end{itemize}
-\end{column}
-\begin{column}{0.2\textwidth}
-    \begin{center}
-        \includegraphics[width = \textwidth]{figure/lm_bad_fit.pdf} 
-    \end{center}
-\end{column}
-\end{columns}
-\quad \\
+\begin{framev}[align=top]{Advantages}
+\splitVTT[0.78]{
+\spacer[0.6]
+\begin{itemizeM}
+\item<+-> Interpretable models are transparent by design, making many model-agnostic explanation methods unnecessary\\
+%For inherently interpretable models some additional model-agnostic interpretation methods not required \\
+$\leadsto$ Eliminates an extra source of estimation error
+\item<+-> They often have few hyperparameters and are structurally simple (e.g., linear, additive, sparse, monotonic)\\
+$\leadsto$ Easy to train, fast to tune, straightforward to explain
+% \item Interpretable models often simple \\
+% $\leadsto$ training time is fairly small
+% \item Some interpretable models estimate monotonic effects \\
+% %the monotonicity constraint \\
+% $\leadsto$ Simple to explain as larger feature values always lead to higher (or smaller) outcomes (e.g., GLMs)
+\item<+-> Many people are familiar with simple interpretable models\\
+$\leadsto$ Increases trust, facilitates communication of results
+%\item Implementations are available in many programming languages \\
+%$\leadsto$ Simple models are easier to deploy in practice or implement from scratch
+\end{itemizeM}
+}{
+\spacer[0]
+\begin{center}
+\begin{tikzpicture}[scale=0.6, transform shape]
+\usetikzlibrary{arrows}
+\usetikzlibrary{shapes}
+\tikzset{treenode/.style={draw, circle, font=\small}}
+\tikzset{line/.style={draw, thick}}
+\node [treenode, draw=red] (a0) {$a_0$};
+\node [treenode, below=0.75cm of a0, xshift=-1cm] (a1) {$a_1$};
+\node [treenode, draw=red, below=0.75cm of a0, xshift=1cm] (a2) {$a_2$};
+\node [treenode, draw=red, below=0.75cm of a2, xshift=-1cm] (a3) {$a_3$};
+\node [treenode, below=0.75cm of a2, xshift=1cm] (a4) {$a_4$};
+\node [treenode, below=0.75cm of a3, xshift=-1cm] (a5) {$a_5$};
+\node [treenode, below=0.75cm of a3, xshift=1cm] (a6) {$a_6$};
+\path [line] (a0.south) -- +(0,-0.4cm) -| (a1.north) node [midway, above] {$x_1<0.3$};
+\path [line] (a0.south) -- +(0,-0.4cm) -| (a2.north) node [midway, above] {$x_1\geq0.3$};
+\path [line] (a2.south) -- +(0,-0.4cm) -| (a3.north) node [midway, above] {$x_1<0.6$};
+\path [line] (a2.south) -- +(0,-0.4cm) -| (a4.north) node [midway, above] {$x_1\geq0.6$};
+\path [line] (a3.south) -- +(0,-0.4cm) -| (a5.north) node [midway, above] {$x_2<0.2$};
+\path [line] (a3.south) -- +(0,-0.4cm) -| (a6.north) node [midway, above] {$x_2\geq0.2$};
+\end{tikzpicture}
+\end{center}
+\spacer[0.25]
+\only<2->{
+\centering
+\image[0.95]{figure/main_effect_lm_temp.pdf}
+\par
+}
+}
+\end{framev}
 
-\begin{itemize}
-\itemsep1em
-        \item<3-> 
-        %No automatic modeling of complex relationships due to limited model flexibility
-        Often do not automatically model complex relationships due to limited flexibility % didn't find a way to fig the hanging word
-        \\
-        e.g., high-order main or interaction effects need to be specified manually in an LM
 
-        %\pause
-     \item<4-> Inherently interpretable models do not address all explanation needs\\
+\begin{framev}[align=top]{Disadvantages \& Limitations}
+\splitVTT[0.8]{
+\spacer[0.6]
+\begin{itemizeM}
+\item<1-> Often require assumptions about data / model structure\\%Often certain assumptions about data / model structure required\\
+$\leadsto$ If assumptions are wrong, models may perform bad
+%\item In high-dimensional settings, it may not be feasible to find and define all feature relationships
+%\item If the wrong assumptions are made, interpretable models may have a bad predictive performance
+%\pause
+\item<2-> Interpretable models may also be hard to interpret, e.g.:
+\begin{itemizeS}
+\item LM with lots of features and interactions
+\item Decision trees with huge tree depth
+\end{itemizeS}
+\end{itemizeM}
+}{
+\spacer[0]
+\imageC{figure/lm_bad_fit.pdf}
+\spacer[0]
+}
+\spacer[0.25]
+\begin{itemizeM}
+\item<3->
+%No automatic modeling of complex relationships due to limited model flexibility
+Often do not automatically model complex relationships due to limited flexibility % didn't find a way to fig the hanging word
+\\
+e.g., high-order main or interaction effects need to be specified manually in LM
+%\pause
+\item<4-> Inherently interpretable models do not address all explanation needs\\
 $\leadsto$ Complementary model-agnostic methods (e.g., counterfactuals) remain valuable for specific tasks
-     % Inherently interpretable models do not provide all types of explanations
-     % %% one might be interested
-     % \\
-     % $\leadsto$ Methods providing other types of explanations still useful  (e.g., counterfactual explanations)
-     %Methods providing other types of explanations still useful  (e.g., counterfactual explanations)
-     %Still requires application of model-agnostic interpretation techniques if certain types of explanations are of interest (e.g., counterfactual explanations)
-\end{itemize}
-\end{frame}
-
-\begin{frame}{Further Comments}
-
-    \begin{itemize}
-    %\itemsep1em
-        \item<1-> Some researchers advocate for inherently interpretable models instead of explaining black boxes after training \furtherreading{RUDIN2019}
-        \begin{itemize}
-        \item Built-in interpretation\\
-        $\leadsto$ fewer risks from misleading post-hoc explanations
-        
-            %\item \ldots instead of explaining uninterpretable models post-hoc
-            % \item Can sometimes work out by spending enough time and energy on data pre-processing or manual feature engineering
-        \item  Good performance possible with effort on preprocessing and/or feature engineering
-        \item But interpretability depends on meaning of created features\\
-        $\leadsto$ E.g., PCA keeps models linear, but yields hard-to-interpret components
-                %, or data cleaning
-        \end{itemize}
-        %\pause
-        %\footnote[frame]{Rudin, C. Stop explaining black box machine learning models for high stakes decisions and use interpretable models instead. Nat Mach Intell 1, 206–215 (2019).}
-        % {https://www.nature.com/articles/s42256-019-0048-x}
-       %\item Interpretable models also have the potential for a high predictive performance, but require more knowledge and time spent on data preprocessing
-       % \item<2->[$\leadsto$] Drawback: Hard to achieve for data for which end-to-end learning is crucial\\ 
-       % $\leadsto$ e.g., hard to extract good features for image / text data\\ 
-       % $\leadsto$ information loss can lead to bad performance
-      \item<2-> Limitation: Less suited for complex data requiring end-to-end learning
-\begin{itemize}
-    \item Applies to image, text, or sensor data where features must be learned from raw input
-    \item Manual extraction of interpretable features is difficult \\$\Rightarrow$ Information loss and lower performance
-\end{itemize}
-       %(e.g., for image / text data extraction of good features is hard $\leadsto$ information loss = bad performance)
-       %(e.g., image and text data would require good feature extraction steps $\leadsto$ information loss)
-        %\pause
-        %\item One can assume a trade-off between interpretability and model performance which generally (but not always) holds
-        %\item<3-> Often there is a trade-off between interpretability and model performance 
-        %(but not always)
-    \end{itemize}
-    
-    %\smallskip
-    
-    %\only<3>{\centering\includegraphics[width=0.65\textwidth]{figure/performance_vs_interpretability.pdf}}
-    % Quelle: https://docs.google.com/presentation/d/12ZPrTjBKEUT-7drdyUJCQGK0oHVDtYIVd2_6byE62f0/edit?usp=sharing
-
-\end{frame}
+% Inherently interpretable models do not provide all types of explanations
+% %% one might be interested
+% \\
+% $\leadsto$ Methods providing other types of explanations still useful  (e.g., counterfactual explanations)
+%Methods providing other types of explanations still useful  (e.g., counterfactual explanations)
+%Still requires application of model-agnostic interpretation techniques if certain types of explanations are of interest (e.g., counterfactual explanations)
+\end{itemizeM}
+\end{framev}
 
 
-\begin{frame}{Recommendation}
-    % \begin{itemize}
-    %     \item Start with most simple model that makes sense for application at hand
-    %     \item Gradually increase complexity if performance is insufficient\\
-    %     $\leadsto$ will usually lower interpretability and require additional interpretation methods
-    %     \item Choose the most simple, sufficient model (Occam's razor)
-    % \end{itemize} 
-\begin{itemize}
-    \item Begin with the simplest model appropriate for the task
-    \item Increase complexity only if necessary to meet performance requirements\\
-    $\leadsto$ Typically reduces interpretability and requires model-agnostic explanations
-    \item Choose the simplest model with sufficient accuracy 
-    $\leadsto$ Occam’s razor
-\end{itemize}
-    \bigskip
+\begin{framev}[align=top]{Further Comments}
+\begin{itemizeM}
+%\itemsep1em
+\item<1-> Some researchers advocate for inherently interpretable models instead of explaining black boxes after training \furtherreading{RUDIN2019}
+\begin{itemizeS}
+\item Built-in interpretation\\
+$\leadsto$ fewer risks from misleading post-hoc explanations
+%\item \ldots instead of explaining uninterpretable models post-hoc
+% \item Can sometimes work out by spending enough time and energy on data pre-processing or manual feature engineering
+\item Good performance possible with effort on preprocessing and/or feature engineering
+\item But interpretability depends on meaning of created features\\
+$\leadsto$ E.g., PCA keeps models linear, but yields hard-to-interpret components
+%, or data cleaning
+\end{itemizeS}
+%\pause
+%\footnote[frame]{Rudin, C. Stop explaining black box machine learning models for high stakes decisions and use interpretable models instead. Nat Mach Intell 1, 206–215 (2019).}
+% {https://www.nature.com/articles/s42256-019-0048-x}
+%\item Interpretable models also have the potential for a high predictive performance, but require more knowledge and time spent on data preprocessing
+% \item<2->[$\leadsto$] Drawback: Hard to achieve for data for which end-to-end learning is crucial\\
+% $\leadsto$ e.g., hard to extract good features for image / text data\\
+% $\leadsto$ information loss can lead to bad performance
+\item<2-> Limitation: Less suited for complex data requiring end-to-end learning
+\begin{itemizeS}
+\item Applies to image, text, or sensor data where features must be learned from raw input
+\item Manual extraction of interpretable features is difficult\\
+$\Rightarrow$ Information loss and lower performance
+\end{itemizeS}
+%(e.g., for image / text data extraction of good features is hard $\leadsto$ information loss = bad performance)
+%(e.g., image and text data would require good feature extraction steps $\leadsto$ information loss)
+%\pause
+%\item One can assume a trade-off between interpretability and model performance which generally (but not always) holds
+%\item<3-> Often there is a trade-off between interpretability and model performance
+%(but not always)
+\end{itemizeM}
+%\smallskip
+%\only<3>{\centering\includegraphics[width=0.65\textwidth]{figure/performance_vs_interpretability.pdf}}
+% Quelle: https://docs.google.com/presentation/d/12ZPrTjBKEUT-7drdyUJCQGK0oHVDtYIVd2_6byE62f0/edit?usp=sharing
+\end{framev}
 
+
+\begin{framev}[align=top]{Recommendation}
+% \begin{itemize}
+%     \item Start with most simple model that makes sense for application at hand
+%     \item Gradually increase complexity if performance is insufficient\\
+%     $\leadsto$ will usually lower interpretability and require additional interpretation methods
+%     \item Choose the most simple, sufficient model (Occam's razor)
+% \end{itemize}
+\begin{itemizeM}
+\item Begin with the simplest model appropriate for the task
+\item Increase complexity only if necessary to meet performance requirements\\
+$\leadsto$ Typically reduces interpretability and requires model-agnostic explanations
+\item Choose the simplest model with sufficient accuracy\\
+$\leadsto$ Occam's razor
+\end{itemizeM}
+\spacer[0.25]
 % \begin{columns}[T, totalwidth=\textwidth]
 % \begin{column}{0.5\textwidth}
 % \centering \textbf{Bike Data}
@@ -234,12 +209,12 @@ $\leadsto$ Complementary model-agnostic methods (e.g., counterfactuals) remain v
 %         \centering
 %         \begin{tabular}{lrr}
 %             \hline
-%             Model & RMSE & $R^2$ \\ 
+%             Model & RMSE & $R^2$ \\
 %             \hline
-%             LM & 142.39 & 0.38 \\ 
-%             Tree & 98.71 & 0.70 \\ 
-%             Random Forest & 57.07 & 0.90 \\ 
-%             Boosting & 197.42 & -0.18 \\  
+%             LM & 142.39 & 0.38 \\
+%             Tree & 98.71 & 0.70 \\
+%             Random Forest & 57.07 & 0.90 \\
+%             Boosting & 197.42 & -0.18 \\
 %             \hline
 %         \end{tabular}
 %     \end{table}
@@ -250,11 +225,11 @@ $\leadsto$ Complementary model-agnostic methods (e.g., counterfactuals) remain v
 %         \centering
 %         \begin{tabular}{lrr}
 %             \hline
-%             Model & RMSE & $R^2$ \\ 
+%             Model & RMSE & $R^2$ \\
 %             \hline
-%             LM & 0.43 & 1.00 \\ 
-%             Tree & 1.81 & 0.96 \\ 
-%             Random Forest & 1.77 & 0.96 \\ 
+%             LM & 0.43 & 1.00 \\
+%             Tree & 1.81 & 0.96 \\
+%             Random Forest & 1.77 & 0.96 \\
 %             Boosting & 16.89 & -2.43 \\
 %             \hline
 %         \end{tabular}
@@ -262,24 +237,23 @@ $\leadsto$ Complementary model-agnostic methods (e.g., counterfactuals) remain v
 % \end{column}
 % \end{columns}
 % code for tables in rsrc/tab_ml_comparison.R
-
-\centering \textbf{Bike Data, 4-fold CV}
-\begin{table}[ht]
+\centering
+\textbf{Bike Data, 4-fold CV}\\
+\spacer[0.25]
+\begin{table}
 \centering
 \begin{tabular}{lrr}
-  \hline
-Model & RMSE & $R^2$ \\ 
-  \hline
-  LM & 800.15 & 0.83 \\ 
-  Tree & 981.83 & 0.74 \\ 
-  Random Forest & 653.25 & 0.88 \\ 
-  Boosting (tuned) & 638.42 & 0.89 \\ 
-   \hline
+\hline
+Model & RMSE & $R^2$ \\
+\hline
+LM & 800.15 & 0.83 \\
+Tree & 981.83 & 0.74 \\
+Random Forest & 653.25 & 0.88 \\
+Boosting (tuned) & 638.42 & 0.89 \\
+\hline
 \end{tabular}
 \end{table}
-\end{frame}
-
-
+\end{framev}
 
 \endlecture
 \end{document}

--- a/slides/interpretable-models/slides02-im-lm-simple.tex
+++ b/slides/interpretable-models/slides02-im-lm-simple.tex
@@ -1,4 +1,4 @@
-\documentclass[10pt,compress,t,notes=noshow, xcolor=table]{beamer}
+\documentclass[10pt,compress,t,notes=noshow,xcolor=table]{beamer}
 
 \input{../../style/preamble}
 % Defines macros and environments
@@ -7,7 +7,6 @@
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \def\firstrowcolor{}
 \def\secondrowcolor{}
@@ -23,7 +22,7 @@
 \begin{document}
 
 \titlemeta{
-Interpretable Models 1 
+Interpretable Models 1
 }{
 Linear Regression Model
 }{
@@ -34,174 +33,154 @@ figure/lm_example
 \item What are significant features?
 }
 
-
-
-
-\begin{frame}[c]{Linear Regression}
+\begin{framev}[align=top]{Linear Regression}
 % https://towardsdatascience.com/assumptions-of-linear-regression-fdb71ebeaa8b
 % https://www.statology.org/linear-regression-assumptions/
 % https://link.springer.com/book/10.1007/978-3-642-34333-9
 %\textbf{Model formula}
-    %$$\mathbb{E}_Y(Y \vert X) = \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \ldots + \theta_p x_p + \epsilon = X^T\mathbf{\theta} + \epsilon$$
-
-\begin{columns}[T, totalwidth = \linewidth]
-\begin{column}{0.58\linewidth}
+%$$\mathbb{E}_Y(Y \vert X) = \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \ldots + \theta_p x_p + \epsilon = X^T\mathbf{\theta} + \epsilon$$
+\splitVTT[0.58]{
+\spacer[0]
 $$y = \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \dots + \theta_p x_p + \epsilon = \xv^\top \thetav + \epsilon$$
-
- \begin{itemize}
-        %\item $\mathbb{E}_Y(Y \vert X)$ expected value of target given features $X$
-        \item $y$: target / output
-        \item $\epsilon$: remaining error / residual %(e.g., due to noise)
-        \item $\theta_j$: weight of input feature $x_j$ (intercept $\theta_0$)\\
-        $\leadsto$ model consists of $p+1$ weights
-        %\item Model equation is additive and identical across entire input space
-        %\pause
-        % \item Polynomial regression extends equation above by
-        % \begin{itemize}
-        % \item \textbf{higher order main effects} which have their own weights (e.g., quadratic: $\theta_{x_j^2} \cdot x_j^2$)
-        % \item \textbf{interaction effects} (e.g., 2-way interaction: $\theta_{x_i, x_j} \cdot x_i \cdot x_j$)
-        % \end{itemize}
-    \end{itemize}
-\end{column}
-\begin{column}{0.42\linewidth}
-\includegraphics[width=\linewidth]{figure/lm_example.pdf}
-\end{column}
-\end{columns}
-   
-   \vspace*{0.2cm} 
-   \pause
-    \textbf{Properties and assumptions} \furtherreading{FARAWAY2002} % \furtherreading{CheckingAssumptions}
-    \begin{itemize}[<+->]
-    \item \textbf{Linear} relationship between features and target
-    %Predictions are \textbf{linear} combination of features $\leadsto$ 
-    %Model equation is additive and linear w.r.t. features% and identical across entire input space
-    \item $\epsilon$ and $y \vert \xv$ are \textbf{normally} distributed with \textbf{constant variance} (homoscedastic)\\
-    $\leadsto$ $\epsilon \sim N(0, \sigma^2) \; \Rightarrow \; (y \vert \xv) \sim N(\xv^\top \theta, \sigma^2)$\\
-    $\leadsto$ if violated, inference-based metrics (e.g., p-values) are invalid
-    %\item Error terms are assumed to have a \textbf{constant variance} over the entire feature space %(homoscedasticity)
-    \item Independence of observations (e.g., no repeated measurements) %(e.g., no autocorrelated error terms)
-    \item Features $x_j$ independent from error term $\epsilon$
-    \item No or little multicollinearity (i.e., no strong feature correlations)
-    % free of measurement error assumption: https://indigo.uic.edu/articles/thesis/Measurement_Error_in_Generalized_Linear_Models/17025971/1/files/31488719.pdf
-    % \item Note: For inference-based metrics (t-statistic, p-values, confidence intervals) to be valid, the error term needs to be normally distributed, i.e., $\epsilon \sim N(0, \sigma^2) \; \Rightarrow \; (y \vert x) \sim N(x^T \theta, \sigma^2)$\\
+% \item $\mathbb{E}_Y(Y \vert X)$ expected value of target given features $X$
+\begin{itemizeM}
+\item $y$: target / output
+\item $\epsilon$: remaining error / residual %(e.g., due to noise)
+\item $\theta_j$: weight of input feature $x_j$ (intercept $\theta_0$)\\
+$\leadsto$ model consists of $p+1$ weights
+% \item Model equation is additive and identical across entire input space
+% \pause
+% \item Polynomial regression extends equation above by
+% \begin{itemize}
+% \item \textbf{higher order main effects} which have their own weights (e.g., quadratic: $\theta_{x_j^2} \cdot x_j^2$)
+% \item \textbf{interaction effects} (e.g., 2-way interaction: $\theta_{x_i, x_j} \cdot x_i \cdot x_j$)
+% \end{itemize}
+\end{itemizeM}
+}{
+\spacer[0]
+\image{figure/lm_example.pdf}
+\spacer[0]
+}
+\spacer[0.25]
+\pause
+\textbf{Properties and assumptions} \furtherreading{FARAWAY2002} % \furtherreading{CheckingAssumptions}
+\begin{itemizeM}
+\item<+-> \textbf{Linear} relationship between features and target
+%Predictions are \textbf{linear} combination of features $\leadsto$
+%Model equation is additive and linear w.r.t. features% and identical across entire input space
+\item<+-> $\epsilon$ and $y \vert \xv$ are \textbf{normally} distributed with \textbf{constant variance} (homoscedastic)\\
+$\leadsto$ $\epsilon \sim N(0, \sigma^2) \; \Rightarrow \; (y \vert \xv) \sim N(\xv^\top \theta, \sigma^2)$\\
+$\leadsto$ if violated, inference-based metrics (e.g., p-values) are invalid
+% \item Error terms are assumed to have a \textbf{constant variance} over the entire feature space %(homoscedasticity)
+\item<+-> Independence of observations (e.g., no repeated measurements) %(e.g., no autocorrelated error terms)
+\item<+-> Features $x_j$ independent from error term $\epsilon$
+\item<+-> No or little multicollinearity (i.e., no strong feature correlations)
+% free of measurement error assumption: https://indigo.uic.edu/articles/thesis/Measurement_Error_in_Generalized_Linear_Models/17025971/1/files/31488719.pdf
+% \item Note: For inference-based metrics (t-statistic, p-values, confidence intervals) to be valid, the error term needs to be normally distributed, i.e., $\epsilon \sim N(0, \sigma^2) \; \Rightarrow \; (y \vert x) \sim N(x^T \theta, \sigma^2)$\\
 %$\leadsto$ Restricts use of LMs in practice as distribution of error is a prior assumption about data
-        % \item Properties and assumptions:
-        % \begin{itemize}
-        %     \item linear
-        %     \item normality assumption of the target % not true...
-        %     \item homoscedastic (i.e., constant variance)
-        %     \item independence of features
-        %     \item fixed features (i.e., free of noise)
-        %     \item no strong correlation of features
-        % \end{itemize} 
-    \end{itemize}
-
-\end{frame}
+% \item Properties and assumptions:
+% \begin{itemize}
+% \item linear
+% \item normality assumption of the target % not true...
+% \item homoscedastic (i.e., constant variance)
+% \item independence of features
+% \item fixed features (i.e., free of noise)
+% \item no strong correlation of features
+% \end{itemize}
+\end{itemizeM}
+\end{framev}
 
 %------------------------------------------------------------------
 %------------------------------------------------------------------
 
-\begin{frame}{Linear Regression - Interpretation}
-
- $$y = \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \dots + \theta_p x_p + \epsilon = \xv^\top \thetav + \epsilon$$
-
-    Interpretation of weights (\textbf{feature effects}) depend on type of feature:
-    \begin{itemize}[<+->]
-        \item \textbf{Numerical $x_j$}: Increasing $x_j$ by one unit changes outcome by $\theta_j$, ceteris paribus \\ (\textit{ceteris paribus} (c.p.) means "everything else held constant".)
-        \item \textbf{Binary $x_j$}: Weight $\theta_j$ is active or not (multiplication with 1 or 0)\\
-        $\leadsto$ reference category $x_j = 0$
-    \end{itemize}
+\begin{framev}[align=top]{Linear Regression - Interpretation}
+$$y = \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \dots + \theta_p x_p + \epsilon = \xv^\top \thetav + \epsilon$$
+Interpretation of weights (\textbf{feature effects}) depend on type of feature:
+\begin{itemizeM}
+\item<+-> \textbf{Numerical $x_j$}: Increasing $x_j$ by one unit changes outcome by $\theta_j$, ceteris paribus\\
+(\textit{ceteris paribus} (c.p.) means "everything else held constant".)
+\item<+-> \textbf{Binary $x_j$}: Weight $\theta_j$ is active or not (multiplication with 1 or 0)\\
+$\leadsto$ reference category $x_j = 0$
+\end{itemizeM}
 %
-\begin{columns}[T, totalwidth = \textwidth]
-\begin{column}{0.67\textwidth}
-    \begin{itemize}
-        \item<3-> %Categorical: One-hot-encoding of $L-1$ new features for $L$ categories (dummy encoding) \\
-        \textbf{Categorical feature $x_j$ with $L$ categories}: 
-        \begin{itemize}
-            \item Create $L-1$ one-hot-encoded features $x_{j,1}, \hdots, x_{j,L-1}$ (each having its own weight)
-            \item Left out cat. is reference ($\hat =$ dummy encoding)
-            \item[$\leadsto$] Interpretation:
-        Outcome changes by $\theta_{j,i}$ for category $i$ compared to reference cat.,  c.p.
-        \end{itemize}
-        %$x_{j,l}, \forall l \in \{1, \hdots, L-1\}$ (with weight $\theta_{j,l}$), left out category is reference ($\hat =$ dummy encoding)       
-        % (for any of the $L-1$ categories):
-        %Predicted outcome changes for $l$-th category compared to the reference category by its weight $\theta_{j,l}$ c.p.
-        %Predicted outcome changes for category $x_{j,l}$ compared to the reference category by $\theta_j$ c.p.
-        \item<4> \textbf{Intercept $\theta_0$}: Expected outcome if all feature values are set to 0 %(baseline) %reflects expected features values if features were standardised (0-mean, 1-stdev)
-        %\item Note: In case of higher order or interaction effects, weights cannot be interpreted in isolation
-    \end{itemize}
-\end{column}
-\begin{column}{0.33\textwidth}
+\splitVTT[0.67]{
+\spacer[0.6]
+\begin{itemizeM}
+\item<3-> %Categorical: One-hot-encoding of $L-1$ new features for $L$ categories (dummy encoding) \\
+\textbf{Categorical feature $x_j$ with $L$ categories}:
+\begin{itemizeS}
+\item Create $L-1$ one-hot-encoded features $x_{j,1}, \hdots, x_{j,L-1}$ (each having its own weight)
+\item Left out cat. is reference ($\hat =$ dummy encoding)
+\item[$\leadsto$] Interpretation:
+Outcome changes by $\theta_{j,i}$ for category $i$ compared to reference cat., c.p.
+\end{itemizeS}
+%$x_{j,l}, \forall l \in \{1, \hdots, L-1\}$ (with weight $\theta_{j,l}$), left out category is reference ($\hat =$ dummy encoding)
+% (for any of the $L-1$ categories):
+%Predicted outcome changes for $l$-th category compared to the reference category by its weight $\theta_{j,l}$ c.p.
+%Predicted outcome changes for category $x_{j,l}$ compared to the reference category by $\theta_j$ c.p.
+\item<4> \textbf{Intercept $\theta_0$}: Expected outcome if all feature values are set to 0 %(baseline) %reflects expected features values if features were standardised (0-mean, 1-stdev)
+%\item Note: In case of higher order or interaction effects, weights cannot be interpreted in isolation
+\end{itemizeM}
+}{
+\spacer[0]
 %\begin{center}
-        \includegraphics[trim={0 5 0 5},clip, width = \textwidth]{figure/reg_lm_plot_interpreted.pdf}\\
-        % Bild aus I2ML: supervised-regression
-        %figure/plot_lin_effect.pdf} \\
-        %Boxplot of $\hat\theta_j x_j$-values (scale invariant)
-        %$\leadsto$ Comparable feature contributions w.r.t. $\hat y$
-    %\end{center}
-\end{column}
-\end{columns}
-    
-\end{frame}
-
-     
-\begin{frame}{Linear Regression - Interpretation}
-\vspace{-0.2cm}
- $$y = \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \dots + \theta_p x_p + \epsilon = \xv^\top \thetav + \epsilon$$
-
-    \textbf{Feature importance}:
-    \begin{columns}[T, totalwidth=\textwidth]
-    \begin{column}{0.61\textwidth}
-    \begin{itemize}
-        \item Absolute \textbf{t-statistic} value: $\hat\theta_j$ scaled with standard error ($SE(\hat\theta_j)$ $\hat =$ reliability of estimate) 
-    $$|t_{\hat\theta_j}| = \left| \frac{\hat\theta_j}{SE(\hat\theta_j)} \right|$$
-        \item High $t$-values $\Rightarrow$ important (significant) feat.
-    \end{itemize}
-    \end{column}
-    \begin{column}{0.39\textwidth}
-    %\vspace{-0.2cm}
-    %\begin{center}
-        \includegraphics[width=\textwidth]{figure/t_stat.pdf} 
-    %\end{center}
-    \end{column}
-    \end{columns}
-    \vspace{0.3cm}
-    \only<2->{
-    \begin{columns}[T, totalwidth=\textwidth]
-    \begin{column}{0.65\textwidth}
-    \begin{itemize}
-        \item \textbf{p-value}: 
-        probability of obtaining a more extreme test statistic assuming $H_0$ is correct (here: $\theta_j =0$, i.e., feat. $j$ not significant)
-        %probability of obtaining a test statistic that is more extreme (values that speak against $H_0$) as the test statistic computed from the sample, assuming $H_0$ (here: $\theta_j =0)$ is correct.
-        \\
-        $\leadsto$ High $|t|$ $\Rightarrow$ small p-val. (speak against $H_0$)
-        %\item The smaller the p-value, the less likely it is to obtain a more extreme test statistic
-    \end{itemize}
-    \end{column}
-    \begin{column}{0.35\textwidth}
-    %\vspace{-0.3cm}
-    %\begin{center}
-        \includegraphics[width=\textwidth]{figure/p-value.pdf}
-    %\end{center}
-    \end{column}
-    \end{columns}}
-\end{frame}
+\centering
+\includegraphics[trim={0 5 0 5},clip,width=\textwidth]{figure/reg_lm_plot_interpreted.pdf}\\
+% Bild aus I2ML: supervised-regression
+%figure/plot_lin_effect.pdf} \\
+%Boxplot of $\hat\theta_j x_j$-values (scale invariant)
+%$\leadsto$ Comparable feature contributions w.r.t. $\hat y$
+%\end{center}
+\par
+}
+\end{framev}
 
 
-\begin{frame}{Example: Lin. Regression - Main Effects}
+\begin{framev}[align=top]{Linear Regression - Interpretation}
+$$y = \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \dots + \theta_p x_p + \epsilon = \xv^\top \thetav + \epsilon$$
+\textbf{Feature importance}:
+\splitVTT[0.61]{
+\spacer[0.6]
+\begin{itemizeM}
+\item Absolute \textbf{t-statistic} value: $\hat\theta_j$ scaled with standard error ($SE(\hat\theta_j)$ $\hat =$ reliability of estimate)
+$$|t_{\hat\theta_j}| = \left| \frac{\hat\theta_j}{SE(\hat\theta_j)} \right|$$
+\item High $t$-values $\Rightarrow$ important (significant) feat.
+\end{itemizeM}
+}{
+\spacer[0]
+\image{figure/t_stat.pdf}
+\spacer[0]
+}
+\spacer[0.25]
+\only<2->{
+\splitVTT[0.65]{
+\spacer[0.6]
+\begin{itemizeM}
+\item \textbf{p-value}: probability of obtaining a more extreme test statistic assuming $H_0$ is correct (here: $\theta_j = 0$, i.e., feat. $j$ not significant)\\
+%probability of obtaining a test statistic that is more extreme (values that speak against $H_0$) as the test statistic computed from the sample, assuming $H_0$ (here: $\theta_j =0)$ is correct.
+$\leadsto$ High $|t|$ $\Rightarrow$ small p-val. (speak against $H_0$)
+%\item The smaller the p-value, the less likely it is to obtain a more extreme test statistic
+\end{itemizeM}
+}{
+\spacer[0]
+\image{figure/p-value.pdf}
+\spacer[0]
+}
+}
+\end{framev}
 
+
+\begin{framev}[align=top]{Example: Lin. Regression - Main Effects}
 \textbf{Bike data}: predict no. of rented bikes using 4 numeric, 1 cat. feat. (season)
-
-\medskip 
-
+\\
+\spacer[0.25]
 % \begin{footnotesize}
 % $$
 % \hat y = \hat \theta_0 + \hat \theta_1 \mathds{1}_{(seas = SPRING)} + \hat \theta_2 \mathds{1}_{(seas = SUMMER)} + \hat \theta_3 \mathds{1}_{(seas = FALL)} + \hat \theta_4 temp + \hat \theta_5 hum + \hat \theta_6 windspeed + \hat \theta_7 days\_since\_2011
 % $$
 % \end{footnotesize}
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.43\linewidth}
-\vspace*{-0.3cm}
+\splitVTT[0.43]{
+\spacer[0]
 \begin{align*}
 \hat y = 
 & \hat \theta_0 + 
@@ -217,9 +196,10 @@ $$y = \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \dots + \theta_p x_p + \epsilon =
 & 
 \hat \theta_7 x_{days\_since\_2011}
 \end{align*}
-\end{column}
-\begin{column}{0.57\linewidth}
-  \centering
+\spacer[0]
+}{
+\spacer[0]
+\centering
 \begin{scriptsize}
 %\begin{overlayarea}{\textwidth}{\textheight}
 %\begin{table}[ht]
@@ -227,38 +207,34 @@ $$y = \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \dots + \theta_p x_p + \epsilon =
 \only<3>{\def\secondrowcolor{\rowcolor{lightgray}}}
 \only<4>{\def\thirdrowcolor{\rowcolor{lightgray}}}
 \begin{tabular}{rrrrr}
-  \hline
- & Weights & SE & t-stat. & p-val. \\
- \hline
+\hline
+& Weights & SE & t-stat. & p-val. \\
+\hline
 \firstrowcolor (Intercept) & 3229.3 & 220.6 & 14.6 & 0.00 \\ 
 \secondrowcolor seasonSPRING & 862.0 & 129.0 & 6.7 & 0.00 \\ 
-  seasonSUMMER & 41.6 & 170.2 & 0.2 & 0.81 \\ 
-  seasonFALL & 390.1 & 116.6 & 3.3 & 0.00 \\ 
+seasonSUMMER & 41.6 & 170.2 & 0.2 & 0.81 \\ 
+seasonFALL & 390.1 & 116.6 & 3.3 & 0.00 \\ 
 \thirdrowcolor temp & 120.5 & 7.3 & 16.5 & 0.00 \\ 
-  hum & -31.1 & 2.6 & -12.1 & 0.00 \\ 
-  windspeed & -56.9 & 7.1 & -8.0 & 0.00 \\ 
-  days\_since\_2011 & 4.9 & 0.2 & 26.9 & 0.00 \\
-   \hline
+hum & -31.1 & 2.6 & -12.1 & 0.00 \\ 
+windspeed & -56.9 & 7.1 & -8.0 & 0.00 \\ 
+days\_since\_2011 & 4.9 & 0.2 & 26.9 & 0.00 \\
+\hline
 \end{tabular}
 %\end{table}
 %\end{overlayarea}
 \end{scriptsize}
-\end{column}
-\end{columns}
+\spacer[0]
+}
 %\vspace*{-0.3cm}
 \pause
-
-\lz
 %\begin{columns}[T, totalwidth=\textwidth]
 %\begin{column}<5>{0.46\textwidth}
 %\textbf{Vis.}: Boxplot of $\hat\theta_j x_j$-values (scale invariant)\\
 %weights multiplied by actual feature value (better comparable due to different scales)
 %$\leadsto$ Comparable feature contributions w.r.t. $\hat y$
-
 %\includegraphics[width = \textwidth]{figure/plot_lin_effect.pdf}
 %   \begin{center}
 %   % Effect of $i$-th observation $= \theta_j x_j^{(i)}$\\
-
 %     %$\leadsto$ Better comparability due to different scales
 %   \end{center}
 %\pause
@@ -266,18 +242,15 @@ $$y = \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \dots + \theta_p x_p + \epsilon =
 %\end{column}\hfill
 %\begin{column}{0.54\textwidth}  %%<--- here
 \textbf{Interpretation:}
-
-\begin{itemize}[<+->]
-    \item \textbf{Intercept}:
-    If all feature values are 0 (and season is \code{WINTER} $\hat =$ reference cat.), the expected number of bike rentals is $\hat\theta_0 = 3229.3$
-    \item \textbf{Categ.}: Rentals in \code{SPRING} are by $\hat\theta_1 = 862$ higher than in \code{WINTER}, c.p.
-    \item \textbf{Numerical}: Rentals increase by $\hat\theta_4 = 120.5$ if \code{temp} increases by 1 $^{\circ}$C, c.p.
-    %If the temperature increases by 1 order Celsius, the number of bike rentals increases by 120.5 c.p.
-
-\end{itemize}
+\begin{itemizeM}
+\item<+-> \textbf{Intercept}: If all feature values are 0 (and season is \code{WINTER} $\hat =$ reference cat.), the expected number of bike rentals is $\hat\theta_0 = 3229.3$
+\item<+-> \textbf{Categ.}: Rentals in \code{SPRING} are by $\hat\theta_1 = 862$ higher than in \code{WINTER}, c.p.
+\item<+-> \textbf{Numerical}: Rentals increase by $\hat\theta_4 = 120.5$ if \code{temp} increases by 1 $^\circ$C, c.p.
+%If the temperature increases by 1 order Celsius, the number of bike rentals increases by 120.5 c.p.
+\end{itemizeM}
 %\end{column}
 %\end{columns}
-\end{frame}
+\end{framev}
 
 \endlecture
 \end{document}

--- a/slides/interpretable-models/slides03-im-lm-extensions.tex
+++ b/slides/interpretable-models/slides03-im-lm-extensions.tex
@@ -6,7 +6,6 @@
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \def\firstrowcolor{}
 \def\secondrowcolor{}
@@ -36,55 +35,47 @@ figure/l1_hat
 }
 
 
-\begin{frame}{Interaction and High-order Effects}
-
+\begin{framev}[align=top]{Interaction and High-order Effects}
 $$\text{LM Equation: } y = \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \dots + \theta_p x_p + \epsilon$$
-
 Equation above can be extended (polynomial regression) by including
-
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.7\linewidth}
-    \begin{itemize}
-        \item \textbf{high-order effects} which have their own weights\\
-        $\leadsto$ e.g., quadratic effect: $\theta_{x_j^2} \cdot x_j^2$
-        \item \textbf{interaction effects} as the product of multiple feat.\\
-        $\leadsto$ e.g., 2-way interaction: $\theta_{x_i, x_j} \cdot x_i \cdot x_j$
-    \end{itemize}
-\end{column}
-\begin{column}{0.3\linewidth}
-    \vspace{-0.2cm}
-    \centering
-    \begin{scriptsize}
-    \begin{table}[ht]
-    \textbf{Bike Data}
-        \begin{tabular}{lrr}
-        \hline
-        Method & $R^2$ & adj. $R^2$ \\ 
-        \hline
-        Simple LM & 0.85 & 0.84 \\ 
-        High-order & 0.87 & 0.87 \\ 
-        Interaction  & 0.96 & 0.93 \\ 
-    %    Both Types & 0.96 & 0.93 \\ 
-        \hline
-        \end{tabular}
-    \end{table}
-    \end{scriptsize}
-    % code for tables in rsrc/tab_lm_comparison.R
-\end{column}
-\end{columns}
-
-\pause
-\medskip
-Implications of including high-order and interaction effects: 
-\begin{itemize}
-    \item Both make the model more flexible but also less interpretable\\
-    $\leadsto$ More weights to interpret
-    \item Both need to be specified manually (inconvenient, sometimes infeasible)\\
-    $\leadsto$ Other ML models often learn them automatically
-    \item Marginal effect of a feat. cannot be interpreted by single weights anymore\\
+\splitVTT[0.7]{
+\spacer[0.6]
+\begin{itemizeM}
+\item \textbf{high-order effects} which have their own weights\\
+$\leadsto$ e.g., quadratic effect: $\theta_{x_j^2} \cdot x_j^2$
+\item \textbf{interaction effects} as the product of multiple feat.\\
+$\leadsto$ e.g., 2-way interaction: $\theta_{x_i, x_j} \cdot x_i \cdot x_j$
+\end{itemizeM}
+}{
+\spacer[0]
+\centering
+\begin{scriptsize}
+\textbf{Bike Data}\\
+\begin{tabular}{lrr}
+\hline
+Method & $R^2$ & adj. $R^2$ \\
+\hline
+Simple LM & 0.85 & 0.84 \\
+High-order & 0.87 & 0.87 \\
+Interaction & 0.96 & 0.93 \\
+%    Both Types & 0.96 & 0.93 \\
+\hline
+\end{tabular}
+\end{scriptsize}
+\spacer[0]
+% code for tables in rsrc/tab_lm_comparison.R
+}
+\pause\\
+\spacer[0.25]
+Implications of including high-order and interaction effects:
+\begin{itemizeM}
+\item Both make the model more flexible but also less interpretable\\
+$\leadsto$ More weights to interpret
+\item Both need to be specified manually (inconvenient, sometimes infeasible)\\
+$\leadsto$ Other ML models often learn them automatically
+\item Marginal effect of a feat. cannot be interpreted by single weights anymore\\
 $\leadsto$ Feature $x_j$ occurs multiple times (with different weights) in equation
-\end{itemize}
-
+\end{itemizeM}
 %Weights cannot be interpreted in isolation as before
 % $$y = \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \dots + \theta_p x_p + \epsilon$$
 
@@ -92,7 +83,7 @@ $\leadsto$ Feature $x_j$ occurs multiple times (with different weights) in equat
 % \item Results in polynomial regression 
 % \item Weights cannot be interpreted in isolation as before
 % \end{itemize}
-\end{frame}
+\end{framev}
 
 % \begin{frame}{Linear and Polynomial Regression}
 
@@ -116,92 +107,91 @@ $\leadsto$ Feature $x_j$ occurs multiple times (with different weights) in equat
 % \end{itemize}
 % \end{frame}
 
-\begin{frame}{Example: Interaction Effect}
+\begin{framev}[align=top]{Example: Interaction Effect}
 \textbf{Ex.}: Interaction between \code{temp} and \code{season} will affect marginal effect of \code{temp}% with (right) and without (left) interaction.
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.65\linewidth}
-\includegraphics[width = \textwidth]{figure/lm_main_vs_interaction_effects.pdf}
-\end{column}
-\begin{column}{0.35\linewidth}
+\spacer[0.25]
+\splitVTT[0.65]{
+\spacer[0]
+\image{figure/lm_main_vs_interaction_effects.pdf}
+\spacer[0]
+}{
+\spacer[0]
+\centering
 \begin{scriptsize}
 %\begin{table}[ht]
 \only<2->{\def\firstrowcolor{\rowcolor{lightgray}}}
 \only<3>{\def\secondrowcolor{\rowcolor{lightgray}}}
 \only<4>{\def\thirdrowcolor{\rowcolor{lightgray}}}
 \only<5>{\def\fourthrowcolor{\rowcolor{lightgray}}}
-\centering
 \begin{tabular}{rr}
-  \hline
- & Weights \\ 
-  \hline
+\hline
+& Weights \\
+\hline
 (Intercept) & 3453.9 \\ 
-  seasonSPRING & 1317.0 \\ 
-  seasonSUMMER & 4894.1 \\ 
-  seasonFALL & -114.2 \\ 
-  \firstrowcolor temp & 160.5 \\ 
-  hum & -37.6 \\ 
-  windspeed & -61.9 \\ 
-  days\_since\_2011 & 4.9 \\
-  \hline
-  \secondrowcolor seasonSPRING:temp & -50.7 \\ 
-  \thirdrowcolor seasonSUMMER:temp & -222.0 \\ 
-  \fourthrowcolor seasonFALL:temp & 27.2 \\ 
-   \hline
+seasonSPRING & 1317.0 \\ 
+seasonSUMMER & 4894.1 \\ 
+seasonFALL & -114.2 \\ 
+\firstrowcolor temp & 160.5 \\ 
+hum & -37.6 \\ 
+windspeed & -61.9 \\ 
+days\_since\_2011 & 4.9 \\
+\hline
+\secondrowcolor seasonSPRING:temp & -50.7 \\ 
+\thirdrowcolor seasonSUMMER:temp & -222.0 \\ 
+\fourthrowcolor seasonFALL:temp & 27.2 \\ 
+\hline
 \end{tabular}
 %\end{table}
 \end{scriptsize}
-\end{column}
-\end{columns}
-\vfill
+\spacer[0]
+}
 \pause
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.65\linewidth}
-\textbf{Interpretation}: If \code{temp} increases by 1 $^{\circ}$C, \\bike rentals
+\spacer[0.25]
+\splitVTT[0.65]{
+\textbf{Interpretation}: If \code{temp} increases by 1 $^{\circ}$C, \\ bike rentals
 \begin{itemize}[<+->]
-    \item increase by 160.5 in \code{WINTER} (reference)
-    \item increase by 109.8 (= 160.5 - 50.7) in \code{SPRING}
-    \item decrease by -61.5 (= 160.5 - 222) in \code{SUMMER}
-    \item increase by 187.7 (= 160.5 + 27.2) in \code{FALL}
+\item increase by 160.5 in \code{WINTER} (reference)
+\item increase by 109.8 (= 160.5 - 50.7) in \code{SPRING}
+\item decrease by -61.5 (= 160.5 - 222) in \code{SUMMER}
+\item increase by 187.7 (= 160.5 + 27.2) in \code{FALL}
 \end{itemize} %\\\vspace*{0.2cm}
-\end{column}
-\begin{column}{0.35\linewidth}
+}{
 % \lz
 % \only<6>{\textbf{Note:}
 % Temperature values (on x-axis) depend on \code{season}\\
 % $\leadsto$ not acknowledged by LM\\
 % $\leadsto$ misleading interpretation due to extrapolation in regions with few points (e.g. low \code{temp} in \code{SUMMER})
 % }
-\end{column}
-\end{columns}
+}
 %Value ranges of temperature differ depending on the season $\leadsto$ not acknowledged by LM
-\end{frame}
+\end{framev}
 
 
-\begin{frame}{Example: Quadratic Effect}
+\begin{framev}[align=top,fs=small]{Example: Quadratic Effect}
 \textbf{Ex.}: Adding quadratic effect for \code{temp} \only<2>{(left) and interaction with \code{season} (right)}
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.7\textwidth}
+\spacer[0.25]
+\splitVTT[0.7]{
+\spacer[0]
 \includegraphics[width=0.5\textwidth, trim=0cm 0.1cm 10.4cm 0cm, clip]{figure/poly_main_vs_interaction_effects.pdf}\invisible<1>{\includegraphics[width=0.5\textwidth, trim=10cm 0.1cm 0.4cm 0cm, clip]{figure/poly_main_vs_interaction_effects.pdf}}
 %\includegraphics[width = \textwidth]{figure/poly_main_vs_interaction_effects.pdf}
 %\begin{columns}[totalwidth=\textwidth]
 %\begin{center}
 %\adjincludegraphics[width=\textwidth, trim={0 0 {.55\width} 0}, clip]{figure/poly_main_vs_interaction_effects.pdf}
-
+\\
 \textbf{Interpretation}: Not linear anymore!
-\begin{itemize}
-    \only<1>{\item \code{temp} depends on two weights: $ 280.2 \cdot x_{temp} -  5.6 \cdot x_{temp}^2$}
-    \item<2> \code{temp} depends on multiple weights due to \code{season}:\\
-    $\leadsto$ \code{WINTER}: \\${\color{winter}39.1} \cdot x_{temp} + {\color{winter}8.6} \cdot x_{temp}^2$ \\
-    $\leadsto$ \code{SPRING}:\\ 
-    $({\color{winter}39.1} {\color{spring}+407.4}) \cdot x_{temp} + ({\color{winter}8.6} {\color{spring} - 18.7}) \cdot x_{temp}^2$ \\
-    $\leadsto$ \code{SUMMER}:\\ $({\color{winter}39.1}  {\color{summer}+801.1}) \cdot x_{temp} + ({\color{winter}8.6} {\color{summer} - 27.2}) \cdot x_{temp}^2$  \\
-    $\leadsto$ \code{FALL}: \\$({\color{winter}39.1}  {\color{fall}+217.4}) \cdot x_{temp} + ({\color{winter}8.6} {\color{fall} - 11.3}) \cdot x_{temp}^2$ 
-    % \item<2>[$\leadsto$] High-order and interaction effects make the model more flexible but also less interpretable (more weights)
-    % \item<2>[$\leadsto$] High-order and interaction effects need to be specified manually (inconvenient) - ML models do this automatically
-\end{itemize}
-
-\end{column}
-\begin{column}{0.3\textwidth}
+\begin{itemizeS}
+\only<1>{\item \code{temp} depends on two weights: $280.2 \cdot x_{temp} - 5.6 \cdot x_{temp}^2$}
+\item<2> \code{temp} depends on multiple weights due to \code{season}:\\
+$\leadsto$ \code{WINTER}: \\${\color{winter}39.1} \cdot x_{temp} + {\color{winter}8.6} \cdot x_{temp}^2$ \\
+$\leadsto$ \code{SPRING}:\\
+$({\color{winter}39.1} {\color{spring}+407.4}) \cdot x_{temp} + ({\color{winter}8.6} {\color{spring} - 18.7}) \cdot x_{temp}^2$ \\
+$\leadsto$ \code{SUMMER}:\\ $({\color{winter}39.1} {\color{summer}+801.1}) \cdot x_{temp} + ({\color{winter}8.6} {\color{summer} - 27.2}) \cdot x_{temp}^2$ \\
+$\leadsto$ \code{FALL}: \\$({\color{winter}39.1} {\color{fall}+217.4}) \cdot x_{temp} + ({\color{winter}8.6} {\color{fall} - 11.3}) \cdot x_{temp}^2$
+% \item<2>[$\leadsto$] High-order and interaction effects make the model more flexible but also less interpretable (more weights)
+% \item<2>[$\leadsto$] High-order and interaction effects need to be specified manually (inconvenient) - ML models do this automatically
+\end{itemizeS}
+}{
+\spacer[0]
 %\hfill
 \begin{scriptsize}
 % \begin{table}[ht]
@@ -215,19 +205,19 @@ $\leadsto$ Feature $x_j$ occurs multiple times (with different weights) in equat
 \only<1>{%
 %\addtolength{\tabcolsep}{-1pt}
 \begin{tabular}{rr}
-  \hline
- & Weights \\ 
-  \hline
+\hline
+& Weights \\
+\hline
 (Intercept) & 3094.1 \\ 
-  seasonSPRING & 619.2 \\ 
-  seasonSUMMER & 284.6 \\ 
-  seasonFALL & 123.1 \\ 
-  hum & -36.4 \\ 
-  windspeed & -65.7 \\ 
-  days\_since\_2011 & 4.7 \\ 
-  \firstrowcolor temp & 280.2 \\ 
-  \firstrowcolor temp$^2$ & -5.6 \\ 
-  \hline
+seasonSPRING & 619.2 \\ 
+seasonSUMMER & 284.6 \\ 
+seasonFALL & 123.1 \\ 
+hum & -36.4 \\ 
+windspeed & -65.7 \\ 
+days\_since\_2011 & 4.7 \\ 
+\firstrowcolor temp & 280.2 \\ 
+\firstrowcolor temp$^2$ & -5.6 \\ 
+\hline
 \end{tabular}%
 %\addtolength{\tabcolsep}{1pt}
 }
@@ -236,39 +226,38 @@ $\leadsto$ Feature $x_j$ occurs multiple times (with different weights) in equat
 \def\firstrowcolor{\rowcolor{winter}}%
 \addtolength{\tabcolsep}{-3pt}%
 \begin{tabular}{rr}
-  \hline
- & Weights \\ 
-  \hline
+\hline
+& Weights \\
+\hline
 (Intercept) & 3802.1 \\ 
-  seasonSPRING & -1345.1 \\ 
-  seasonSUMMER & -6006.3 \\ 
-  seasonFALL & -681.4 \\ 
-  hum & -38.9 \\ 
-  windspeed & -64.1 \\ 
-  days\_since\_2011 & 4.8 \\ 
- \firstrowcolor temp & 39.1 \\ 
- \firstrowcolor temp$^2$ & 8.6 \\ 
-  \hline
-  \hline
-  \secondrowcolor seasonSPRING:temp & 407.4 \\ 
- \secondrowcolor seasonSPRING:temp$^2$ & -18.7 \\ 
-  \thirdrowcolor seasonSUMMER:temp & 801.1 \\ 
- \thirdrowcolor seasonSUMMER:temp$^2$ & -27.2 \\ 
-  \fourthrowcolor seasonFALL:temp & 217.4 \\ 
- \fourthrowcolor seasonFALL:temp$^2$ & -11.3 \\ 
-   \hline
+seasonSPRING & -1345.1 \\ 
+seasonSUMMER & -6006.3 \\ 
+seasonFALL & -681.4 \\ 
+hum & -38.9 \\ 
+windspeed & -64.1 \\ 
+days\_since\_2011 & 4.8 \\ 
+\firstrowcolor temp & 39.1 \\ 
+\firstrowcolor temp$^2$ & 8.6 \\ 
+\hline
+\hline
+\secondrowcolor seasonSPRING:temp & 407.4 \\ 
+\secondrowcolor seasonSPRING:temp$^2$ & -18.7 \\ 
+\thirdrowcolor seasonSUMMER:temp & 801.1 \\ 
+\thirdrowcolor seasonSUMMER:temp$^2$ & -27.2 \\ 
+\fourthrowcolor seasonFALL:temp & 217.4 \\ 
+\fourthrowcolor seasonFALL:temp$^2$ & -11.3 \\ 
+\hline
 \end{tabular}%
 \addtolength{\tabcolsep}{3pt}
 }%
 %Table: Weights for main effect model
 \end{scriptsize}
 %\end{center}
-\end{column}
-\end{columns}
-\end{frame}
+}
+\end{framev}
 
 
-\begin{frame}{Regularization via LASSO \furtherreading{TIBSHIRANI1996}}
+\begin{framev}[align=top]{Regularization via LASSO \furtherreading{TIBSHIRANI1996}}
 % \begin{itemize}
 %     \item LASSO adds an $L_1$-norm penalization term ($\lambda||\theta||_1$) to the least squares optimization problem%\\
 %     % $\leadsto$ Shrinks some feature weights to zero (feature selection)\\
@@ -276,76 +265,70 @@ $\leadsto$ Feature $x_j$ occurs multiple times (with different weights) in equat
 %     % %Aim: Feature selection (sparsity) and regularization of feature weights
 %     % \item Penalization parameter $\lambda$ must be chosen (e.g., by CV) %or depending on the number of features to keep
 % \end{itemize}
-
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.6\textwidth}
-\begin{itemize}
-    \item LASSO adds an $L_1$-norm penalization term ($\lambda||\theta||_1$) to least squares optimization problem
-    \begin{itemize}
-        \item[$\leadsto$] Shrinks some feature weights to zero\\ (feature selection)
-        \item[$\leadsto$] Sparser models (fewer features): \\ more interpretable
-    \end{itemize}
-    %Aim: Feature selection (sparsity) and regularization of feature weights
-    \item Penalization parameter $\lambda$ must be chosen (e.g., by CV) %or depending on the number of features to keep
-\end{itemize}
-\vspace{0.2cm}
+\splitVTT[0.6]{
+\spacer[0.6]
+\begin{itemizeM}
+\item LASSO adds an $L_1$-norm penalization term ($\lambda||\theta||_1$) to least squares optimization problem
+\begin{itemizeS}
+\item[$\leadsto$] Shrinks some feature weights to zero\\
+(feature selection)
+\item[$\leadsto$] Sparser models (fewer features): \\
+more interpretable
+\end{itemizeS}
+%Aim: Feature selection (sparsity) and regularization of feature weights
+\item Penalization parameter $\lambda$ must be chosen (e.g., by CV) %or depending on the number of features to keep
+\end{itemizeM}
+\spacer[0.25]
 $$
 min_{\theta} \bigg(\underbrace{\frac{1}{n} \sum_{i=1}^{n} (y^{(i)} - {\xi}^{\top} \theta)^2}_\text{Least square estimate for LM} + \lambda||\theta||_1\bigg) 
 $$
-\end{column}
-\begin{column}{0.4\textwidth}
-\centerline{\includegraphics[width=.8\textwidth]{figure/l1_hat.png}} 
-\centerline{\includegraphics[width=.8\textwidth]{figure/lm_example}} 
-\end{column}
-\end{columns}
-
-\end{frame}
+}{
+\spacer[0]
+\imageC[0.8]{figure/l1_hat.png}
+\imageC[0.8]{figure/lm_example}
+}
+\end{framev}
 
 
-\begin{frame}{Regularization via LASSO \furtherreading{TIBSHIRANI1996}}
+\begin{framev}[align=top]{Regularization via LASSO \furtherreading{TIBSHIRANI1996}}
 \textbf{Example} (interpretation of weights analogous to LM):
-
-\begin{itemize}
-    \item LASSO with main effects and interaction \code{temp} with \code{season}
-\end{itemize}
-\vspace{-0.5\topsep}
-\begin{columns}[c, totalwidth=\textwidth]
-\begin{column}{0.65\textwidth}
-\begin{itemize}
-    %\item LASSO with main effects and interaction \code{temp} with \code{season}
-    \item $\lambda$ is chosen $\leadsto$ 6 selected features ($\neq 0$)
-    \item LASSO shrinks weights of single categories separately (due to dummy encoding)\\
-    %only weights of single categories are set to zero (due to dummy encoding) not the whole feature\\
-    $\leadsto$ No feature selection of whole categorical features (only w.r.t. category levels)\\
-    %May be problematic for categorical features as only weights of single categories are set to zero (due to dummy encoding) instead of the whole categorical feature\\ %, polynomials and interactions
-    $\leadsto$ Solution: group LASSO \furtherreading{YUANLIN2006}
-\end{itemize}
-\smallskip
-\centering
-\includegraphics[width = 0.6\textwidth]{figure/reg_lm_plot_interpreted.pdf}
-
-\end{column}
-\begin{column}{0.35\textwidth}
-
-\scriptsize
+\begin{itemizeM}
+\item LASSO with main effects and interaction \code{temp} with \code{season}
+\end{itemizeM}
+\splitVTT[0.65]{
+\spacer[0.6]
+\begin{itemizeM}
+%\item LASSO with main effects and interaction \code{temp} with \code{season}
+\item $\lambda$ is chosen $\leadsto$ 6 selected features ($\neq 0$)
+\item LASSO shrinks weights of single categories separately (due to dummy encoding)\\
+%only weights of single categories are set to zero (due to dummy encoding) not the whole feature\\
+$\leadsto$ No feature selection of whole categorical features (only w.r.t. category levels)\\
+%May be problematic for categorical features as only weights of single categories are set to zero (due to dummy encoding) instead of the whole categorical feature\\ %, polynomials and interactions
+$\leadsto$ Solution: group LASSO \furtherreading{YUANLIN2006}
+\end{itemizeM}
+\spacer[0.25]
+\imageC[0.6]{figure/reg_lm_plot_interpreted.pdf}
+}{
+\spacer[0]
+\begin{scriptsize}
 \centering
 \begin{tabular}{rr}
-  \hline
- & Weights \\ 
-  \hline
+\hline
+& Weights \\
+\hline
 (Intercept) & 3135.2 \\ 
-  seasonSPRING & 767.4 \\ 
-  seasonSUMMER & 0.0 \\ 
-  seasonFALL & 0.0 \\ 
-  temp & 116.7 \\ 
-  hum & -28.9 \\ 
-  windspeed & -50.5 \\ 
-  days\_since\_2011 & 4.8 \\ 
-  \hline
-  seasonSPRING:temp & 0.0 \\ 
-  seasonSUMMER:temp & 0.0 \\ 
-  seasonFALL:temp & 30.2 \\ 
-   \hline
+seasonSPRING & 767.4 \\ 
+seasonSUMMER & 0.0 \\ 
+seasonFALL & 0.0 \\ 
+temp & 116.7 \\ 
+hum & -28.9 \\ 
+windspeed & -50.5 \\ 
+days\_since\_2011 & 4.8 \\ 
+\hline
+seasonSPRING:temp & 0.0 \\ 
+seasonSUMMER:temp & 0.0 \\ 
+seasonFALL:temp & 30.2 \\ 
+\hline
 \end{tabular}
 %\end{table}
 % \begin{table}[ht]
@@ -366,14 +349,10 @@ $$
 %   \hline
 % \end{tabular}
 % \end{table}
-\end{column}
-\end{columns}
-
-
+\end{scriptsize}
+}
 %\includegraphics[width = 0.8\textwidth]{figure/reg_lm_plot_interpreted.pdf}
-
-
-\end{frame}
+\end{framev}
 \endlecture
 
 \end{document}

--- a/slides/interpretable-models/slides04-im-glm.tex
+++ b/slides/interpretable-models/slides04-im-glm.tex
@@ -2,13 +2,12 @@
 
 \input{../../style/preamble}
 % Defines macros and environments
- \input{../../latex-math/basic-ml.tex}
+\input{../../latex-math/basic-ml.tex}
 \input{../../latex-math/basic-math.tex}
 
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
 
@@ -26,32 +25,28 @@ figure/logreg-2vars-surface
 
 %------------------------------------------------------------------
 %------------------------------------------------------------------
-\begin{frame}{GLM \furtherreading{NELDERWEDDERBURN1972}}
-\vspace{-0.2cm}
-\textbf{Problem}: Target variable given feat not always normally distributed \\$\leadsto$ LM not suitable
-
-\begin{itemize}
-    \item Target is binary (e.g., disease classif.)\\
-    $\leadsto$ Bernoulli / Binomial distribution
-\end{itemize}
-\begin{splitVCC}[0.5]{
-% \vspace{-0.5cm}
-
-\begin{itemize}
-    \item Target is count variable \\(e.g., number of sold products)\\
-    $\leadsto$ Poisson distribution
-    \item Time until an event occurs\\ (e.g., time until death)\\
-    $\leadsto$ Gamma distribution
-\end{itemize}
+\begin{framev}[align=top]{GLM \furtherreading{NELDERWEDDERBURN1972}}
+\textbf{Problem}: Target variable given feat. not always normally distributed\\
+$\leadsto$ LM not suitable
+\begin{itemizeM}
+\item Target is binary (e.g., disease classif.)\\
+$\leadsto$ Bernoulli / Binomial distribution
+\end{itemizeM}
+\splitVCC[0.55]{
+\begin{itemizeM}
+\item Target is count variable\\
+(e.g., number of sold products)\\
+$\leadsto$ Poisson distribution
+\item Time until an event occurs\\
+(e.g., time until death)\\
+$\leadsto$ Gamma distribution
+\end{itemizeM}
 }{
-\begin{center}
-    \includegraphics[width = \textwidth]{figure/density_intervals.pdf}
-\end{center}
+\image{figure/density_intervals.pdf}
+\spacer[0]
 }
-\end{splitVCC}
-\medskip
 \pause
-\textbf{Solution}: GLMs - extend LMs by allowing other distrib.-s from exp. family
+\textbf{Solution}: GLMs extend LMs by allowing other distrib.-s from exp. family\\
 %$$g(\E (y \mid \xv)) = \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \ldots + \theta_p x_p$$
 % \begin{align*}
 % &g(\E (y \mid \xv)) = 
@@ -59,15 +54,16 @@ figure/logreg-2vars-surface
 % \xv^\top \theta\\
 % \Leftrightarrow \; & \E (y \mid \xv) = g^{-1}(\xv^\top \theta)
 % \end{align*}
-$$g(\E (y \mid \xv)) = \xv^\top \thetav \; \Leftrightarrow \; \E (y \mid \xv) = g^{-1}(\xv^\top \thetav)$$
-\vspace*{-0.5cm}
-    \begin{itemize}
-        \item Link function $g$ links linear predictor $\xv^\top \thetav$ to expectation of distrib. of $y \mid \xv$\\ %$\E$ of specified distribution of
-        $\leadsto$ LM is special case: Gaussian distrib. for $y \mid \xv$ with $g$ as identity func. 
-        \item Link function $g$ and distribution need to be specified 
-        \item High-order and interaction effects can be manually added as in LMs
-        \item Note: Interpretation of weights depend on link function and distribution
-    \end{itemize}
+\spacer[0.25]
+\centerline{$g(\E(y \mid \xv)) = \xv^\top \thetav \; \Leftrightarrow \; \E(y \mid \xv) = g^{-1}(\xv^\top \thetav)$}
+\spacer[0.25]
+\begin{itemizeM}
+\item Link function $g$ links linear predictor $\xv^\top \thetav$ to expectation of distrib. of $y \mid \xv$\\ %$\E$ of specified distribution of
+$\leadsto$ LM is special case: Gaussian distrib. for $y \mid \xv$ with $g$ as identity func.
+\item Link function $g$ and distribution need to be specified
+\item High-order and interaction effects can be manually added as in LMs
+\item Note: Interpretation of weights depend on link function and distribution
+\end{itemizeM}
  %   \medskip
  %   Non-Gaussian outputs via Generalized Linear Models (GLMs):
   %  \begin{itemize}
@@ -77,33 +73,28 @@ $$g(\E (y \mid \xv)) = \xv^\top \thetav \; \Leftrightarrow \; \E (y \mid \xv) = 
     %\end{itemize}
     %\medskip 
     %\pause
-    %Interaction effects via feature engineering:
-    %\begin{itemize}
-    %    \item E.g., feature expansion: $\theta_{x_i,x_j} x_i \cdot x_j$
-    %\end{itemize}
-\end{frame}
- 	
-\begin{frame}{GLM - Logistic Regression}
+ %Interaction effects via feature engineering:
+ %\begin{itemize}
+ %    \item E.g., feature expansion: $\theta_{x_i,x_j} x_i \cdot x_j$
+ %\end{itemize}
+\end{framev}
+
+
+\begin{framev}[align=top]{GLM - Logistic Regression}
 %\begin{columns}[T, totalwidth=\textwidth]
 %\begin{column}{0.45\textwidth}
-
-\begin{itemize}
-    \item Logistic regression $\hat{=}$ GLM with Bernoulli distribution and logit link function: 
-
+\begin{itemizeM}
+\item Logistic regression $\hat{=}$ GLM with Bernoulli distribution and logit link function:
 %\begin{align*}
 %    g(x) &= \log\left(\frac{x}{1 - x}\right)  
 %    \Rightarrow \; g^{-1}(x) &= \frac{1}{1+\exp(-x)}
 %\end{align*}
-
 $$
-g(x) = \log\left(\frac{x}{1 - x}\right)  
-\Rightarrow \; g^{-1}(x) = \frac{1}{1+\exp(-x)}
+g(x) = \log\left(\frac{x}{1 - x}\right)
+\Rightarrow \; g^{-1}(x) = \frac{1}{1 + \exp(-x)}
 $$
-
-
 %\end{column}
 %\begin{column}{0.55\textwidth}
-
 % \begin{columns}[c, totalwidth=\textwidth]
 % \begin{column}{0.005\linewidth}
 % \scriptsize
@@ -116,44 +107,37 @@ $$
 % \end{columns}
 %\end{column}
 %\end{columns}
-
-%\bigskip
-
 % \begin{columns}[T, totalwidth=\textwidth]
 % \begin{column}{0.65\textwidth}
 % \begin{itemize}
-    \item Models probabilities for binary classification by
-    $$\pi(\xv) = \E(y \mid \xv) = P(y = 1) = g^{-1}(\xv^\top \thetav) = \frac{1}{1 + \exp(- \xv^\top \thetav)} $$
-    %\item Logistic regression models $\E(y \mid \xv) = P(y = 1)$, i.e., probabilities for binary classification 
-    %\item Logistic regression formula:
-    %$$P(y = 1) =\frac{1}{1 + \exp(-( \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \ldots + \theta_p x_p ))} $$
-\end{itemize}
+\item Models probabilities for binary classification by
+$$\pi(\xv) = \E(y \mid \xv) = P(y = 1) = g^{-1}(\xv^\top \thetav) = \frac{1}{1 + \exp(-\xv^\top \thetav)}$$
+%\item Logistic regression models $\E(y \mid \xv) = P(y = 1)$, i.e., probabilities for binary classification
+%\item Logistic regression formula:
+%$$P(y = 1) =\frac{1}{1 + \exp(-( \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \ldots + \theta_p x_p ))} $$
+\end{itemizeM}
 % \end{column}
 % \begin{column}{0.35\textwidth}
 % \end{column}
 % \end{columns}
 \centering
-\includegraphics[width=0.3\textwidth]{figure/logreg-2vars-surface.png} \qquad
-\includegraphics[width=0.4\textwidth]{figure/reg_class_log_7} 
-\end{frame}
+\image[0.3]{figure/logreg-2vars-surface.png}
+\qquad
+\image[0.4]{figure/reg_class_log_7}
+\end{framev}
 
 
-
-\begin{frame}{GLM - Logistic Regression}
-
-\begin{itemize}
-    \item Typically, we set the threshold to $0.5$ to predict classes, e.g.,
-    \begin{itemize}
-        \item Class 1 if $\pi(\xv) > 0.5$
-        \item Class 0 if $\pi(\xv) \leq 0.5$
-    \end{itemize}
-\end{itemize}
-
-\medskip
-\centering
-\includegraphics[width = \textwidth]{figure/reg_class_log_6.pdf}
+\begin{framev}[align=top]{GLM - Logistic Regression}
+\begin{itemizeM}
+\item Typically, we set the threshold to $0.5$ to predict classes, e.g.,
+\begin{itemizeS}
+\item Class 1 if $\pi(\xv) > 0.5$
+\item Class 0 if $\pi(\xv) \leq 0.5$
+\end{itemizeS}
+\end{itemizeM}
+\image{figure/reg_class_log_6.pdf}
 % figs from i2ml course, Chapter 03.04: Logistic Regression, slide 7 
-\end{frame}
+\end{framev}
 
 
 % \begin{frame}{Generalized Linear Models (GLMs)}
@@ -185,43 +169,41 @@ $$
 %------------------------------------------------------------------
 %------------------------------------------------------------------
 
-\begin{frame}[c]{GLM - Log. Regression - Interpretation}
+\begin{framev}[align=top]{GLM - Log. Regression - Interpretation}
+\begin{itemizeM}
+\item \textbf{Recall:} Odds is ratio of two probabilities, odds ratio is ratio of two odds
+\item Weights $\theta_j$ are interpreted linear as in LM (but w.r.t. log-odds)\\
+$\leadsto$ difficult to comprehend
+%relate to log-odds %$\leadsto$ Effects are linear as in LM (but w.r.t. log-odds)
+$$log\text{-}odds = \log\left(\frac{\pi(\xv)}{1 - \pi(\xv)}\right) = \log\left(\frac{P(y = 1)}{P(y = 0)}\right) = \theta_0 + \theta_1 x_1 + \ldots + \theta_p x_p$$
+\textbf{Interpretation}: Changing $x_j$ by one unit changes log-odds of class 1 compared to class 0 by $\theta_j$
+%\leadsto$ Effects are interpreted linear as in LM (but w.r.t. log-odds) $\leadsto$ difficult to comprehend
+\pause
+\item Odds for cls 1 vs. cls 0: %Odds can be caulculated by:
+% deliberate choice to use in line with \displaystyle given full slide
+$odds = \displaystyle\frac{\pi(\xv)}{1 - \pi(\xv)}= \exp(\theta_0 + \theta_1 x_1 + \ldots + \theta_p x_p)$
+\item Instead of interpreting changes w.r.t. log-odds, it is more common to use the odds ratio
+$$\frac{odds_{x_j+1}}{odds} = \frac{\exp(\theta_0 + \theta_1 x_1 + \ldots + \theta_j(x_j + 1) + \ldots + \theta_p x_p)}{\exp(\theta_0 + \theta_1 x_1 + \ldots + \theta_j x_j + \ldots + \theta_p x_p)} = \exp(\theta_j)$$
+\textbf{Interpretation}: Changing $x_j$ by one unit changes the \textbf{odds ratio} for class 1 (compared to class 0) by the \textbf{factor} $\exp(\theta_j)$
+%\pause
+%\item Interpretation for different feature types is the same as for linear regression (however, linear interpretation only possible w.r.t. log odds $\leadsto$ difficult to comprehend)
+\end{itemizeM}
+\end{framev}
 
-    \begin{itemize}
-        \item \textbf{Recall:} Odds is ratio of two probabilities, odds ratio is ratio of two odds 
-        \item Weights $\theta_j$ are interpreted linear as in LM (but w.r.t. log-odds) \\
-        $\leadsto$ difficult to comprehend
-        %relate to log-odds %$\leadsto$ Effects are linear as in LM (but w.r.t. log-odds)
-        $$log\text{-}odds = \log \left(\frac{\pi(\xv)}{1 - \pi(\xv)}\right) = \log \left(\frac{P(y=1)}{P(y=0)}\right) = \theta_0 + \theta_1 x_1 + \ldots + \theta_p x_p  $$
-        \textbf{Interpretation:} Changing $x_j$ by one unit, changes log-odds of class 1 compared to class 0 by $\theta_j$%\\
-        %$\leadsto$ Effects are interpreted linear as in LM (but w.r.t. log-odds) $\leadsto$ difficult to comprehend
-        \pause
-        \item Odds for cls 1 vs. cls 0: %Odds can be caulculated by:
-        $odds = \displaystyle\frac{\pi(\xv)}{1 - \pi(\xv)}= \exp(\theta_0 + \theta_1 x_1 + \ldots + \theta_p x_p)$
-        \item Instead of interpreting changes w.r.t. log-odds, it is more common to use $odds\text{ }ratio$ 
-        $$ = \frac{odds_{x_j+1}}{odds} = \frac{\exp(\theta_0 + \theta_1 x_1 + \ldots + \theta_j (x_j+1) + \ldots + \theta_p x_p)}{\exp(\theta_0 + \theta_1 x_1 + \ldots + \theta_j x_j + \ldots + \theta_p x_p)} = \exp{(\theta_j)} $$
-        \textbf{Interpretation}: Changing $x_j$ by one unit, changes the \textbf{odds ratio} for class 1 (compared to class 0) by the \textbf{factor} $\exp(\theta_j)$
-        %\pause
-        %\item Interpretation for different feature types is the same as for linear regression (however, linear interpretation only possible w.r.t. log odds $\leadsto$ difficult to comprehend)
-    \end{itemize}	
 
-\end{frame}
-
-\begin{frame}{GLM - Logistic Regression - Example}
-
-\begin{itemize}
-    \item Create a binary target variable for bike rental data:
-    \begin{itemize}
-        \item Class 1: ``high number of rentals'' $>70\%$ quantile (i.e., \code{cnt} $> 5531$)
-        \item Class 0: ``low to medium number of rentals'' (i.e., \code{cnt} $\leq$ 5531)
-    \end{itemize}
-    \item Fit a logistic regression model (GLM with Bernoulli distri. and logit link)
-\end{itemize}
-
-\begin{columns}[T, totalwidth = \textwidth]
-\begin{column}{0.55\textwidth}
-%\begin{table}[ht]
+\begin{framev}[align=top]{GLM - Logistic Regression - Example}
+\begin{itemizeM}
+\item Create a binary target variable for bike rental data:
+\begin{itemizeS}
+\item Class 1: ``high number of rentals'' $> 70\%$ quantile (i.e., \code{cnt} $> 5531$)
+\item Class 0: ``low to medium number of rentals'' (i.e., \code{cnt} $\leq 5531$)
+\end{itemizeS}
+\item Fit a logistic regression model (GLM with Bernoulli distri. and logit link)
+\end{itemizeM}
+\splitVTT[0.55]{
+\spacer[0]
 \centering
+%\begin{table}[ht]
 % \begin{tabular}{rrrrr}
 %   \hline
 %  & Weights & SE & z value & p-value \\ 
@@ -238,39 +220,37 @@ $$
 % \end{tabular}
 \begin{scriptsize}
 \begin{tabular}{rrrr}
-  \hline
- & Weights & SE & p-value \\ 
-  \hline
+\hline
+& Weights & SE & p-value \\
+\hline
 (Intercept) & -8.52 & 1.21 & 0.00 \\ 
-  seasonSPRING & 1.74 & 0.60 & 0.00 \\ 
-  seasonSUMMER & -0.86 & 0.77 & 0.26 \\ 
-  seasonFALL & -0.64 & 0.55 & 0.25 \\ 
-  temp & 0.29 & 0.04 & 0.00 \\ 
-  hum & -0.06 & 0.01 & 0.00 \\ 
-  windspeed & -0.09 & 0.03 & 0.00 \\ 
-  days\_since\_2011 & 0.02 & 0.00 & 0.00 \\ 
-   \hline
+seasonSPRING & 1.74 & 0.60 & 0.00 \\ 
+seasonSUMMER & -0.86 & 0.77 & 0.26 \\ 
+seasonFALL & -0.64 & 0.55 & 0.25 \\ 
+temp & 0.29 & 0.04 & 0.00 \\ 
+hum & -0.06 & 0.01 & 0.00 \\ 
+windspeed & -0.09 & 0.03 & 0.00 \\ 
+days\_since\_2011 & 0.02 & 0.00 & 0.00 \\ 
+\hline
 \end{tabular}
 \end{scriptsize}
 %\end{table}
 \pause
-\end{column}
-\hfill
+\spacer[0]
+}{
+\spacer[0]
 %\pause
-\begin{column}{0.45\textwidth}
-\includegraphics[width = 0.9\textwidth]{figure/logistic_marginal_temp.pdf}
-\end{column}
-\end{columns}
-
-\bigskip
-
+\imageC[0.9]{figure/logistic_marginal_temp.pdf}
+\spacer[0]
+}
+\spacer[0.25]
 \textbf{Interpretation}
-\begin{itemize}
-    %\item If the temperature increases by 1 degree Celsius then the log odds of high number of bike rentals increase linearly by 0.3 c.p.
-    \item If \code{temp} increases by 1$^\circ C$, odds ratio for class 1 increases by factor $\exp (0.29) = 1.34$ compared to class 0, c.p. ($\hat =$ ``high number of bike rentals'' now 1.34 times more likely)
-    %\item If \code{season} is SPRING instead of WINTER (reference), odds ratio for class 1 increases by factor $\exp (1.74) = 1.34$ compared to class 0
-\end{itemize}
-\end{frame}
+\begin{itemizeM}
+%\item If the temperature increases by 1 degree Celsius then the log odds of high number of bike rentals increase linearly by 0.3 c.p.
+\item If \code{temp} increases by $1^\circ C$, odds ratio for class 1 increases by factor $\exp(0.29) = 1.34$ compared to class 0, c.p. ($\hat{=}$ ``high number of bike rentals'' now 1.34 times more likely)
+%\item If \code{season} is SPRING instead of WINTER (reference), odds ratio for class 1 increases by factor $\exp (1.74) = 1.34$ compared to class 0
+\end{itemizeM}
+\end{framev}
 
 
 

--- a/slides/interpretable-models/slides05-im-rule-based.tex
+++ b/slides/interpretable-models/slides05-im-rule-based.tex
@@ -8,7 +8,6 @@
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \def\firstrowcolor{}
 \def\secondrowcolor{}
@@ -31,83 +30,68 @@ figure/tree_surface2.png
 \item Decision rules
 }
 
-\begin{frame}{Decision Trees \furtherreading{BREIMANETAL1984}}
-
+\begin{framev}[align=top]{Decision Trees \furtherreading{BREIMANETAL1984}}
 %\textbf{Problem}: Can we model non-linear effects and interactions automatically (without manual specification as in GLMs or GAMs)?\\
 %Relationship between features and target are non-linear or interactions are present\\
 %\medskip
 %\pause
 
-\textbf{Idea}: 
+\textbf{Idea}:
 %Split data in different subsets based on cut-off values in features 
 Partition data into axis-aligned regions via greedy search for feature cut points (minimizing a split criterion), then predict a constant mean $c_m$ in each leaf region $\mathcal{R}_m$:
 %Partition data into subsets based on cut-off values in features (found by minimizing a split criterion via greedy search) and predict constant mean $c_m$ in leaf node $\mathcal{R}_m$:
-
-\begin{columns}[T, totalwidth=\textwidth]
-
-\begin{column}{0.65\textwidth}
+\splitVTT[0.65]{
+\spacer[0]
 $$
 \textstyle\hat f(x) = \sum\limits_{m=1}^M c_m \mathds{1}_{\{x \in \mathcal{R}_m\}}
 $$
-
 % \begin{itemize}
 % \item where $c_m$ is a constant and 
 % \item $\mathcal{R}_m$ the $m$-th leaf node of the tree
 % \end{itemize}
 \pause
-\begin{itemize}
-    %\item Finding best split point (CART): Greedy search for the point that minimizes the variance of $y$ (regression) or the Gini index (classification)
-    \item Applicable to regression and classification
-    \item Models interactions and non-linear effects
-    \item Handles mixed feat, spaces \& missing values
-\end{itemize}
-
-\end{column}
-\begin{column}{0.35\textwidth}
-\vspace{0.15cm}
+\begin{itemizeM}
+%\item Finding best split point (CART): Greedy search for the point that minimizes the variance of $y$ (regression) or the Gini index (classification)
+\item Applicable to regression and classification
+\item Models interactions and non-linear effects
+\item Handles mixed feat, spaces \& missing values
+\end{itemizeM}
+}{
+\spacer[0]
 \centering
 \begin{tikzpicture}[scale=0.8, transform shape]
-   \usetikzlibrary{arrows}
-    \usetikzlibrary{shapes}
-     \tikzset{treenode/.style={draw, circle, font=\small}}
-     \tikzset{line/.style={draw, thick}}
-     \node [treenode, draw=red] (a0) {};
-     \node [treenode, below=0.75cm of a0, xshift=-1.5cm]  (a1) {};
-     \node [treenode, below=0.75cm of a0, xshift=1.5cm]  (a2) {};
-
-     \node [treenode, below=0.75cm of a2, xshift=-0.75cm] (a3) {$c_1$};
-     \node [treenode, below=0.75cm of a2, xshift=0.75cm]  (a4) {$c_2$};
-
-    \node [treenode, below=0.75cm of a1, xshift=-0.75cm] (a5) {$c_3$};
-    \node [treenode, below=0.75cm of a1, xshift=0.75cm]  (a6) {$c_4$};
-
-     \path [line] (a0.south) -- + (0,-0.4cm) -| (a1.north) node [midway, above] {$x_1<3$};
-     \path [line] (a0.south) -- +(0,-0.4cm) -|  (a2.north) node [midway, above] {$x_1\geq3$};
-
-     \path [line] (a2.south) -- + (0,-0.4cm) -| (a3.north) node [midway, above] {$x_2<6$};;
-     \path [line] (a2.south) -- +(0,-0.4cm) -|  (a4.north) node [midway, above] {$x_2\geq6$};
-
-    \path [line] (a1.south) -- + (0,-0.4cm) -| (a5.north) node [midway, above] {$x_3<2$};;
-    \path [line] (a1.south) -- +(0,-0.4cm) -|  (a6.north) node [midway, above] {$x_3\geq2$};
-
-    %\path (a5.south) -- +(0,0) -|  (a5.south) node [midway, below] {$f_{1,3}(x_1,x_3)$};
-    %\path (a6.south) -- +(0,0) -|  (a6.south) node [midway, below] {$f_{1,3}(x_1,x_3)$};
-
-    %\path (a3.south) -- +(0,0) -|  (a3.south) node [midway, below] {$f_{1,2}(x_1,x_2)$};
-    %\path (a3.south) -- +(0,0) -|  (a4.south) node [midway, below] {$f_{1,2}(x_1,x_2)$};
-    % \path (a3) edge [bend right, draw=white] node [below] {$f_{1,2}(x_1,x_2)$} (a4);
-    % \path (a5) edge [bend right, draw=white] node [below] {$f_{1,3}(x_1,x_3)$} (a6);
-   \end{tikzpicture}
-   
-\end{column}
-\end{columns}
-%\vspace{-0.4cm}
-\begin{center}
-\includegraphics[width=0.45\textwidth]{figure/tree_surface1.pdf} \qquad  
-\includegraphics[width=0.33\textwidth]{figure/tree_surface2.png}
-\end{center}
-
-\end{frame}
+\usetikzlibrary{arrows}
+\usetikzlibrary{shapes}
+\tikzset{treenode/.style={draw, circle, font=\small}}
+\tikzset{line/.style={draw, thick}}
+\node [treenode, draw=red] (a0) {};
+\node [treenode, below=0.75cm of a0, xshift=-1.5cm] (a1) {};
+\node [treenode, below=0.75cm of a0, xshift=1.5cm] (a2) {};
+\node [treenode, below=0.75cm of a2, xshift=-0.75cm] (a3) {$c_1$};
+\node [treenode, below=0.75cm of a2, xshift=0.75cm] (a4) {$c_2$};
+\node [treenode, below=0.75cm of a1, xshift=-0.75cm] (a5) {$c_3$};
+\node [treenode, below=0.75cm of a1, xshift=0.75cm] (a6) {$c_4$};
+\path [line] (a0.south) -- +(0,-0.4cm) -| (a1.north) node [midway, above] {$x_1<3$};
+\path [line] (a0.south) -- +(0,-0.4cm) -| (a2.north) node [midway, above] {$x_1\geq3$};
+\path [line] (a2.south) -- +(0,-0.4cm) -| (a3.north) node [midway, above] {$x_2<6$};
+\path [line] (a2.south) -- +(0,-0.4cm) -| (a4.north) node [midway, above] {$x_2\geq6$};
+\path [line] (a1.south) -- +(0,-0.4cm) -| (a5.north) node [midway, above] {$x_3<2$};
+\path [line] (a1.south) -- +(0,-0.4cm) -| (a6.north) node [midway, above] {$x_3\geq2$};
+%\path (a5.south) -- +(0,0) -|  (a5.south) node [midway, below] {$f_{1,3}(x_1,x_3)$};
+%\path (a6.south) -- +(0,0) -|  (a6.south) node [midway, below] {$f_{1,3}(x_1,x_3)$};
+%\path (a3.south) -- +(0,0) -|  (a3.south) node [midway, below] {$f_{1,2}(x_1,x_2)$};
+%\path (a3.south) -- +(0,0) -|  (a4.south) node [midway, below] {$f_{1,2}(x_1,x_2)$};
+% \path (a3) edge [bend right, draw=white] node [below] {$f_{1,2}(x_1,x_2)$} (a4);
+% \path (a5) edge [bend right, draw=white] node [below] {$f_{1,3}(x_1,x_3)$} (a6);
+\end{tikzpicture}
+\spacer[0]
+}
+\splitVCC[0.55]{
+\imageC[0.82]{figure/tree_surface1.pdf}
+}{
+\imageC[0.73]{figure/tree_surface2.png}
+}
+\end{framev}
 
 
 % \begin{frame}{Interpretation}
@@ -120,77 +104,66 @@ $$
 
 % \end{frame}
 
-\begin{frame}{Interpretation of Tree-Based Models}
-\begin{itemize}
-    \item Interpretation via path of decision rules along tree branches
-    \item \textbf{Feature importance} (quantifies how often and how usefully $x_j$ is used): 
-    \begin{itemize}
-        \item For each split on feature $x_j$, record the decrease in the split criterion 
-        \item Aggregate this over the tree: sum or avg. over all splits involving $x_j$
-        \item Split criterion: variance (regression), Gini index / entropy (classif.)
-    \end{itemize}
-    %\item[] $\leadsto$ Quantifies how often and how usefully $x_j$ is used
-\end{itemize}
-\begin{columns}[T, totalwidth=\textwidth]
-  \begin{column}{0.6\textwidth}
-    %\begin{center}
-    % \begin{tikzpicture}[scale=0.7, every node/.style={font=\small}]
-    %   % Nodes
-    %   \node[draw, circle] (root) at (0,0) {$x_j < 5$};
-    %   \node[draw, circle] (left) at (-3,-2.5) {$x_k < 3$};
-    %   \node[draw, rectangle] (L1) at (-4.2,-5) {$c_1$};
-    %   \node[draw, rectangle] (L2) at (-1.8,-5) {$c_2$};
-
-    %   \node[draw, circle] (right) at (3,-2.5) {$x_k < 7$};
-    %   \node[draw, rectangle] (R1) at (2,-5) {$c_3$};
-    %   \node[draw, rectangle] (R2) at (4,-5) {$c_4$};
-
-    %   % Edges with labels
-    %   \draw[->] (root) -- node[above left] {\scriptsize } node[midway, left=3pt] {\scriptsize  $\Delta\text{Var} = 0.18$} (left);
-    %   \draw[->] (root) -- node[above right] {\scriptsize } node[midway, right=3pt] {\scriptsize } (right);
-
-    %   \draw[->] (left) -- node[left] {\scriptsize $\Delta\text{Var} = 0.07$} (L1);
-    %   \draw[->] (left) -- (L2);
-
-    %   \draw[->] (right) -- node[left] {\scriptsize $\Delta\text{Var} = 0.10$} (R1);
-    %   \draw[->] (right) -- (R2);
-    % \end{tikzpicture}
-    \begin{tikzpicture}[scale=0.75, every node/.style={font=\small}]
-  % Nodes: rectangular with split condition + delta
-  \node[draw, ellipse, align=center] (root) at (0,0) {$x_j < 5$\\ \scriptsize$ \Delta\text{Var} = 0.18$};
-  \node[draw, ellipse, align=center] (left) at (-3,-2.5) {$x_k < 3$\\ \scriptsize$\Delta\text{Var} = 0.07$};
-  \node[draw, ellipse, align=center] (right) at (3,-2.5) {$x_k < 7$\\ \scriptsize$\Delta\text{Var} = 0.10$};
-
-  % Leaf nodes
-  \node[draw, rectangle] (L1) at (-4.2,-5) {$c_1$};
-  \node[draw, rectangle] (L2) at (-1.8,-5) {$c_2$};
-  \node[draw, rectangle] (R1) at (2,-5) {$c_3$};
-  \node[draw, rectangle] (R2) at (4,-5) {$c_4$};
-
-  % Edges (unlabeled)
-  \draw[->] (root) -- (left);
-  \draw[->] (root) -- (right);
-  \draw[->] (left) -- (L1);
-  \draw[->] (left) -- (L2);
-  \draw[->] (right) -- (R1);
-  \draw[->] (right) -- (R2);
+\begin{framev}[align=top]{Interpretation of Tree-Based Models}
+\begin{itemizeM}
+\item Interpretation via path of decision rules along tree branches
+\item \textbf{Feature importance} (quantifies how often and how usefully $x_j$ is used):
+\begin{itemizeS}
+\item For each split on feature $x_j$, record the decrease in the split criterion
+\item Aggregate this over the tree: sum or avg. over all splits involving $x_j$
+\item Split criterion: variance (regression), Gini index / entropy (classif.)
+\end{itemizeS}
+%\item[] $\leadsto$ Quantifies how often and how usefully $x_j$ is used
+\end{itemizeM}
+\splitVTT[0.6]{
+\spacer[0]
+% \begin{tikzpicture}[scale=0.7, every node/.style={font=\small}]
+%   % Nodes
+%   \node[draw, circle] (root) at (0,0) {$x_j < 5$};
+%   \node[draw, circle] (left) at (-3,-2.5) {$x_k < 3$};
+%   \node[draw, rectangle] (L1) at (-4.2,-5) {$c_1$};
+%   \node[draw, rectangle] (L2) at (-1.8,-5) {$c_2$};
+%   \node[draw, circle] (right) at (3,-2.5) {$x_k < 7$};
+%   \node[draw, rectangle] (R1) at (2,-5) {$c_3$};
+%   \node[draw, rectangle] (R2) at (4,-5) {$c_4$};
+%   % Edges with labels
+%   \draw[->] (root) -- node[above left] {\scriptsize } node[midway, left=3pt] {\scriptsize  $\Delta\text{Var} = 0.18$} (left);
+%   \draw[->] (root) -- node[above right] {\scriptsize } node[midway, right=3pt] {\scriptsize } (right);
+%   \draw[->] (left) -- node[left] {\scriptsize $\Delta\text{Var} = 0.07$} (L1);
+%   \draw[->] (left) -- (L2);
+%   \draw[->] (right) -- node[left] {\scriptsize $\Delta\text{Var} = 0.10$} (R1);
+%   \draw[->] (right) -- (R2);
+% \end{tikzpicture}
+\begin{tikzpicture}[scale=0.75, every node/.style={font=\small}]
+% Nodes: rectangular with split condition + delta
+\node[draw, ellipse, align=center] (root) at (0,0) {$x_j < 5$\\ \scriptsize$ \Delta\text{Var} = 0.18$};
+\node[draw, ellipse, align=center] (left) at (-3,-2.5) {$x_k < 3$\\ \scriptsize$\Delta\text{Var} = 0.07$};
+\node[draw, ellipse, align=center] (right) at (3,-2.5) {$x_k < 7$\\ \scriptsize$\Delta\text{Var} = 0.10$};
+% Leaf nodes
+\node[draw, rectangle] (L1) at (-4.2,-5) {$c_1$};
+\node[draw, rectangle] (L2) at (-1.8,-5) {$c_2$};
+\node[draw, rectangle] (R1) at (2,-5) {$c_3$};
+\node[draw, rectangle] (R2) at (4,-5) {$c_4$};
+% Edges (unlabeled)
+\draw[->] (root) -- (left);
+\draw[->] (root) -- (right);
+\draw[->] (left) -- (L1);
+\draw[->] (left) -- (L2);
+\draw[->] (right) -- (R1);
+\draw[->] (right) -- (R2);
 \end{tikzpicture}
-
-    %\end{center}
-  \end{column}
-
-  \begin{column}{0.4\textwidth}
-    \begin{itemize}
-  \item Each $\Delta\text{Var}$ is assigned to the splitting feature
-  % Variance reductions $\Delta\text{Var}$ from splits are attributed to the splitting feature.
-  \item Feature importance = sum of all $\Delta\text{Var}$ for that feat.:
-  \begin{itemize}
-    \item[$x_j$:]  $0.18$
-    \item[$x_k$:]  $0.07 + 0.10 = 0.17$
-  \end{itemize}
-    \end{itemize}
-  \end{column}
-\end{columns}
+}{
+\spacer[0.6]
+\begin{itemizeM}
+\item Each $\Delta\text{Var}$ is assigned to the splitting feature
+% Variance reductions $\Delta\text{Var}$ from splits are attributed to the splitting feature.
+\item Feature importance = sum of all $\Delta\text{Var}$ for that feat.:
+\begin{itemizeS}
+\item[$x_j$:] $0.18$
+\item[$x_k$:] $0.07 + 0.10 = 0.17$
+\end{itemizeS}
+\end{itemizeM}
+}
 % \vspace{0.4cm}
 % \begin{center}
 % \begin{tikzpicture}[scale=0.7, every node/.style={font=\small}]
@@ -221,40 +194,33 @@ $$
 %     \item[] $\Rightarrow$ Feature importance($x_j$) += 0.18
 %     \item[] $\Rightarrow$ Feature importance($x_k$) += 0.07 + 0.10 = 0.17
 % \end{itemize}
+\end{framev}
 
-\end{frame}
 
-
-\begin{frame}{Decision Trees - Example}
-\begin{itemize}
-    \item Fit decision tree with tree depth of 3 on bike data
-    \item E.g., mean prediction for the first 105 days since 2011 is 1798\\
-    $\leadsto$ Applies to $\hat = 15\%$ of the data (leftmost branch)
-    \item \code{days\_since\_2011}: highest feat. importance (explains most of variance)
-\end{itemize}
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.37\textwidth}
-\vspace{1.5cm}
-\begin{table}[ht]
+\begin{framev}[align=top]{Decision Trees - Example}
+\begin{itemizeM}
+\item Fit decision tree with tree depth of 3 on bike data
+\item E.g., mean prediction for the first 105 days since 2011 is 1798\\
+$\leadsto$ Applies to $15\%$ of the data (leftmost branch)
+\item \code{days\_since\_2011}: highest feat. importance (explains most of variance)
+\end{itemizeM}
+\splitVCC[0.37]{
 \centering
-\scriptsize
+\begin{scriptsize}
 \begin{tabular}{lr}
-  \hline
- Feature & Importance \\
-  \hline
-days\_since\_2011 & 79.53 \\ 
-  temp & 17.55 \\ 
-  hum & 2.92 \\ 
-   \hline
+\hline
+Feature & Importance \\
+\hline
+days\_since\_2011 & 79.53 \\
+temp & 17.55 \\
+hum & 2.92 \\
+\hline
 \end{tabular}
-\end{table}
-\end{column}
-\begin{column}{0.63\textwidth}
-  \includegraphics[width = \textwidth]{figure/tree.pdf} 
-\end{column}
-\end{columns}
- 
-\end{frame}
+\end{scriptsize}
+}{
+\image{figure/tree.pdf}
+}
+\end{framev}
 %------------------------------------------------------------------
 %------------------------------------------------------------------
 
@@ -455,45 +421,39 @@ days\_since\_2011 & 79.53 \\
 % \end{frame}
 
 
-\begin{frame}{Unbiased Recursive Partitioning}  
-\vspace{-0.2cm}
+\begin{framev}[align=top]{Unbiased Recursive Partitioning}
 \furtherreading{HOTHORNETAL2006}
 \furtherreading{ZEILEISETAL2008}
-\furtherreading{STROBETAL2007}
-
-\vspace{0.2cm}
-\textbf{Problems} with CART (Classification and Regression Trees): 
-
+\furtherreading{STROBETAL2007}\\
+\textbf{Problems} with CART (Classification and Regression Trees):
 \begin{enumerate}
-    \item Selection bias towards high-cardinal/continuous features 
-    \item Splits on any improvement, regardless of significance \\$\leadsto$ prone to overfitting
+\item Selection bias towards high-cardinal/continuous features
+\item Splits on any improvement, regardless of significance\\
+$\leadsto$ prone to overfitting
 \end{enumerate}
-\smallskip
 \pause
-\textbf{Unbiased recursive partitioning} via conditional inference trees (\texttt{ctree}) or model-based recursive partitioning (\texttt{mob}): 
-\begin{enumerate}  
-  \item Separate selection of \textbf{feature used for splitting} and \textbf{split point}
-  \item Hypothesis test as stopping criteria 
+\textbf{Unbiased recursive partitioning} via conditional inference trees (\texttt{ctree}) or model-based recursive partitioning (\texttt{mob}):
+\begin{enumerate}
+\item Separate selection of \textbf{feature used for splitting} and \textbf{split point}
+\item Hypothesis test as stopping criteria
 \end{enumerate}
 %\medskip
+\spacer[0.25]
 \pause
-\begin{columns}[T, totalwidth = \textwidth]
-    \begin{column}{0.5\textwidth}
-    \textbf{Example (selection bias)}: \\
-         Simulate data ($n=200$), $Y \sim N(0,1)$ and 3 features of different cardinality indep. from $Y$ (repeat 500 times):
-\begin{itemize}
-    \item $X_1 \sim Binom(n, \frac{1}{2})$
-    \item $X_2 \sim M(n, (\frac{1}{4}, \frac{1}{4}, \frac{1}{4}, \frac{1}{4}))$
-    \item $X_3 \sim M(n, (\frac{1}{8}, \frac{1}{8}, \frac{1}{8}, \frac{1}{8}, \frac{1}{8}, \frac{1}{8}, \frac{1}{8}, \frac{1}{8}))$
-\end{itemize}
-    \end{column}
-    \begin{column}{0.5\textwidth}
-    \scriptsize
-    \centering
-    Which feature is selected in the first split?
-    \includegraphics[width = \textwidth]{figure/selection_bias_simulation_1000.pdf}
-    \end{column}
-\end{columns}
+\splitVTT{
+\textbf{Example (selection bias)}:\\
+Simulate data ($n=200$), $Y \sim N(0,1)$ and 3 features of different cardinality indep. from $Y$ (repeat 500 times):
+\begin{itemizeM}
+\item $X_1 \sim Binom(n, \frac{1}{2})$
+\item $X_2 \sim M(n, (\frac{1}{4}, \frac{1}{4}, \frac{1}{4}, \frac{1}{4}))$
+\item $X_3 \sim M(n, (\frac{1}{8}, \frac{1}{8}, \frac{1}{8}, \frac{1}{8}, \frac{1}{8}, \frac{1}{8}, \frac{1}{8}, \frac{1}{8}))$
+\end{itemizeM}
+}{
+\begin{scriptsize}
+Which feature is selected in the first split?
+\end{scriptsize}
+\image{figure/selection_bias_simulation_1000.pdf}
+}
 % \medskip
 % \scriptsize
 % \pause
@@ -527,51 +487,46 @@ days\_since\_2011 & 79.53 \\
 %         %\normalsize
 %     \end{column}
 % \end{columns}
+\end{framev}
 
-\end{frame}
 
-
-\begin{frame}{Unbiased Recursive Partitioning}
-
+\begin{framev}[align=top]{Unbiased Recursive Partitioning}
 %\vspace{-0.1cm}
 Differences to CART:
-\begin{itemize}
-    \item Two-step approach (finds 1. most significant split feat., 2. best split point)
-    \item Parametric model (e.g. LM instead of constant) can be fitted in leaf nodes % OLS regression, GLMs, and survival regression    
-    \item Significance of split (p-value) given in each node
-    \item \texttt{ctree} and \texttt{mob} differ in hypothesis test used for selecting the split feature (independence test vs. fluctuation test) and how to find the best split point
-\end{itemize}
-
-\medskip
-
-\begin{columns}[c, totalwidth = \textwidth]
-     \begin{column}{0.85\textwidth}
+\begin{itemizeM}
+\item Two-step approach (finds 1. most significant split feat., 2. best split point)
+\item Parametric model (e.g. LM instead of constant) can be fitted in leaf nodes % OLS regression, GLMs, and survival regression
+\item Significance of split (p-value) given in each node
+\item \texttt{ctree} and \texttt{mob} differ in hypothesis test used for selecting the split feature (independence test vs. fluctuation test) and how to find the best split point
+\end{itemizeM}
+\spacer[0.25]
+\splitVCC[0.8]{
 \only<2>{
 \textbf{Example} (\texttt{ctree}): Bike data (constant model in final nodes)
-\centerline{\includegraphics[width =\textwidth]{figure/bike_ctree.pdf}}
+\image{figure/bike_ctree.pdf}
 }
 \only<3>{
-\textbf{Example}  (\texttt{mob}): Bike data (linear model with \texttt{temp} in final nodes)
-\centerline{\includegraphics[width = \textwidth]{figure/bike_mob.pdf}}
+\textbf{Example} (\texttt{mob}): Bike data (linear model with \texttt{temp} in final nodes)
+\image{figure/bike_mob.pdf}
 }
 % \only<3>{
 % \centerline{Train error (MSE): 758,844.0 (\texttt{ctree}), 742,244.4 (\texttt{mob})}
 % }
-     \end{column}
-     \begin{column}{0.15\textwidth}
-     \only<2-3>{\scriptsize
-     Train MSE: \\
-     758,844 (\texttt{ctree})\\
-     742,244 (\texttt{mob})
-     }
+}{
+\only<2-3>{
+\begin{scriptsize}
+Train MSE:\\
+758,844 (\texttt{ctree})\\
+742,244 (\texttt{mob})
+\end{scriptsize}
+}
 % \only<3>{
 % Comparison MSE: \\
 % \texttt{ctree}: 758,844.0 \\
 % \texttt{mob}: 742,244.4
 % }
-     \end{column}
- \end{columns}
-\end{frame}
+}
+\end{framev}
 
 
 % \begin{frame}{Model-based (MOB) Recursive Partitioning \citebutton{Zeileis et al. (2008)}{https://doi.org/10.1198/106186008X319331}}
@@ -608,89 +563,66 @@ Differences to CART:
 %------------------------------------------------------------------
 
 
-\begin{frame}[t]{Other Rule-based Models}
+\begin{framev}[align=top]{Other Rule-based Models}
+\splitVCC[0.6]{
+\textbf{Decision Rules} \furtherreading{HOLTE1993}
+\begin{itemizeM}
+\item Flat list of simple ``if -- then'' statements\\
+$\leadsto$ very intuitive and easy-to-interpret
+\item Mainly devised for classification\\
+(support for regression is limited)
+\item Numeric features are typically discretised
+\end{itemizeM}
+}{
+\begin{scriptsize}
+\textcolor{blue}{IF} $x_1 \le 2.3$ \textcolor{blue}{AND} $x_4 = \text{``A''}$ \hfill \textcolor{blue}{THEN} \hspace{5pt} $y = 1$\\[2pt]
+\textcolor{blue}{ELSE IF} $x_2 > 5.0$ \hfill \textcolor{blue}{THEN} \hspace{5pt} $y = 2$\\[2pt]
+\textcolor{blue}{ELSE} \hfill $y = 3$
+\end{scriptsize}
+}
+\spacer[0.25]
+\splitVCC[0.65]{
+\only<2->{
+% \textbf{RuleFit} \citebutton{Friedman and Popescu 2008}{https://arxiv.org/abs/0811.1679}
+% \begin{itemize}
+%     \item Combination of LM and decision trees 
+%     \item Uses (many) decision trees to extract important decision rules $r_1, r_2, r_3, r_4$ which are used as features in a (regularized) LM
+%     \item Allows for feature interactions and non-linearities
+% \end{itemize}
+\textbf{RuleFit} \furtherreading{FRIEDMANPOPESCU2008}
+\begin{itemizeM}
+\item Extract binary rules $r_m(\mathbf{x}) \in \{0,1\}$ from many shallow trees (one per root-to-leaf path)
+\item Fit an $L_1$-regularized LM\\
+$\hat f(\mathbf{x})=\beta_0+\textstyle\sum_m\beta_m r_m(\mathbf{x})+\sum_j\gamma_j x_j$
+\item Regularization retains only a few rules\\
+$\Rightarrow$ sparse, non-linear, interaction-aware
+\item Coefficients relate to rule/feature importance
+\end{itemizeM}
+}
+% \only<3->{\textbf{Naive Bayes}
+% \citebutton{Zhang 2004}{https://www.aaai.org/Papers/FLAIRS/2004/Flairs04-097.pdf}
+% %$$P (C_k \mid x ) = \frac{1}{Z} P(C_k) \prod_{i=1}^{n} P(x_i \mid C_k) $$
+% \begin{itemize}
+%     \item Uses Bayes' theorem to assign class prob. to observations
+%     %Product of (conditional) probabilities for a class on the value of each feature
+%     %For each feature, it calculates the probability for a class depending on the value of the feature. 
+%     \item Strong assumption: Independence of features
+% \end{itemize}}
 
-\begin{columns}[c, totalwidth=\textwidth]
-    \begin{column}{0.6\textwidth}
-        \textbf{Decision Rules} \furtherreading{HOLTE1993}
-        \begin{itemize}
-            \item Flat list of simple ``if -- then'' statements\\
-            $\leadsto$ very intuitive and easy-to-interpret
-            \item Mainly devised for classification \\
-            (support for regression is limited)
-            \item Numeric features are typically discretised
-        \end{itemize}
-    \end{column}
-    \begin{column}{0.4\textwidth}
-        %\vspace{\dimexpr-2\parsep-2\parskip\relax}
-        %\begin{center}
-        \scriptsize
-\textcolor{blue}{IF}  $x_{1} \le 2.3$  \textcolor{blue}{AND}  $x_{4} = \text{``A''}$   \hfill\textcolor{blue}{THEN} \hspace{5pt} y = 1\\[2pt]
-\textcolor{blue}{ELSE IF}  $x_{2} > 5.0$  \hfill \textcolor{blue}{THEN} \hspace{5pt} y = 2\\[2pt]
-\textcolor{blue}{ELSE}  \hfill y = 3
-      %  \end{center}
-    % \vspace{\dimexpr-2\parsep-2\parskip\relax}
-    %     \begin{center}
-    %         \includegraphics[width = 0.8\textwidth]{figure/decision_rules.png}
-    %         % \only<4->{\includegraphics[width = 0.7\textwidth]{figure/knn.png} 
-    %         % \citebutton{José 2018}{https://towardsdatascience.com/knn-k-nearest-neighbors-1-a4707b24bd1d}}
-    %     \end{center}
-    \end{column}
-\end{columns}
+% \only<4->{\textbf{k-Nearest Neighbor}
+% \citebutton{Cover 1967}{https://doi.org/10.1109/TIT.1967.1053964}
+% \begin{itemize}
+%     \item (Closely related to case-based reasoning)
+%     \item Average of the outcome of neighbors -- local explanation
+% \end{itemize}
 
-\bigskip
-
-\begin{columns}[c, totalwidth=\textwidth]
-    \begin{column}{0.65\textwidth}
-        \only<2->{
-        % \textbf{RuleFit} \citebutton{Friedman and Popescu 2008}{https://arxiv.org/abs/0811.1679}
-        % \begin{itemize}
-        %     \item Combination of LM and decision trees 
-        %     \item Uses (many) decision trees to extract important decision rules $r_1, r_2, r_3, r_4$ which are used as features in a (regularized) LM
-        %     \item Allows for feature interactions and non-linearities
-        % \end{itemize}
-        \textbf{RuleFit} \furtherreading{FRIEDMANPOPESCU2008}
-\begin{itemize}
-  \item Extract binary rules \(r_m(\mathbf{x}) \in \{0,1\}\) from many shallow trees (one per root-to-leaf path)
-  \item Fit an $L_1$-regularized LM
-$\hat f(\mathbf x)=\beta_0+\textstyle\sum_m\beta_m r_m(\mathbf x)+\sum_j\gamma_j x_j$
-  \item Regularization retains only a few rules\\
-  $\Rightarrow$ sparse, non-linear, interaction-aware
-  \item Coefficients relate to rule/feature importance
-\end{itemize}
-
-        }
-
-        % \only<3->{\textbf{Naive Bayes}
-        % \citebutton{Zhang 2004}{https://www.aaai.org/Papers/FLAIRS/2004/Flairs04-097.pdf}
-        % %$$P (C_k \mid x ) = \frac{1}{Z} P(C_k) \prod_{i=1}^{n} P(x_i \mid C_k) $$
-        % \begin{itemize}
-        %     \item Uses Bayes' theorem to assign class prob. to observations
-        %     %Product of (conditional) probabilities for a class on the value of each feature
-        %     %For each feature, it calculates the probability for a class depending on the value of the feature. 
-        %     \item Strong assumption: Independence of features
-        % \end{itemize}}
-
-        % \only<4->{\textbf{k-Nearest Neighbor}
-        % \citebutton{Cover 1967}{https://doi.org/10.1109/TIT.1967.1053964}
-        % \begin{itemize}
-        %     \item (Closely related to case-based reasoning)
-        %     \item Average of the outcome of neighbors -- local explanation
-        % \end{itemize}
-
-        % ...}
-    \end{column}
-    \begin{column}{0.35\textwidth}
-    \vspace{\dimexpr-2\parsep-2\parskip\relax}
-        \begin{center}
-            \only<2->{\includegraphics[width = 0.6\textwidth]{figure/RuleFit.png}\\
-            \furtherreading{MOLNAR2022}\\
-            \smallskip }
-            % \only<4->{\includegraphics[width = 0.7\textwidth]{figure/knn.png} 
-            % \citebutton{José 2018}{https://towardsdatascience.com/knn-k-nearest-neighbors-1-a4707b24bd1d}}
-        \end{center}
-    \end{column}
-\end{columns}
-\end{frame}
+% ...}
+}{
+\only<2->{
+\imageC[0.6]{figure/RuleFit.png}
+\furtherreading{MOLNAR2022}
+}
+}
+\end{framev}
 \endlecture
 \end{document}

--- a/slides/interpretable-models/slides06-im-gam-boosting.tex
+++ b/slides/interpretable-models/slides06-im-gam-boosting.tex
@@ -8,15 +8,13 @@
 % new
 \input{../../style/preamble}
 % Defines macros and environments
- \input{../../latex-math/basic-ml} 
+\input{../../latex-math/basic-ml}
 \input{../../latex-math/basic-math}
 \input{../../latex-math/ml-ensembles}
-
 
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
 
@@ -50,58 +48,53 @@ figure/gam_effects.pdf
 %------------------------------------------------------------------
 %------------------------------------------------------------------
 
-\begin{frame}{Generalized Additive Model (GAM) % OLD
+\begin{framev}[align=top]{Generalized Additive Model (GAM) % OLD
 %\citebutton{Hastie and Tibshirani (1986)}{https://www.jstor.org/stable/2245459}
 % new
 \furtherreading{TIBSHIRANI1986}}
-
 \textbf{Problem}: LM not great if features act on outcome non-linearly % $\leadsto$ standard 
-
-\begin{columns}[totalwidth=\textwidth]
-    \begin{column}{0.57\textwidth}
-    
-        \only<2->{
-        \textbf{Workaround in LMs / GLMs}: 
-        \begin{itemize}
-            \item Feature transformations (e.g., exp, log)
-            \item Including high-order effects
-            \item Categorization of features (i.e., intervals/ buckets of feature values)
-        \end{itemize}}
-    \end{column}
-    \begin{column}{0.43\textwidth}
-        \begin{center}
-            \includegraphics[width = .95\textwidth]{figure/intro_lm_bike.pdf}
-            %\includegraphics[width = \textwidth]{figure/lm_bad_fit2.pdf}
-        \end{center}
-    \end{column}
-\end{columns}
-
-%\medskip
+\spacer[0.25]
+\splitVTT[0.57]{
+\spacer[0]
+\uncover<2->{
+\textbf{Workaround in LMs / GLMs}:
+\begin{itemizeM}
+\item Feature transformations (e.g., exp, log)
+\item Including high-order effects
+\item Categorization of features (i.e., intervals/ buckets of feature values)
+\end{itemizeM}
+}
+}{
+\spacer[0]
+\centering
+\image[0.95]{figure/intro_lm_bike.pdf}
+%\includegraphics[width = \textwidth]{figure/lm_bad_fit2.pdf}
+\spacer[0]
+}
+\spacer[0.25]
 
 \only<3->{
 \textbf{Idea of GAMs:}
-
-    \begin{itemize}
-        \item Instead of linear terms $\theta_j x_j$, use flexible functions $f_j(x_j)$ $\leadsto$ splines
-            $$g(\E (y \mid \xv)) = \theta_0 + f_1(x_1) + f_2(x_2) + \ldots + f_p(x_p)$$
-    
-        \item Preserves additive structure and allows to model non-linear effects
-        \item Splines have smoothness param. to control flexibility (prevent overfitting)\\
-        $\leadsto$ Needs to be chosen, e.g., via cross-validation
-    \end{itemize}}   
-
-\end{frame}
+\begin{itemizeM}
+\item Instead of linear terms $\theta_j x_j$, use flexible functions $f_j(x_j)$ $\leadsto$ splines
+$$g(\E (y \mid \xv)) = \theta_0 + f_1(x_1) + f_2(x_2) + \ldots + f_p(x_p)$$
+\item Preserves additive structure and allows to model non-linear effects
+\item Splines have smoothness param. to control flexibility (prevent overfitting)\\
+$\leadsto$ Needs to be chosen, e.g., via cross-validation
+\end{itemizeM}
+}
+\end{framev}
 
 
-\begin{frame}{Generalized Additive Model (GAM) - Example}
+\begin{framev}[align=top]{Generalized Additive Model (GAM) - Example}
 Fit a GAM with smooth splines for four numeric features of bike rental data \\
 $\leadsto$ more flexible and better model fit but less interpretable than LM
-
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.5\textwidth}
+\spacer[0.25]
+\splitVTT[0.5]{
+\spacer[0]
 \begin{table}[ht]
 \centering
-\scriptsize
+\begin{scriptsize}
 % \begin{tabular}{rrrrr}
 %   \hline
 %  & edf & Ref.df & F & p-value \\ 
@@ -112,39 +105,36 @@ $\leadsto$ more flexible and better model fit but less interpretable than LM
 %   s(days\_since\_2011) & 8.3 & 8.8 & 154.4 & 0.00 \\ 
 %   \hline
 \begin{tabular}{rrr}
-  \hline
- & edf & p-value \\ 
-  \hline
-s(temp) & 5.8 & 0.00 \\ 
-  s(hum) & 4.0 & 0.00 \\ 
-  s(windspeed) & 1.7 & 0.00 \\ 
-  s(days\_since\_2011) & 8.3 & 0.00 \\ 
-   \hline
+\hline
+& edf & p-value \\
+\hline
+s(temp) & 5.8 & 0.00 \\
+s(hum) & 4.0 & 0.00 \\
+s(windspeed) & 1.7 & 0.00 \\
+s(days\_since\_2011) & 8.3 & 0.00 \\
+\hline
 \end{tabular}
+\end{scriptsize}
 \end{table}
-
-
 \textbf{Interpretation}
-\begin{itemize}
-    %\item If the temperature increases by 1 degree Celsius then the log odds of high number of bike rentals increase linearly by 0.3 c.p.
-    \item Interpretation is done visually and relative to average prediction
-    %, also see PDPs
-    \item Edf: effective degrees of freedom\\
-    $\leadsto$ represents degree of smoothness/complexity
-\end{itemize}
-\end{column}
-\hfill
+\begin{itemizeM}
+%\item If the temperature increases by 1 degree Celsius then the log odds of high number of bike rentals increase linearly by 0.3 c.p.
+\item Interpretation is done visually and relative to average prediction
+%, also see PDPs
+\item Edf: effective degrees of freedom\\
+$\leadsto$ represents degree of smoothness/complexity
+\end{itemizeM}
+}{
+\spacer[0]
 \centering
-\begin{column}{0.5\textwidth}
-\includegraphics[width = \textwidth]{figure/gam_effects.pdf}
-\end{column}
-\end{columns}
-\end{frame}
+\image{figure/gam_effects.pdf}
+}
+\end{framev}
 
 %------------------------------------------------------------------
 %------------------------------------------------------------------
 
-\begin{frame}{Model-based Boosting % OLD
+\begin{framei}[align=top]{Model-based Boosting % OLD
 %\citebutton{Bühlmann, Yu 2003}{https://doi.org/10.1198/016214503000125}
 % new
 \furtherreading{BÜHLMANNYU2003} % OLD
@@ -152,7 +142,6 @@ s(temp) & 5.8 & 0.00 \\
 % new
 \furtherreading{BÜHLMANNHOTHORN2008}}
 
-\begin{itemize}%[<+->]
 %\setlength\itemsep{2em}
 \item Boosting iteratively combines weak base learners to create powerful ensemble 
 \item
@@ -180,209 +169,191 @@ In each iteration, fit a set of BLs, add best one to model (with step-size $\nu$
 &= \hat{f}_0 + \textcolor{blue}{\hat{f}_3(\xv_3)} + \textcolor{orange}{\hat{f}_1(\xv_1)}
 \end{align*}
 \item Final model is additive GAM, we can read off effect curves
-\end{itemize}
-\end{frame}
+\end{framei}
 
 
-
-
-
-
-
-
-
-
-\begin{frame}{Model-based Boosting - Linear Example}
-
+\begin{framev}[align=top]{Model-based Boosting - Linear Example}
 Simple case: Use linear model with single feature (including intercept) as BL
 $$
 \bl[j](x_j, \thetav) = x_j\thetav + \thetav_0 \hspace*{0.2cm}\text{ for } j = 1,\ldots p \hspace*{0.3cm} \leadsto \text{ordinary linear regression}
 $$
-
-\begin{itemize}
+\begin{itemizeM}
 \item<1-> Here: Interpretation of weights as in LM
 \item<1-> After many iterations, it converges to same solution as LM %least square estimate of
 \item<2-> Early stopping allows feature selection \& may also prevent\\ overfitting (regularization)
 %\item Specifying loss and link function according to exponential family leads a (regularized) GLM
-\end{itemize}
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.49\linewidth}
-\scriptsize
+\end{itemizeM}
+\spacer[0.25]
+\splitVTT[0.49]{
+\spacer[0]
 \begin{table}[ht]
 \centering
-\tiny
+\begin{tiny}
 \begin{tabular}{r|r|l}
-  %\hline
-\textbf{1000 iter. with $\nu = 0.1$} & Intercept & Weights \\ 
-  \hline  \hline
-days\_since\_2011 & -1791.06 & 4.9 \\ 
-  \hline
-  hum & 1953.05 & -31.1 \\ 
-    \hline
-  season & 0 &  \begin{tabular}[c]{@{}l@{}}
-  WINTER: -323.4\\
-  SPRING: 539.5\\
-  SUMMER: -280.2\\
-  FALL: 67.2
-  \end{tabular}\\
-    \hline
-  %season &  & WINTER: -323.4, SPRING: 539.5, SUMMER: -280.2, FALL: 67.2 \\ 
-  temp & -1839.85 & 120.4 \\ 
-    \hline
-  windspeed & 725.70 & -56.9 \\ 
-    \hline
-  offset & 4504.35 &  \\ 
-   %\hline
+%\hline
+\textbf{1000 iter. with $\nu = 0.1$} & Intercept & Weights \\
+\hline \hline
+days\_since\_2011 & -1791.06 & 4.9 \\
+\hline
+hum & 1953.05 & -31.1 \\
+\hline
+season & 0 & \begin{tabular}[c]{@{}l@{}}
+WINTER: -323.4\\
+SPRING: 539.5\\
+SUMMER: -280.2\\
+FALL: 67.2
+\end{tabular}\\
+\hline
+%season &  & WINTER: -323.4, SPRING: 539.5, SUMMER: -280.2, FALL: 67.2 \\
+temp & -1839.85 & 120.4 \\
+\hline
+windspeed & 725.70 & -56.9 \\
+\hline
+offset & 4504.35 &  \\
+%\hline
 \end{tabular}
+\end{tiny}
 \end{table}
-% \centering
-% $\Rightarrow$ Converges to solution of LM 
-\end{column}
-\begin{column}{0.49\linewidth}
-
-\only<1>{\scriptsize
-\medskip
+\spacer[0]
+{\scriptsize
+\centering
+$\Rightarrow$ Converges to solution of LM
+\par
+}
+}{
+\only<1>{
+\spacer[0]
+{\scriptsize
 Relative frequency of selected BLs across iterations
-\includegraphics[width = .95 \linewidth]{figure/compboost_base_linear.pdf}}
+\par
+}
+% no use of \imageC due to additional vertical spacing which in this case looks worse
+\centering
+\image[0.95]{figure/compboost_base_linear.pdf}
 
-
+\spacer[0]
+}
 \only<2>{
+\spacer[0]
 \begin{table}[ht]
 \centering
-\tiny
+\begin{tiny}
 \begin{tabular}{r|r|l}
-  %\hline
- \textbf{20 iter. with $\nu = 0.1$} & Intercept & Weights \\ 
-  \hline  \hline
-  days\_since\_2011 & -1210.27 & 3.3 \\ 
-    \hline
-   season & 0 & 
-   \begin{tabular}[c]{@{}l@{}}
-  WINTER: -276.9\\
-  SPRING: 137.6\\
-  SUMMER: 112.8\\
-  FALL: 20.3
-   \end{tabular}\\
-     \hline
-  temp & -1118.94 & 73.2 \\ 
-    \hline
-  offset & 4504.35 &  \\ 
-   %\hline
+%\hline
+\textbf{20 iter. with $\nu = 0.1$} & Intercept & Weights \\
+\hline \hline
+days\_since\_2011 & -1210.27 & 3.3 \\
+\hline
+season & 0 &
+\begin{tabular}[c]{@{}l@{}}
+WINTER: -276.9\\
+SPRING: 137.6\\
+SUMMER: 112.8\\
+FALL: 20.3
+\end{tabular}\\
+\hline
+temp & -1118.94 & 73.2 \\
+\hline
+offset & 4504.35 &  \\
+%\hline
 \end{tabular}
+\end{tiny}
 \end{table}
-% \centering
-% \scriptsize
-% $\Rightarrow$ 3 BLs selected after 20 iter. (feature selection)
-}
-\end{column}
-\end{columns}
-
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.49\linewidth}
-\scriptsize
+\spacer[0]
+{\scriptsize
 \centering
-$\Rightarrow$ Converges to solution of LM 
-\end{column}
-\begin{column}{0.49\linewidth}
-
-\only<2>{
-\centering
-\scriptsize
 $\Rightarrow$ 3 BLs selected after 20 iter. (feature selection)
+\par
 }
-\end{column}
-\end{columns}
+}
+}
 % \begin{itemize}
 %     \item Linear base learners for numeric features and categorical base learner for season
 %     \item 3 base learners selected after 100 iterations
 % \end{itemize}
+\end{framev}
 
-\end{frame}
 
-
-\begin{frame}{Linear Example: Interpretation}
-
-\medskip
+\begin{framev}[align=top]{Linear Example: Interpretation}
 \textbf{Feature importance:} aggregated change in risk in each iteration per feature
-\begin{itemize}
-    \item E.g. iter. 1: \code{days\_since\_2011} with risk reduction (MSE) of 140,782.94
-    \item For every iteration the change in risk can be attributed to a feature
-\end{itemize}
-\medskip
-
-\begin{columns}[T, totalwidth=\textwidth]
-\begin{column}{0.47\linewidth}
-\hspace{46pt}{\scriptsize{1000 iterations}}
-\includegraphics[width = \linewidth]{figure/compboost_pfi_base2.pdf}\\
-\centering \scriptsize
+\begin{itemizeM}
+\item E.g. iter. 1: \code{days\_since\_2011} with risk reduction (MSE) of 140,782.94
+\item For every iteration the change in risk can be attributed to a feature
+\end{itemizeM}
+\spacer[0.25]
+\splitVTT[0.5]{
+\centering
+{\scriptsize 1000 iterations}\\
+\image{figure/compboost_pfi_base2.pdf}\\
+{\scriptsize
 In-bag-risk: 434,686.0 \\
 OOB risk (10-fold CV): 446,450.0
-\end{column}
-
-
-\begin{column}{0.47\linewidth}
-\hspace{46pt}{\scriptsize{20 iterations}}
-\includegraphics[width = \linewidth]{figure/compboost_pfi_base1.pdf}\\
-\centering \scriptsize
+}
+}{
+\centering
+{\scriptsize 20 iterations}\\
+\image{figure/compboost_pfi_base1.pdf}\\
+{\scriptsize
 In-bag-risk: 693,505.0\\
 OOB risk (10-fold CV): 705,776.0
-\end{column}
-\end{columns}
-
+}
+}
 \begin{center}
-\scriptsize
+{\scriptsize
 $\Rightarrow$ Difference in risk: 258,819.0\\
 Difference in OOB risk: 259,326.0\\
+}
 % \normalsize
 % \medskip
 % $\leadsto$ Ranking of features stays the same
 
 \end{center}
+\end{framev}
 
-\end{frame}
 
-
-\begin{frame}{Non-linear Example: Interpretation}
-
-\begin{itemize}
-    \item Fit model on bike data with different BL types (1000 iter.) % OLD
+\begin{framev}[align=top]{Non-linear Example: Interpretation}
+\begin{itemizeM}
+\item Fit model on bike data with different BL types (1000 iter.) % OLD
 %\citebutton{Daniel Schalk et al. 2018}{https://doi.org/10.21105/joss.00967}
 % new
 \furtherreading{SCHALKETAL2018}
-    \item BLs: linear and centered splines for numeric feat., categorical for season
-    %and categorical base learner for season
-\end{itemize}
-\begin{columns}[T, totalwidth = \textwidth]
+\item BLs: linear and centered splines for numeric feat., categorical for season
+%and categorical base learner for season
+\end{itemizeM}
+\spacer[0.25]
 \visible<2->{
-\begin{column}{0.5\linewidth}
-\hspace{45pt}{\scriptsize{Feature importance}}
- \includegraphics[width = \linewidth]{figure/compboost_pfi.pdf}
+\splitVCC[0.5]{
+\centering
+{\scriptsize Feature importance}\\
+\image{figure/compboost_pfi.pdf}
+\spacer[0]
 %Feature importance (risk reduction over iter.)\\
 %$\leadsto$ \code{days\_since\_2011} most important
 %\scriptsize
 %\verbatiminput{figure/mboost_output.txt}
-\end{column}
-}
-\visible<2->{
-\begin{column}{0.5\linewidth}  %%<--- here
-\hspace{23pt}{\scriptsize{Feature effect}}
-  \includegraphics[width = \linewidth]{figure/compboost_pfe.pdf}
+}{
+\centering
+{\scriptsize Feature effect}\\
+\image{figure/compboost_pfe.pdf}
+\spacer[0]
 %Partial feature effect for \code{days\_since\_2011}\\
 %$\leadsto$ Total effect: Combination of partial effects of linear BL and centered spline BL
-\end{column}
 }
-\end{columns}
-\smallskip
-\scriptsize
-\only<2->{\qquad $\Rightarrow$ In-bag-risk: 250,202.0 \, ; \, OOB risk (10-fold CV): 267,497.0 (difference to lin. example: 178,953.0)\\
-\qquad $\Rightarrow$ In-bag-risk: 434,686.0 \, ; \, OOB risk (10-fold CV): 446,450.0 (previous lin. example with 1000 iter.)}
-\begin{itemize}
-    \normalsize
-    \item<2->  Feature importance (risk reduction over iter.) \\ $\leadsto$ \code{days\_since\_2011} most important
-    \item<2-> Total effect for \code{days\_since\_2011}\\
+}
+\only<2->{
+\spacer[0]
+{\scriptsize
+\qquad $\Rightarrow$ In-bag-risk: 250,202.0 \, ; \, OOB risk (10-fold CV): 267,497.0 (difference to lin. example: 178,953.0)\\
+\qquad $\Rightarrow$ In-bag-risk: 434,686.0 \, ; \, OOB risk (10-fold CV): 446,450.0 (previous lin. example with 1000 iter.)
+}
+}
+\begin{itemizeM}
+\item<2-> Feature importance (risk reduction over iter.)\\
+$\leadsto$ \code{days\_since\_2011} most important
+\item<2-> Total effect for \code{days\_since\_2011}\\
 $\leadsto$ Combination of partial effects of linear BL and centered spline BL
-\end{itemize}
-\end{frame}
+\end{itemizeM}
+\end{framev}
 
 %------------------------------------------------------------------
 %------------------------------------------------------------------

--- a/slides/interpretable-models/slides07-im-ebm.tex
+++ b/slides/interpretable-models/slides07-im-ebm.tex
@@ -17,7 +17,6 @@
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lectureml/}{compstat-lmu.github.io/lecture\ml}}
-\date{}
 
 \def\firstrowcolor{}
 \def\secondrowcolor{}
@@ -47,11 +46,11 @@ Explainable Boosting Machines (EBM)
 }{
 figure/ebm.jpg
 }{
-  \item Understand link between GAM and EBM
-  \item Learn univariate EBMs\\
-  $\hat{=}$ GAM + boosting + shallow bagged trees
-  \item Extend to GA2M: GAMs with selected pairwise interactions
-  \item Detect interactions efficiently using FAST algorithm
+\item Understand link between GAM and EBM
+\item Learn univariate EBMs\\
+$\hat{=}$ GAM + boosting + shallow bagged trees
+\item Extend to GA2M: GAMs with selected pairwise interactions
+\item Detect interactions efficiently using FAST algorithm
 }
 
 
@@ -60,12 +59,15 @@ figure/ebm.jpg
 
 % Improved and streamlined version of regression tree splitting slides
 % --- Slide 1: RSS as Impurity Measure ---
-\begin{frame}{Recap: Split Selection Decision Tree}
-  \begin{itemize}
-    \item \textbf{Impurity (Regression):} Variance of target $Y$ in a node:
-    \[ \text{Var}(Y) = \frac{1}{n}\sum_{i=1}^n (y^{(i)} - \bar{y})^2 = \frac{1}{n} \sum_{i=1}^n (y^{(i)})^2 - \bar{y}^2 \]
-    \item \textbf{Sum of squared errors (SSE) =  residual sum of squares (RSS)}: 
-$$%\Rightarrow
+\begin{framev}[align=top]{Recap: Split Selection Decision Tree}
+\begin{itemizeM}
+\item \textbf{Impurity (Regression):} Variance of target $Y$ in a node:
+$$
+\text{Var}(Y) = \frac{1}{n}\sum_{i=1}^n (y^{(i)} - \bar{y})^2 = \frac{1}{n} \sum_{i=1}^n (y^{(i)})^2 - \bar{y}^2
+$$
+\item \textbf{Sum of squared errors (SSE) = residual sum of squares (RSS)}:
+$$
+%\Rightarrow
 %    \begin{aligned}
 %\textstyle
 \text{RSS} 
@@ -79,91 +81,83 @@ $$%\Rightarrow
 %\end{aligned}
 $$
 %\Rightarrow \text{RSS} = SS_n - \frac{S_n^2}{n}$ with $S_n = \sum_{i=1}^n y^{(i)}, \quad SS_n = \sum_{i=1}^n (y^{(i)})^2$
-      \[
-        \text{Hence: } \boxed{\text{RSS}=SS_{n}-\dfrac{S_{n}^{2}}{n}
-        \quad\text{with}\quad
-        S_{n}=\sum_{i=1}^{n}y^{(i)},\;
-        SS_{n}=\sum_{i=1}^{n}(y^{(i)})^{2}}
-      \]
-    \item \textbf{Split criterion:} 
-    \begin{itemize}
-    \item \textbf{Minimize post-split RSS:}
-    $
-    \text{RSS}_{\text{split}} = \text{RSS}_L + \text{RSS}_R
-    $
-    \item \textbf{Maximize reduction in RSS:}
-    $
-    \Delta \text{RSS} = \text{RSS}_{\text{parent}} - (\text{RSS}_L + \text{RSS}_R)
-    $
-  \end{itemize}
-  \end{itemize}
-  % \vspace{0.5em}
-  % \textit{Used in CART for regression (Breiman et al., 1984)}
-\end{frame}
+$$
+\text{Hence: } \boxed{\text{RSS}=SS_{n}-\dfrac{S_{n}^{2}}{n}
+\quad\text{with}\quad
+S_{n}=\sum_{i=1}^{n}y^{(i)},\;
+SS_{n}=\sum_{i=1}^{n}(y^{(i)})^{2}}
+$$
+\item \textbf{Split criterion:}
+\begin{itemizeS}
+\item \textbf{Minimize post-split RSS:} $\text{RSS}_{\text{split}} = \text{RSS}_L + \text{RSS}_R$
+\item \textbf{Maximize reduction in RSS:} $\Delta \text{RSS} = \text{RSS}_{\text{parent}} - (\text{RSS}_L + \text{RSS}_R)$
+\end{itemizeS}
+\end{itemizeM}
+% \vspace{0.5em}
+% \textit{Used in CART for regression (Breiman et al., 1984)}
+\end{framev}
 
 % --- Slide 2: Naive Split Computation ---
-\begin{frame}{Naive Split Selection: Explicit Comput.}
-  % \begin{itemize}
-  %   \item Sort data by feature $X$, examine $n-1$ potential split points
-  %   \item For each split at split point $s_i$:
-  %   \begin{itemize}
-  %     \item Compute group sizes $N_L$, $N_R$
-  %     \item Compute means $\bar{y}_L$, $\bar{y}_R$ and $\text{RSS}_L = \sum (y^{(i)} - \bar{y}_L)^2$
-  %     \item Total impurity: $\text{RSS}_L + \text{RSS}_R$
-  %   \end{itemize}
-  %   \item Select split that minimizes total RSS
-  %   \item \textbf{Computational cost:} $O(n^2)$ per feature (recomputes means/RSS from scratch in L and R node)
-  % \end{itemize}
-\begin{itemize}
-  \item For a given feature \( X_j \), sort the pairs \( (x_j^{(i)}, y^{(i)}) \) by increasing \( x_j^{(i)} \).
-
-  \item For each of the \( n - 1 \) potential split points at \( s_k =  \frac{1}{2}(x_j^{(k)} + x_j^{(k+1)})\):
-  \begin{itemize}
-    \item Define partitions:
-    $\mathcal{I}_L = \{ i : x^{(i)} \leq s_k \}, \quad \mathcal{I}_R = \{ i : x^{(i)} > s_k \}
-    $
-    \item Compute group means and counts after splitting at $s_k$:
-    \[\textstyle 
-    \bar{y}_L = \frac{1}{N_L} \sum_{i \in \mathcal{I}_L} y^{(i)}, \quad
-    \bar{y}_R = \frac{1}{N_R} \sum_{i \in \mathcal{I}_R} y^{(i)}, \text{ with }   N_L = |\mathcal{I}_L|, \quad N_R = |\mathcal{I}_R|
-    \]
-    \item Compute RSS after splitting at $s_k$:
-    \[\textstyle
-    \text{RSS}_\text{split}(s_k) = \text{RSS}_L(s_k) + \text{RSS}_R(s_k) = \sum_{i \in \mathcal{I}_L} (y^{(i)} - \bar{y}_L)^2 + \sum_{i \in \mathcal{I}_R} (y^{(i)} - \bar{y}_R)^2
-    \]
-    % \item Total impurity after split:
-    % \[
-    % \text{RSS}_{\text{split}} = \text{RSS}_L + \text{RSS}_R
-    % \]
-  \end{itemize}
-  \item Select split point \( s_k \) that minimizes \( \text{RSS}_\text{split}(s_k) \)
-  \item \textbf{Compute cost:} \( O(n^2) \) per feat. (recompute mean \& RSS at each split)
-\end{itemize}
-  % --- TikZ figure: explicit computation for naive split selection ---
-  \centering
+\begin{framev}[align=top]{Naive Split Selection: Explicit Comput.}
+% \begin{itemize}
+%   \item Sort data by feature $X$, examine $n-1$ potential split points
+%   \item For each split at split point $s_i$:
+%   \begin{itemize}
+%     \item Compute group sizes $N_L$, $N_R$
+%     \item Compute means $\bar{y}_L$, $\bar{y}_R$ and $\text{RSS}_L = \sum (y^{(i)} - \bar{y}_L)^2$
+%     \item Total impurity: $\text{RSS}_L + \text{RSS}_R$
+%   \end{itemize}
+%   \item Select split that minimizes total RSS
+%   \item \textbf{Computational cost:} $O(n^2)$ per feature (recomputes means/RSS from scratch in L and R node)
+% \end{itemize}
+\begin{itemizeM}
+\item For a given feature $X_j$, sort the pairs $(x_j^{(i)}, y^{(i)})$ by increasing $x_j^{(i)}$.
+\item For each of the $n - 1$ potential split points at $s_k = \frac{1}{2}(x_j^{(k)} + x_j^{(k+1)})$:
+\begin{itemizeS}
+\item Define partitions: $\mathcal{I}_L = \{ i : x^{(i)} \leq s_k \}, \quad \mathcal{I}_R = \{ i : x^{(i)} > s_k \}$
+\item Compute group means and counts after splitting at $s_k$:
+$$
+\textstyle
+\bar{y}_L = \frac{1}{N_L} \sum_{i \in \mathcal{I}_L} y^{(i)}, \quad
+\bar{y}_R = \frac{1}{N_R} \sum_{i \in \mathcal{I}_R} y^{(i)}, \text{ with } N_L = |\mathcal{I}_L|, \quad N_R = |\mathcal{I}_R|
+$$
+\item Compute RSS after splitting at $s_k$:
+$$
+\textstyle
+\text{RSS}_\text{split}(s_k) = \text{RSS}_L(s_k) + \text{RSS}_R(s_k) = \sum_{i \in \mathcal{I}_L} (y^{(i)} - \bar{y}_L)^2 + \sum_{i \in \mathcal{I}_R} (y^{(i)} - \bar{y}_R)^2
+$$
+% \item Total impurity after split:
+% \[
+% \text{RSS}_{\text{split}} = \text{RSS}_L + \text{RSS}_R
+% \]
+\end{itemizeS}
+\item Select split point $s_k$ that minimizes $\text{RSS}_\text{split}(s_k)$.
+\item \textbf{Compute cost:} $O(n^2)$ per feat. (recompute mean \& RSS at each split)
+\end{itemizeM}
+\centering
 \begin{tikzpicture}[x=1.2cm,y=0.9cm]
-  \foreach \x/\val/\i in {0/1.2/1, 1/2.0/2, 2/1.5/3, 3/3.2/4, 4/2.8/5, 5/4.1/6} {
-    \node[circle, draw, fill=blue!12, inner sep=2pt] (y\i) at (\x,0) {$y^{(\i)}$};
-  }
-  \foreach \s/\j in {0.5/1,1.5/2,2.5/3,3.5/4,4.5/5}{
-    \draw[dashed] (\s,0.55) -- (\s,-0.55);
-    \node[font=\scriptsize] at (\s,0.8) {$s_{\j}$};
-  }
-  \draw[decorate, decoration={brace,mirror, amplitude=4pt}]
-        (-0.25,-0.75) -- (2.5,-0.75)
-        node[midway,below=4pt,font=\scriptsize] {left: $N_L=3$};
-  \draw[decorate, decoration={brace,mirror, amplitude=4pt}]
-        (2.5,-0.75) -- (5.25,-0.75)
-        node[midway,below=4pt,font=\scriptsize] {right: $N_R=3$};
-  \node[draw,rounded corners,align=left,font=\scriptsize] (comp) at (2.5,-2.0) {
-      Compute: 
-      $\displaystyle\bar{y}_L,\;\bar{y}_R\;$ and 
-      $\displaystyle\text{RSS}_L + \text{RSS}_R$};
-  \draw[->,>=latex] (2.5,-0.55) -- (comp.north);
-  \node[font=\tiny,anchor=west] at (0.2,-2.55)
-        {$\color{gray}{\mathcal{O}(n^2)\ \text{operations (recompute for each split } s_i \text{ per feature})}$};
+\foreach \x/\val/\i in {0/1.2/1, 1/2.0/2, 2/1.5/3, 3/3.2/4, 4/2.8/5, 5/4.1/6} {
+\node[circle, draw, fill=blue!12, inner sep=2pt] (y\i) at (\x,0) {$y^{(\i)}$};
+}
+\foreach \s/\j in {0.5/1,1.5/2,2.5/3,3.5/4,4.5/5}{
+\draw[dashed] (\s,0.55) -- (\s,-0.55);
+\node[font=\scriptsize] at (\s,0.8) {$s_{\j}$};
+}
+\draw[decorate, decoration={brace,mirror, amplitude=4pt}]
+(-0.25,-0.75) -- (2.5,-0.75)
+node[midway,below=4pt,font=\scriptsize] {left: $N_L=3$};
+\draw[decorate, decoration={brace,mirror, amplitude=4pt}]
+(2.5,-0.75) -- (5.25,-0.75)
+node[midway,below=4pt,font=\scriptsize] {right: $N_R=3$};
+\node[draw,rounded corners,align=left,font=\scriptsize] (comp) at (2.5,-2.0) {
+Compute:
+$\displaystyle\bar{y}_L,\;\bar{y}_R\;$ and
+$\displaystyle\text{RSS}_L + \text{RSS}_R$};
+\draw[->,>=latex] (2.5,-0.55) -- (comp.north);
+\node[font=\tiny,anchor=west] at (0.2,-2.55)
+{$\color{gray}{\mathcal{O}(n^2)\ \text{operations (recompute for each split } s_i \text{ per feature})}$};
 \end{tikzpicture}
-\end{frame}
+\end{framev}
 
 % % --- Slide 3: Optimized Split via Prefix Sums ---
 % \begin{frame}{Efficient Split Selection: Prefix-Sum Trick}
@@ -181,9 +175,9 @@ $$
 
 
 
-\begin{frame}{Efficient Split Selection}
-\begin{itemize}
-  \item \textbf{Setup:} For feature \(X_j\), sort the data \((x_j^{(i)}, y^{(i)})_{i=1}^n\) by increasing \(x_j^{(i)}\)
+\begin{framev}[align=top]{Efficient Split Selection}
+\begin{itemizeM}
+\item \textbf{Setup:} For feature $X_j$, sort the data $(x_j^{(i)}, y^{(i)})_{i=1}^n$ by increasing $x_j^{(i)}$
   % \item \textbf{Candidate split at threshold } \(s_k := \tfrac{1}{2}(x_j^{(k)} + x_j^{(k+1)})\)
 
   % \item \textbf{Define index sets (based on split at } \(s_k\)\textbf{):}
@@ -192,47 +186,44 @@ $$
   %     \mathcal{I}_R = \{ i : x_j^{(i)} > s_k \}
   %   \]
 
-  \item \textbf{Define group statistics (cumulative sums) after split at $s_k$:}
-    % \[
-    % \begin{aligned}
-    %   S_L &= \textstyle\sum_{i \in \mathcal{I}_L} y^{(i)}, \qquad
-    %   SS_L = \sum_{i \in \mathcal{I}_L} (y^{(i)})^2, \qquad
-    %   N_L = |\mathcal{I}_L| \\
-    %   S_R &= \textstyle\sum_{i \in \mathcal{I}_R} y^{(i)}, \qquad
-    %   SS_R = \sum_{i \in \mathcal{I}_R} (y^{(i)})^2, \qquad
-    %   N_R = |\mathcal{I}_R|
-    % \end{aligned}
-    % \]
-      \[
-    \begin{aligned}
-      S_L &= \textstyle\sum_{i \in \mathcal{I}_L} y^{(i)}, \qquad
-      SS_L = \sum_{i \in \mathcal{I}_L} (y^{(i)})^2, \qquad
-      N_L = |\mathcal{I}_L| \\
-      S_R &= \textstyle S_n - S_L, \qquad
-      SS_R = SS_n - SS_L, \qquad
-      N_R = n - N_L
-    \end{aligned}
-    \]
-
-  \item \textbf{RSS for child nodes and parent node:}
-    \[
-      \text{RSS}_L(s_k) = SS_L - \frac{S_L^2}{N_L}, 
-      \text{RSS}_R(s_k) = SS_R - \frac{S_R^2}{N_R}, 
-      \text{RSS}_{\text{parent}} = SS_L + SS_R - \frac{S_n^2}{n}
-    \]
-  \item<2-> \textbf{Reduction in RSS:}
-    \[
-      \Delta\text{RSS}(s_k) = \text{RSS}_{\text{parent}} - (\text{RSS}_L + \text{RSS}_R)
-      = \frac{S_L^2}{N_L} + \frac{S_R^2}{N_R} - \frac{S_n^2}{n}
-    \]
-
-    \emph{All squared-target terms \( SS_L \), \( SS_R \) cancel. Only first-order sums needed.}
-
-  \item<2-> \textbf{Search:} Choose best split \(s_k^\star = \arg\max_{s_k} \Delta\text{RSS}(s_k)\)
-
-  \item<2-> \textbf{Complexity per feature:}\\\; \(O(n\log n)\) (sorting) + \(O(n)\) (cumulative sums and scan)
-\end{itemize}
- HB\end{frame}
+\item \textbf{Define group statistics (cumulative sums) after split at $s_k$:}
+% \[
+% \begin{aligned}
+%   S_L &= \textstyle\sum_{i \in \mathcal{I}_L} y^{(i)}, \qquad
+%   SS_L = \sum_{i \in \mathcal{I}_L} (y^{(i)})^2, \qquad
+%   N_L = |\mathcal{I}_L| \\
+%   S_R &= \textstyle\sum_{i \in \mathcal{I}_R} y^{(i)}, \qquad
+%   SS_R = \sum_{i \in \mathcal{I}_R} (y^{(i)})^2, \qquad
+%   N_R = |\mathcal{I}_R|
+% \end{aligned}
+% \]
+$$
+\begin{aligned}
+S_L &= \textstyle\sum_{i \in \mathcal{I}_L} y^{(i)}, \qquad
+SS_L = \sum_{i \in \mathcal{I}_L} (y^{(i)})^2, \qquad
+N_L = |\mathcal{I}_L| \\
+S_R &= \textstyle S_n - S_L, \qquad
+SS_R = SS_n - SS_L, \qquad
+N_R = n - N_L
+\end{aligned}
+$$
+\item \textbf{RSS for child nodes and parent node:}
+$$
+\text{RSS}_L(s_k) = SS_L - \frac{S_L^2}{N_L},
+\text{RSS}_R(s_k) = SS_R - \frac{S_R^2}{N_R},
+\text{RSS}_{\text{parent}} = SS_L + SS_R - \frac{S_n^2}{n}
+$$
+\item<2-> \textbf{Reduction in RSS:}
+$$
+\Delta\text{RSS}(s_k) = \text{RSS}_{\text{parent}} - (\text{RSS}_L + \text{RSS}_R)
+= \frac{S_L^2}{N_L} + \frac{S_R^2}{N_R} - \frac{S_n^2}{n}
+$$
+\emph{All squared-target terms $SS_L$, $SS_R$ cancel. Only first-order sums needed.}
+\item<2-> \textbf{Search:} Choose best split $s_k^\star = \arg\max_{s_k} \Delta\text{RSS}(s_k)$
+\item<2-> \textbf{Complexity per feature:}\\
+$O(n\log n)$ (sorting) + $O(n)$ (cumulative sums and scan)
+\end{itemizeM}
+\end{framev}
 
 
 
@@ -388,87 +379,77 @@ $$
 % ------------------------------------------------------------
 % --- Slide : Prefix-Sum Trick - Worked Example  -------------
 % ------------------------------------------------------------
-\begin{frame}{Efficient Split Selection - Example}
+\begin{framev}[align=top]{Efficient Split Selection - Example}
 \centering
-{
-\scriptsize
-\[
-  \boxed{y^{(1)}\!=\!1.2,\;
-         y^{(2)}\!=\!2.0,\;
-         y^{(3)}\!=\!1.5,\;
-         y^{(4)}\!=\!3.2,\;
-         y^{(5)}\!=\!2.8,\;
-         y^{(6)}\!=\!4.1}
-  \quad(\,x_j^{(1)}\le\dots\le x_j^{(6)}\,)
-\]
-}
+\begin{scriptsize}
+$$
+\boxed{y^{(1)}\!=\!1.2,\;
+y^{(2)}\!=\!2.0,\;
+y^{(3)}\!=\!1.5,\;
+y^{(4)}\!=\!3.2,\;
+y^{(5)}\!=\!2.8,\;
+y^{(6)}\!=\!4.1}
+\quad(\,x_j^{(1)}\le\dots\le x_j^{(6)}\,)
+$$
+\end{scriptsize}
 \begin{tikzpicture}[>=latex,x=1.75cm,y=0.75cm,font=\tiny]
-  % sorted targets --------------------------------------------------
-  \foreach \x/\i in {0/1,1/2,2/3,3/4,4/5,5/6}{
-    \node[circle,draw,fill=blue!12,inner sep=2pt] (y\i) at (\x,0) {$y^{(\i)}$};
-  }
-
-  % prefix sums S_k -------------------------------------------------
-  \foreach \x/\val/\i in {0/1.2/1,1/3.2/2,2/4.7/3,3/7.9/4,4/10.7/5,5/14.8/6}{
-    \node[draw,fill=green!10,minimum width=1.4cm,minimum height=0.5cm,
-          align=center] (S\i) at (\x,-1.0) {$S_{\i}=\val$};
-  }
-  \node[anchor=east] at (-0.35,-1.0) {cumulative sums $S_k$ \;};
-
-  % split after k = 4 ----------------------------------------------
-  \draw[dashed] (3.5,0.55) -- (3.5,-1.6);
-  \node[anchor=south] at (3.5,0.7) {$k=4$};
-
-  \draw[decorate,decoration={brace,mirror,amplitude=4pt}]
-        (-0.25,-1.45) -- (3.5,-1.45)
-        node[midway,below=4pt] {$N_L=4$};
-  \draw[decorate,decoration={brace,mirror,amplitude=4pt}]
-        (3.5,-1.45) -- (5.25,-1.45)
-        node[midway,below=4pt] {$N_R=2$};
-
-  % computation box -------------------------------------------------
-  \node[draw,rounded corners,align=left,anchor=north,
-        minimum width=7.1cm] (box) at (2.5,-2.8) {
-     \strut$\displaystyle
-       G(k{=}4)=\frac{S_4^{2}}{4}
-               +\frac{(S_6-S_4)^{2}}{2}$\\[2pt]
-     \phantom{$G(k{=}4)$}$=\dfrac{7.9^{2}}{4}
-       +\dfrac{(14.8-7.9)^{2}}{2}
-       \;\approx\;39.41$
-  };
-  \draw[->] (3.0,-1.25) -- (box.north);
+% sorted targets --------------------------------------------------
+\foreach \x/\i in {0/1,1/2,2/3,3/4,4/5,5/6}{
+\node[circle,draw,fill=blue!12,inner sep=2pt] (y\i) at (\x,0) {$y^{(\i)}$};
+}
+\foreach \x/\val/\i in {0/1.2/1,1/3.2/2,2/4.7/3,3/7.9/4,4/10.7/5,5/14.8/6}{
+\node[draw,fill=green!10,minimum width=1.4cm,minimum height=0.5cm,
+align=center] (S\i) at (\x,-1.0) {$S_{\i}=\val$};
+}
+\node[anchor=east] at (-0.35,-1.0) {cumulative sums $S_k$ \;};
+\draw[dashed] (3.5,0.55) -- (3.5,-1.6);
+\node[anchor=south] at (3.5,0.7) {$k=4$};
+\draw[decorate,decoration={brace,mirror,amplitude=4pt}]
+(-0.25,-1.45) -- (3.5,-1.45)
+node[midway,below=4pt] {$N_L=4$};
+\draw[decorate,decoration={brace,mirror,amplitude=4pt}]
+(3.5,-1.45) -- (5.25,-1.45)
+node[midway,below=4pt] {$N_R=2$};
+\node[draw,rounded corners,align=left,anchor=north,
+minimum width=7.1cm] (box) at (2.5,-2.8) {
+\strut$\displaystyle
+G(k{=}4)=\frac{S_4^{2}}{4}
++\frac{(S_6-S_4)^{2}}{2}$\\[2pt]
+\phantom{$G(k{=}4)$}$=\dfrac{7.9^{2}}{4}
++\dfrac{(14.8-7.9)^{2}}{2}
+\;\approx\;39.41$
+};
+\draw[->] (3.0,-1.25) -- (box.north);
 \end{tikzpicture}
-
-\vspace{0.5em}
-\begin{itemize}
-  \item $G(k)$ omits $-\!S_n^{2}/n$  
-        (identical for all splits $\Rightarrow$ does not affect $\arg\max$).
-  \item Only cumulative sums $S_k$ are required, no $SS_k$ is stored or updated.
-  \item \(\mathcal{O}(1)\) per split \(\Rightarrow\) \(\mathcal{O}(n)\) per feature.
-\end{itemize}
-\end{frame}
+\spacer[0.25]
+\begin{itemizeM}
+\item $G(k)$ omits $-\!S_n^{2}/n$ (identical for all splits $\Rightarrow$ does not affect $\arg\max$).
+\item Only cumulative sums $S_k$ are required, no $SS_k$ is stored or updated.
+\item $\mathcal{O}(1)$ per split $\Rightarrow$ $\mathcal{O}(n)$ per feature.
+\end{itemizeM}
+\end{framev}
 
 
-\begin{frame}{Explainable Boosting Machines (EBM)}
+\begin{framev}[align=top]{Explainable Boosting Machines (EBM)}
 \textbf{Recall GAM}: 
 $$
 g\big(\mathbb{E}[y \mid \mathbf{x}]\big) = \theta_0 + f_1(x_{1}) + f_2(x_{2}) + \ldots + f_p(x_{p}),
 $$
-
-\begin{itemize}
-    \item One shape function $f_j$ per feature $x_j$\\ $\leadsto$ \textbf{Feature-level interpretability}
-    \item Captures non-linear univariate effects\\ $\leadsto$ \textbf{Better performance / more flexible than GLMs}
-\end{itemize}
-
-\medskip
+\begin{itemizeM}
+\item One shape function $f_j$ per feature $x_j$\\
+$\leadsto$ \textbf{Feature-level interpretability}
+\item Captures non-linear univariate effects\\
+$\leadsto$ \textbf{Better performance / more flexible than GLMs}
+\end{itemizeM}
+\spacer[0.25]
 
 \textbf{EBM idea:} \textbf{GAMs} train with \textbf{gradient boosting} over \textbf{shallow bagged trees}
-\begin{itemize}
-    \item \textbf{GAMs} - feature-wise interpretability via separate shape functions $f_j(x_j)$\\
-    $\leadsto$ Potentially include pairwise interactions manually
-    \item \textbf{Gradient Boosting} - incrementally fits residuals to improve predictive performance while retaining additivity
-    \item \textbf{Shallow Bagged Trees} - low-depth trees (2-4 leaves) reduce variance and create interpretable shape functions
-\end{itemize}
+\begin{itemizeM}
+\item \textbf{GAMs} - feature-wise interpretability via separate shape functions $f_j(x_j)$\\
+$\leadsto$ Potentially include pairwise interactions manually
+\item \textbf{Gradient Boosting} - incrementally fits residuals to improve predictive performance while retaining additivity
+\item \textbf{Shallow Bagged Trees} - low-depth trees (2-4 leaves) reduce variance and create interpretable shape functions
+\end{itemizeM}
 
 % \textbf{Idea of EBM}: \textbf{GAMs} trained with \textbf{gradient boosting} over \textbf{shallow bagged trees}\\
 
@@ -477,116 +458,102 @@ $$
 %         \item Accuracy close to unrestricted ensembles (e.g., random forests)
 %     \end{itemize}
 
-\end{frame}
+\end{framev}
 
 
-
-
-\begin{frame}{EBM - Two-Stage Model Construction}
+\begin{framev}[align=top]{EBM - Two-Stage Model Construction}
 \begin{enumerate}
-    \item \textbf{Stage 1: Fit Main Effects (Univariate Terms) % OLD
+\item \textbf{Stage 1: Fit Main Effects (Univariate Terms) % OLD
 %\citebutton{Lou et al. 2012}{https://www.cs.cornell.edu/~yinlou/papers/lou-kdd12.pdf}
 % new
 \furtherreading{LOU2012}}
-    \begin{itemize}
-        \item Train EBM using only feature-wise shape functions $f_j(x_j)$
-        \item Freeze the univariate model after convergence
-    \end{itemize}
-    
-    \item \textbf{Stage 2: Add Selected Pairwise Interactions % OLD
+\begin{itemizeS}
+\item Train EBM using only feature-wise shape functions $f_j(x_j)$
+\item Freeze the univariate model after convergence
+\end{itemizeS}
+\item \textbf{Stage 2: Add Selected Pairwise Interactions % OLD
 %\citebutton{Lou et al. 2013}{https://www.cs.cornell.edu/~yinlou/papers/lou-kdd13.pdf}
 % new
 \furtherreading{LOU2013}}
-    \begin{itemize}
-        \item Apply \textbf{FAST} to rank all $O(p^2)$ feat pairs by potential reduction in RSS
-        \item Select top $K$ pairwise interactions and store them in $\mathcal{K}$
-        \item Use boosting to fit pairwise interaction terms $f_{ij}(x_i, x_j)$ on residuals
-        \item Final model: $\hat{f}(\xv) = \sum_{j=1}^p f_j(x_j) + \sum_{(i,j)\in\mathcal{K}} f_{ij}(x_i, x_j)$
-    \end{itemize}
+\begin{itemizeS}
+\item Apply \textbf{FAST} to rank all $O(p^2)$ feat pairs by potential reduction in RSS
+\item Select top $K$ pairwise interactions and store them in $\mathcal{K}$
+\item Use boosting to fit pairwise interaction terms $f_{ij}(x_i, x_j)$ on residuals
+\item Final model: $\hat{f}(\xv) = \sum_{j=1}^p f_j(x_j) + \sum_{(i,j)\in\mathcal{K}} f_{ij}(x_i, x_j)$
+\end{itemizeS}
 \end{enumerate}
-
 % \includegraphics[width=1\linewidth]{figure/GA2M_Step1.png}
-\end{frame}
+\end{framev}
 
 
-
-\begin{frame}{Univariate EBM - Initialization}
-
+\begin{framei}[align=top]{Univariate EBM - Initialization}
 %\textbf{Initialization:}
-\begin{itemize}
-    \item Set all shape functions to zero:
-    $$
-    f_j^{[0]}(x_j) = 0 \quad \text{for all } j = 1, \dots, p
-    $$
-    \item Compute initial model prediction:
-    $$
-    \hat{y}^{[0]} = \sum_{j=1}^p f_j^{[0]}(x_j) = 0
-    $$
-    \item Compute initial pseudo-residuals (e.g., for squared loss):
-    $$
-    \tilde{r}^{[0]} = -\frac{\partial L}{\partial \hat{y}} = y - \hat{y}^{[0]} = y
-    $$
-\end{itemize}
-
-\end{frame}
-
-\begin{frame}{Univariate EBM - First Feature Update}
-\begin{figure}
-    \centering
-    \includegraphics[width=\linewidth]{figure/EBM_Step1.png}
-\end{figure}
-\begin{itemize}
-    \item Fit shallow bagged tree $T_1^{[1]}$ (2-4 leaves) to training data $\left\{\left(x_1, \tilde{r}^{[0]}\right)^{(i)}\right\}_{i=1}^n$\\
-    $\leadsto$ Use only feature $x_1$ as input and $\tilde{r}^{[0]}$ as target
-    \item Update first shape function with learning rate $\eta$:
-    $$
-    f_1^{[1]}(x_1) = f_1^{[0]}(x_1) + \eta \cdot T_1^{[1]}(x_1)
-    $$
-    \item Update prediction:
-    $$
-    \hat{y}^{[1]} = \sum_{j=1}^p f_j^{[1]}(x_j)
-    $$
-    \item Recompute pseudo-residuals:
-    $$
-    \tilde{r}^{[1]} =  -\frac{\partial L}{\partial \hat{y}} = y - \hat{y}^{[1]}
-    $$
-\end{itemize}
-
-\end{frame}
+\item Set all shape functions to zero:
+$$
+f_j^{[0]}(x_j) = 0 \quad \text{for all } j = 1, \dots, p
+$$
+\item Compute initial model prediction:
+$$
+\hat{y}^{[0]} = \sum_{j=1}^p f_j^{[0]}(x_j) = 0
+$$
+\item Compute initial pseudo-residuals (e.g., for squared loss):
+$$
+\tilde{r}^{[0]} = -\frac{\partial L}{\partial \hat{y}} = y - \hat{y}^{[0]} = y
+$$
+\end{framei}
 
 
-\begin{frame}{Univariate EBM - Cycle Through Features}
-\begin{figure}
-    \centering
-    \includegraphics[width=\linewidth]{figure/EBM_Step2.png}
-\end{figure}
-\begin{itemize}
-    \item 1st boosting iteration: \\
-    Cycle through each feature $j = 2,\dots,p$:
-    \begin{itemize}
-        \item Fit shallow bagged tree $T_j^{[1]}$ using feature $x_j$ and previous residual $\tilde{r}^{[j-1]}$ %to $(x_j, \tilde{r}^{[j-1]})$
-        \item Update $f_j$: $f_j^{[1]}(x_j) = f_j^{[0]}(x_j) + \eta \cdot T_j^{[1]}(x_j)$
-        \item Recompute $\hat{y}$ and residuals: $\tilde{r}^{[j]} = y - \hat{y}^{[j]}$
-    \end{itemize}
-    \item After one full pass over features, we complete one boosting iteration
-\end{itemize}
-\end{frame}
+\begin{framev}[align=top]{Univariate EBM - First Feature Update}
+\image{figure/EBM_Step1.png}
+\spacer[0.25]
+\begin{itemizeM}
+\item Fit shallow bagged tree $T_1^{[1]}$ (2-4 leaves) to training data $\left\{\left(x_1, \tilde{r}^{[0]}\right)^{(i)}\right\}_{i=1}^n$\\
+$\leadsto$ Use only feature $x_1$ as input and $\tilde{r}^{[0]}$ as target
+\item Update first shape function with learning rate $\eta$:
+$$
+f_1^{[1]}(x_1) = f_1^{[0]}(x_1) + \eta \cdot T_1^{[1]}(x_1)
+$$
+\item Update prediction:
+$$
+\hat{y}^{[1]} = \sum_{j=1}^p f_j^{[1]}(x_j)
+$$
+\item Recompute pseudo-residuals:
+$$
+\tilde{r}^{[1]} = -\frac{\partial L}{\partial \hat{y}} = y - \hat{y}^{[1]}
+$$
+\end{itemizeM}
+\end{framev}
 
-\begin{frame}{Univariate EBM - Iterate Boosting Process}
-\begin{figure}
-    \centering
-    \includegraphics[width=\linewidth]{figure/EBM_Step3.png}
-\end{figure}
-\begin{itemize}
-    \item Repeat feature-wise updates for $M$ boosting iterations (e.g., $M=10000$)
-    \item In each boosting iteration:
-    \begin{itemize}
-        \item Cycle over all features $j=1,\dots,p$ individually %just one feature at a time 
-        \item Update only one $f_j$ at a time using residuals from previous state
-    \end{itemize}
-    \item Use small learning rate $\eta$ to ensure smooth updates and order-invariance
-\end{itemize}
-\end{frame}
+
+\begin{framev}[align=top]{Univariate EBM - Cycle Through Features}
+\image{figure/EBM_Step2.png}
+\spacer[0.25]
+\begin{itemizeM}
+\item 1st boosting iteration:\\
+Cycle through each feature $j = 2,\dots,p$:
+\begin{itemizeS}
+\item Fit shallow bagged tree $T_j^{[1]}$ using feature $x_j$ and previous residual $\tilde{r}^{[j-1]}$ %to $(x_j, \tilde{r}^{[j-1]})$
+\item Update $f_j$: $f_j^{[1]}(x_j) = f_j^{[0]}(x_j) + \eta \cdot T_j^{[1]}(x_j)$
+\item Recompute $\hat{y}$ and residuals: $\tilde{r}^{[j]} = y - \hat{y}^{[j]}$
+\end{itemizeS}
+\item After one full pass over features, we complete one boosting iteration
+\end{itemizeM}
+\end{framev}
+
+
+\begin{framev}[align=top]{Univariate EBM - Iterate Boosting Process}
+\image{figure/EBM_Step3.png}
+\spacer[0.25]
+\begin{itemizeM}
+\item Repeat feature-wise updates for $M$ boosting iterations (e.g., $M=10000$)
+\item In each boosting iteration:
+\begin{itemizeS}
+\item Cycle over all features $j=1,\dots,p$ individually %just one feature at a time 
+\item Update only one $f_j$ at a time using residuals from previous state
+\end{itemizeS}
+\item Use small learning rate $\eta$ to ensure smooth updates and order-invariance
+\end{itemizeM}
+\end{framev}
 
 
 
@@ -652,27 +619,22 @@ $$
 % \end{frame}
 
 
-\begin{frame}{Univariate EBM - Prediction \& Interpretability}
-\begin{itemize}
-    \item Final model consists of $M$ shallow trees per feature:
-    $$
-    \text{EBM Model} = \sum_{j=1}^p \sum_{m=1}^M \eta \cdot T_j^{[m]}(x_j)
-    $$
-    \item For each feature $x_j$, combine its $M$ trees into a shape function:
-    $$
-    \hat{f}_j(x_j) = \sum_{m=1}^M \eta \cdot T_j^{[m]}(x_j)
-    $$
-    \item Plot $\hat{f}_j(x_j)$ vs. $x_j$ $\leadsto$ Shows univariate marginal effect of feature $j$
-    \item One plot per feature $\leadsto$ Model is fully explainable via $p$ additive plots
-\end{itemize}
-
-\medskip
-
-\begin{figure}
-    \centering
-    \includegraphics[width=\textwidth]{figure/ebm_prediction.png}
-\end{figure}
-\end{frame}
+\begin{framev}[align=top]{Univariate EBM - Prediction \& Interpretability}
+\begin{itemizeM}
+\item Final model consists of $M$ shallow trees per feature:
+$$
+\text{EBM Model} = \sum_{j=1}^p \sum_{m=1}^M \eta \cdot T_j^{[m]}(x_j)
+$$
+\item For each feature $x_j$, combine its $M$ trees into a shape function:
+$$
+\hat{f}_j(x_j) = \sum_{m=1}^M \eta \cdot T_j^{[m]}(x_j)
+$$
+\item Plot $\hat{f}_j(x_j)$ vs. $x_j$ $\leadsto$ Shows univariate marginal effect of feature $j$
+\item One plot per feature $\leadsto$ Model is fully explainable via $p$ additive plots
+\end{itemizeM}
+\spacer[0.25]
+\image{figure/ebm_prediction.png}
+\end{framev}
 
 
 % \begin{frame}{Intelligible GAM - Prediction}
@@ -740,30 +702,30 @@ $$
 % \end{itemize}
 % \end{frame}
 
-\begin{frame}{EBM with Pairwise Interactions}
+\begin{framev}[align=top]{EBM with Pairwise Interactions}
 \textbf{Generalized Additive Models plus Interactions (GA2M):}
 $$
 g\big(\mathbb{E}[y \mid \xv]\big) = \theta_0 + \sum_{j=1}^p f_j(x_j) + \sum_{i<j} f_{ij}(x_i, x_j)
 $$
-
-\begin{itemize}
-    \item \textbf{Motivation}: Univariate EBM does not model interactions
-    \item \textbf{Challenge}: $O(p^2)$ potential pairwise interactions
-    $\leadsto$ often infeasible %to include all pairs directly
-    \item \textbf{Solution - FAST algorithm} % OLD
+\begin{itemizeM}
+\item \textbf{Motivation}: Univariate EBM does not model interactions
+\item \textbf{Challenge}: $O(p^2)$ potential pairwise interactions 
+$\leadsto$ often infeasible %to include all pairs directly
+\item \textbf{Solution - FAST algorithm} % OLD
 %\citebutton{Lou et al. 2013}{https://www.cs.cornell.edu/~yinlou/papers/lou-kdd13.pdf}
 % new
 \furtherreading{LOU2013}:
-    \begin{itemize}
-        \item Efficiently estimates importance of all feature pairs
-        \item Ranks pairs by reduction in residual sum of squares (RSS)
-        \item Avoids fitting EBM with each pairwise interaction
-    \end{itemize}
-    \item \textbf{Result}: \\Add only top-ranked interactions $f_{ij}$ via asecond-stage boosting step\\
-    $\leadsto$ Performed after the univariate EBM has been trained
-    \item \textbf{Interpretability preserved}: Each $f_{ij}(x_i, x_j)$ visualized as a 2D heatmap
-\end{itemize}
-\end{frame}
+\begin{itemizeS}
+\item Efficiently estimates importance of all feature pairs
+\item Ranks pairs by reduction in residual sum of squares (RSS)
+\item Avoids fitting EBM with each pairwise interaction
+\end{itemizeS}
+\item \textbf{Result}:\\
+Add only top-ranked interactions $f_{ij}$ via a second-stage boosting step\\
+$\leadsto$ Performed after the univariate EBM has been trained
+\item \textbf{Interpretability preserved}: Each $f_{ij}(x_i, x_j)$ visualized as a 2D heatmap
+\end{itemizeM}
+\end{framev}
 
 
 % \begin{frame}{FAST Algorithm for Interaction Detection}
@@ -1009,34 +971,32 @@ $$
 
 
 
-\begin{frame}{FAST: Pair-wise Interaction Strength}
-
+\begin{framev}[fs=small,align=top]{FAST: Pair-wise Interaction Strength}
 We evaluate a 4-leaf, axis-aligned tree $T_{ij}$ over the 2D feature projection $(x_i, x_j)$.
-
-\begin{columns}[T,totalwidth=\textwidth]
-% ----- left: predictor diagram ---------------------------------
-\begin{column}{0.4\textwidth}\centering
+\spacer[0.25]
+\splitVTT[0.4]{
+\spacer[0]
+\centering
 \only<1>{
-
 \begin{figure}
 \scalebox{0.85}{
 \begin{tikzpicture}[
-  level 1/.style={sibling distance=28mm},
-  level 2/.style={sibling distance=15mm},
-  level distance=10mm,
-  every node/.style = {circle, draw, minimum size=7mm},
-  edge from parent/.style={draw,-latex}
+level 1/.style={sibling distance=28mm},
+level 2/.style={sibling distance=15mm},
+level distance=10mm,
+every node/.style = {circle, draw, minimum size=7mm},
+edge from parent/.style={draw,-latex}
 ]
 
 \node (root) {$c_i$}
-  child { node {$c_j$}
-    child { node {A} }
-    child { node {B} }
-  }
-  child { node {$c_j$}
-    child { node {C} }
-    child { node {D} }
-  };
+child { node {$c_j$}
+child { node {A} }
+child { node {B} }
+}
+child { node {$c_j$}
+child { node {C} }
+child { node {D} }
+};
 
 %\node[draw=none] at (-2.8,0.8) {$T_{ij}:$};
 
@@ -1064,179 +1024,152 @@ We evaluate a 4-leaf, axis-aligned tree $T_{ij}$ over the 2D feature projection 
 \node[left]  at (0,\yc) {$c_i$};
 \end{tikzpicture}
 
-{\small tree $T_{ij}$ with 4 leaves}
+tree $T_{ij}$ with 4 leaves
 }
-
 \only<2>{
-\[
+$$
 \begin{array}{@{}l@{\hskip 0.6em}l@{\hskip 0.6em}l@{\hskip 0.6em}l@{\hskip 0.6em}l}
-    \begin{tikzpicture}[baseline=(current bounding box.center)]
-        \draw (0,0) rectangle (1.2,1.2);
-        \draw (0.4,0) -- (0.4,1.2); 
-        \draw (0,0.8) -- (1.2,0.8); 
-        \node at (0.2,0.4) {C};
-        \node at (0.8,0.4) {D};
-        \node at (0.2,1) {A};
-        \node at (0.8,1) {B};
-    \end{tikzpicture} & \text{$\Rightarrow$} & \begin{tikzpicture}[baseline=(current bounding box.center)]
-        \draw (0,0) rectangle (1.2,1.2);
-        \draw (0.4,0) -- (0.4,1.2); 
-        \draw (0,0.8) -- (1.2,0.8); 
-        \node at (0.2,0.4) {$\hat{y}_C$};
-        \node at (0.8,0.4) {$\hat{y}_D$};
-        \node at (0.2,1) {$\hat{y}_A$};
-        \node at (0.8,1) {$\hat{y}_B$};
-    \end{tikzpicture} & \text{$\Rightarrow$} & \text{$RSS_1$}\\[0.7cm] 
-    \begin{tikzpicture}[baseline=(current bounding box.center)]
-        \draw (0,0) rectangle (1.2,1.2);
-        \draw (0.6,0) -- (0.6,1.2); 
-        \draw (0,0.6) -- (1.2,0.6); 
-        \node at (0.3,0.3) {C};
-        \node at (0.9,0.3) {D};
-        \node at (0.3,0.9) {A};
-        \node at (0.9,0.9) {B};
-    \end{tikzpicture} & \text{$\Rightarrow$} & \begin{tikzpicture}[baseline=(current bounding box.center)]
-        \draw (0,0) rectangle (1.2,1.2);
-        \draw (0.6,0) -- (0.6,1.2); 
-        \draw (0,0.6) -- (1.2,0.6); 
-        \node at (0.3,0.3) {$\hat{y}_C$};
-        \node at (0.9,0.3) {$\hat{y}_D$};
-        \node at (0.3,0.9) {$\hat{y}_A$};
-        \node at (0.9,0.9) {$\hat{y}_B$};
-    \end{tikzpicture} & \text{$\Rightarrow$} & \text{$RSS_2$}\\[0.7cm] 
-    \makebox[1cm][c]{\vdots} & & \makebox[1cm][c]{\vdots} & & \makebox[1cm][c]{\vdots}\\[0.3cm]
-    \begin{tikzpicture}[baseline=(current bounding box.center)]
-        \draw (0,0) rectangle (1.2,1.2);
-        \draw (0.8,0) -- (0.8,1.2); 
-        \draw (0,0.4) -- (1.2,0.4); 
-        \node at (0.4,0.2) {C};
-        \node at (1,0.2) {D};
-        \node at (0.4,0.8) {A};
-        \node at (1,0.8) {B};
-    \end{tikzpicture} & \text{$\Rightarrow$} & \begin{tikzpicture}[baseline=(current bounding box.center)]
-        \draw (0,0) rectangle (1.2,1.2);
-        \draw (0.8,0) -- (0.8,1.2); 
-        \draw (0,0.4) -- (1.2,0.4); 
-        \node at (0.4,0.2) {$\hat{y}_C$};
-        \node at (1,0.2) {$\hat{y}_D$};
-        \node at (0.4,0.8) {$\hat{y}_A$};
-        \node at (1,0.8) {$\hat{y}_B$};
-    \end{tikzpicture} & \text{$\Rightarrow$} & \text{$RSS_{b^2}$}\\ 
+\begin{tikzpicture}[baseline=(current bounding box.center)]
+\draw (0,0) rectangle (1.2,1.2);
+\draw (0.4,0) -- (0.4,1.2);
+\draw (0,0.8) -- (1.2,0.8);
+\node at (0.2,0.4) {C};
+\node at (0.8,0.4) {D};
+\node at (0.2,1) {A};
+\node at (0.8,1) {B};
+\end{tikzpicture} & \text{$\Rightarrow$} & \begin{tikzpicture}[baseline=(current bounding box.center)]
+\draw (0,0) rectangle (1.2,1.2);
+\draw (0.4,0) -- (0.4,1.2);
+\draw (0,0.8) -- (1.2,0.8);
+\node at (0.2,0.4) {$\hat{y}_C$};
+\node at (0.8,0.4) {$\hat{y}_D$};
+\node at (0.2,1) {$\hat{y}_A$};
+\node at (0.8,1) {$\hat{y}_B$};
+\end{tikzpicture} & \text{$\Rightarrow$} & \text{$RSS_1$}\\[0.7cm]
+\begin{tikzpicture}[baseline=(current bounding box.center)]
+\draw (0,0) rectangle (1.2,1.2);
+\draw (0.6,0) -- (0.6,1.2);
+\draw (0,0.6) -- (1.2,0.6);
+\node at (0.3,0.3) {C};
+\node at (0.9,0.3) {D};
+\node at (0.3,0.9) {A};
+\node at (0.9,0.9) {B};
+\end{tikzpicture} & \text{$\Rightarrow$} & \begin{tikzpicture}[baseline=(current bounding box.center)]
+\draw (0,0) rectangle (1.2,1.2);
+\draw (0.6,0) -- (0.6,1.2);
+\draw (0,0.6) -- (1.2,0.6);
+\node at (0.3,0.3) {$\hat{y}_C$};
+\node at (0.9,0.3) {$\hat{y}_D$};
+\node at (0.3,0.9) {$\hat{y}_A$};
+\node at (0.9,0.9) {$\hat{y}_B$};
+\end{tikzpicture} & \text{$\Rightarrow$} & \text{$RSS_2$}\\[0.7cm]
+\makebox[1cm][c]{\vdots} & & \makebox[1cm][c]{\vdots} & & \makebox[1cm][c]{\vdots}\\[0.3cm]
+\begin{tikzpicture}[baseline=(current bounding box.center)]
+\draw (0,0) rectangle (1.2,1.2);
+\draw (0.8,0) -- (0.8,1.2);
+\draw (0,0.4) -- (1.2,0.4);
+\node at (0.4,0.2) {C};
+\node at (1,0.2) {D};
+\node at (0.4,0.8) {A};
+\node at (1,0.8) {B};
+\end{tikzpicture} & \text{$\Rightarrow$} & \begin{tikzpicture}[baseline=(current bounding box.center)]
+\draw (0,0) rectangle (1.2,1.2);
+\draw (0.8,0) -- (0.8,1.2);
+\draw (0,0.4) -- (1.2,0.4);
+\node at (0.4,0.2) {$\hat{y}_C$};
+\node at (1,0.2) {$\hat{y}_D$};
+\node at (0.4,0.8) {$\hat{y}_A$};
+\node at (1,0.8) {$\hat{y}_B$};
+\end{tikzpicture} & \text{$\Rightarrow$} & \text{$RSS_{b^2}$}\\
 \end{array}
-\]
+$$
 }
-\end{column}
-% ----- right: algorithm steps ----------------------------------
-\begin{column}{0.6\textwidth}
-\small
-\begin{enumerate}\itemsep4pt
-  \item<1-> {\bf Discretize}\,: Map each axis to \(b\!\le\!256\) ordered
-        bins (quantile or equal-width).
-  \item<2-> {\bf Iterate} over \(b^{2}\) candidate cuts
-        \((c_i,c_j)\). %at bin boundaries.
-  \item<2-> {\bf Fit}\,: For each cut, assign a constant
-        \(\hat y_r\!=\!\text{mean}(y\!\in\!r)\) to
-        \(r\!\in\!\{A,B,C,D\}\).
-  \item<2-> {\bf Compute RSS summed over all regions}:   
-  {\footnotesize
-  \[
+}{
+\spacer[0]
+\begin{enumerate}
+\item<1-> {\bf Discretize}: Map each axis to $b\!\le\!256$ ordered bins (quantile or equal-width).
+\item<2-> {\bf Iterate} over $b^{2}$ candidate cuts $(c_i,c_j)$. %at bin boundaries.
+\item<2-> {\bf Fit}: For each cut, assign a constant $\hat y_r\!=\!\text{mean}(y\!\in\!r)$ to $r\!\in\!\{A,B,C,D\}$.
+\item<2-> {\bf Compute RSS summed over all regions:}
+\begin{footnotesize}
+$$
 \begin{aligned}
-\text{RSS}(c_i, c_j) 
+\text{RSS}(c_i, c_j)
 &= \sum_{r} \sum_{(x,y) \in r} (y - \hat{y}_r)^2 \\
 &= \sum_{r} \left( \sum_{(x,y) \in r} y^2 - \frac{1}{n_r} \left(\sum_{(x,y) \in r} y \right)^2 \right)
 %\sum_{r} \left( \sum_{(x,y) \in r} y^2 - 2 \hat{y}_r \sum_{(x,y) \in r} y + \hat{y}_r^2 \cdot n_r \right)
 \end{aligned}
-\]
-        % \(\text{RSS}(c_i,c_j)=\sum_{r}
-        %  \sum_{(x,y)\in r}(y-\hat y_r)^{2}
-        %  \)
-         
- % \(\text{RSS}_0\;=\;\sum_{i=1}^{n}\bigl(y_k-\bar y\bigr)^2
- %              =\sum_{i}y_k^{2}-\frac{T^{2}}{n}\)
-              
- % \(\Delta\text{RSS}(c_i,c_j) =\text{RSS}_0-\text{RSS}(c_i,c_j)\)
- }
-  \item<2-> {\bf Select}\,: Keep the split with minimal RSS.\\
-  $\leadsto$ largest RSS drop = strongest interaction. \\% of \((x_i,x_j)\) \\
-  %$\leadsto$ $\mathcal{O}(n+b^{2})$ per pair.
+$$
+% \(\text{RSS}(c_i,c_j)=\sum_{r}
+%  \sum_{(x,y)\in r}(y-\hat y_r)^{2}
+%  \)
+ 
+% \(\text{RSS}_0\;=\;\sum_{i=1}^{n}\bigl(y_k-\bar y\bigr)^2
+%              =\sum_{i}y_k^{2}-\frac{T^{2}}{n}\)
+             
+% \(\Delta\text{RSS}(c_i,c_j) =\text{RSS}_0-\text{RSS}(c_i,c_j)\)
+\end{footnotesize}
+\item<2-> {\bf Select}: Keep the split with minimal RSS.\\
+$\leadsto$ largest RSS drop = strongest interaction. \\% of $(x_i,x_j)$ \\
+%$\leadsto$ $\mathcal{O}(n+b^{2})$ per pair.
 \end{enumerate}
-
-\end{column}
-\end{columns}
-\end{frame}
+}
+\end{framev}
 
 
-
-
-
-
-
-
-
-
-
-\begin{frame}{FAST: Use RSS Drop}
-\small
-
+\begin{framev}[fs=small,align=top]{FAST: Use RSS Drop}
 To evaluate a cut pair $(c_i, c_j)$, we use precomputed per-region statistics:
-
-\begin{itemize}
-  \item For each region $r \in \{A, B, C, D\}$, compute:
-    \[
-    S_r = \sum_{(x,y)\in r} y,\quad
-    %Q_r = \sum_{(x,y)\in r} y^2,\quad
-    n_r = |\{(x,y)\in r\}|,\quad
-    \hat y_r = S_r / n_r
-    \]
-  \item Plug into RSS summed over all regions: $$
-\text{RSS}(c_i, c_j) = \sum_{r} \left( \sum_{(x,y) \in r} y^2 - \frac{1}{n_r} \left(\sum_{(x,y) \in r} y \right)^2 \right) = 
+\begin{itemizeM}
+\item For each region $r \in \{A, B, C, D\}$, compute:
+$$
+S_r = \sum_{(x,y)\in r} y,\quad
+%Q_r = \sum_{(x,y)\in r} y^2,\quad
+n_r = |\{(x,y)\in r\}|,\quad
+\hat y_r = S_r / n_r
+$$
+\item Plug into RSS summed over all regions:
+$$
+\text{RSS}(c_i, c_j) = \sum_{r} \left( \sum_{(x,y) \in r} y^2 - \frac{1}{n_r} \left(\sum_{(x,y) \in r} y \right)^2 \right) =
 %\sum_{r}\!\left(\sum_{(x,y)\in r} y^2-\frac{S_r^{2}}{n_r}\right)
 \sum_{r}\sum_{(x,y)\in r} y^2+\sum_{r}\frac{S_r^{2}}{n_r}
 $$
-  %\item Requires only scalar summaries $(S_r, Q_r, n_r)$
-  %\item No access to individual samples needed at scoring time
-  %\item Baseline (unsplit) RSS: $\text{RSS}_0 = \sum_k y_k^2 - \frac{T^2}{n}$, with $T = \sum_k y_k$ and $\bar y = T/n$
-  \item 
-For a candidate cut, compute \textbf{RSS drop}:
-\begin{align*}
-  \Delta\text{RSS}(c_i,c_j)
-     &=\text{RSS}_{\text{parent}}-\text{RSS}(c_i,c_j)\\
-     &=\left(\sum_{i = 1}^n \left(y^{(i)}\right)^{2} -\frac{S_n^{2}}{n}\right)
-       -  \sum_{r}\sum_{(x,y)\in r} y^2+\sum_{r}\frac{S_r^{2}}{n_r}
-\end{align*}
-\end{itemize}
-
-
-\end{frame}
+%\item Requires only scalar summaries $(S_r, Q_r, n_r)$
+%\item No access to individual samples needed at scoring time
+%\item Baseline (unsplit) RSS: $\text{RSS}_0 = \sum_k y_k^2 - \frac{T^2}{n}$, with $T = \sum_k y_k$ and $\bar y = T/n$
+\item For a candidate cut, compute \textbf{RSS drop}:
+$$
+\begin{aligned}
+\Delta\text{RSS}(c_i,c_j)
+&=\text{RSS}_{\text{parent}}-\text{RSS}(c_i,c_j)\\
+&=\left(\sum_{i = 1}^n \left(y^{(i)}\right)^{2} -\frac{S_n^{2}}{n}\right)
+- \sum_{r}\sum_{(x,y)\in r} y^2+\sum_{r}\frac{S_r^{2}}{n_r}
+\end{aligned}
+$$
+\end{itemizeM}
+\end{framev}
 % ============================================================================
-\begin{frame}{FAST: Use RSS drop}
-
+\begin{framev}[fs=small,align=top]{FAST: Use RSS drop}
 Because $\sum_{i = 1}^n \left(y^{(i)}\right) ^{2} = \sum_{r}\sum_{(x,y)\in r} y^2$, \emph{all squared target terms cancel}:
-\[
-  \boxed{\displaystyle
-  \Delta\text{RSS}(c_i,c_j)
-     =\sum_{r}\frac{S_r^{2}}{n_r}\;-
-      \frac{S_n^{2}}{n}}
-\]
-The parent term $S_n^{2}/n$ is constant across all cuts.  Hence
-\[
-  \textbf{maximize }\Delta\text{RSS}(c_i,c_j)=\sum_{r}\frac{S_r^{2}}{n_r}
-  \quad\Longleftrightarrow\quad
-  \textbf{minimize }\text{RSS}(c_i,c_j).
-\]
-
-
+$$
+\boxed{\displaystyle
+\Delta\text{RSS}(c_i,c_j)
+=\sum_{r}\frac{S_r^{2}}{n_r}\;-
+\frac{S_n^{2}}{n}}
+$$
+The parent term $S_n^{2}/n$ is constant across all cuts. Hence
+$$
+\textbf{maximize }\Delta\text{RSS}(c_i,c_j)=\sum_{r}\frac{S_r^{2}}{n_r}
+\quad\Longleftrightarrow\quad
+\textbf{minimize }\text{RSS}(c_i,c_j).
+$$
 \textbf{Why is this efficient?}
-\begin{itemize}
-  \item Precompute cummulative sums of \(y\) and counts across the binned grid
-  \item Enables fast lookup of region statistics \(S_r, n_r\) for any cut
-  \item No additional data scan or recomputation needed across the \(b^2\) candidate cuts
-  \item For the best cut: Compare and select the largest
-$\Delta\text{RSS}(c_i,c_j)$.
-\end{itemize}
-
-
-\end{frame}
+\begin{itemizeM}
+\item Precompute cumulative sums of $y$ and counts across the binned grid
+\item Enables fast lookup of region statistics $S_r, n_r$ for any cut
+\item No additional data scan or recomputation needed across the $b^2$ candidate cuts
+\item For the best cut: Compare and select the largest $\Delta\text{RSS}(c_i,c_j)$.
+\end{itemizeM}
+\end{framev}
 
 % % ============================================================================
 % \begin{frame}{Step 4: FAST search in $\mathcal O(b^2)$ per pair}
@@ -1527,20 +1460,19 @@ $\Delta\text{RSS}(c_i,c_j)$.
 % \end{frame}
 
 
-\begin{frame}{EBM - Boosting Pairwise Interactions}
+\begin{framev}[align=top]{EBM - Boosting Pairwise Interactions}
 %\vspace{-0.2cm}
 %\begin{figure}
 %    \centering
-    \includegraphics[width=\linewidth]{figure/GA2M_Step1.png}
+\image{figure/GA2M_Step1.png}
 %\end{figure}
-
-\begin{columns}[c, totalwidth=\textwidth]
-    \begin{column}{0.3\textwidth}
-        % \vspace{-1.2cm}
-        % \hspace{-0.6cm}
-        %\includegraphics[width=\linewidth]{figure/GA2M_Step0.png}
-\begin{center}
-    \centering
+\spacer[0.25]
+\splitVTT[0.3]{
+\spacer[0]
+\centering
+% \vspace{-1.2cm}
+% \hspace{-0.6cm}
+%\includegraphics[width=\linewidth]{figure/GA2M_Step0.png}
 \begin{tikzpicture}[scale=0.9]
 
 % Rectangle dimensions
@@ -1573,26 +1505,22 @@ $\Delta\text{RSS}(c_i,c_j)$.
 \node at (\cxTwo,-0.3) {$c_{j_2}$};
 
 \end{tikzpicture}
-
-\end{center}
-    \end{column}
-    
-    \begin{column}{0.7\textwidth}
-       % \vspace{-0.6cm}
-        \begin{itemize}
-            \item \textbf{Goal:} Fit each selected interaction $f_{ij}(x_i, x_j)$ on residuals from main effects
-            \item Use tree-like predictor, inspired by FAST
-            %\item \textbf{Cuts:} 
-            \begin{itemize}
-                \item Use two axis-aligned cuts $(c_i, c_j)$ 
-                \item Plus one refinement cut to increase flexibility while keeping interpretability
-            \end{itemize}
-            \item Reuse region-wise sums from FAST lookup tables
-            \item Greedy search for cut config minimizing RSS
-        \end{itemize}
-    \end{column}
-\end{columns}
-\end{frame}
+}{
+\spacer[0.6]
+% \vspace{-0.6cm}
+\begin{itemizeM}
+\item \textbf{Goal:} Fit each selected interaction $f_{ij}(x_i, x_j)$ on residuals from main effects
+\item Use tree-like predictor, inspired by FAST
+%\item \textbf{Cuts:}
+\begin{itemizeS}
+\item Use two axis-aligned cuts $(c_i, c_j)$
+\item Plus one refinement cut to increase flexibility while keeping interpretability
+\end{itemizeS}
+\item Reuse region-wise sums from FAST lookup tables
+\item Greedy search for cut config minimizing RSS
+\end{itemizeM}
+}
+\end{framev}
 
 
 % \begin{frame}{Accurate GAM - Prediction}
@@ -1627,38 +1555,33 @@ $\Delta\text{RSS}(c_i,c_j)$.
 % \includegraphics[width=0.42\linewidth]{figure/3D Heatmap.png}
 % \end{frame}
 
-\begin{frame}{EBM - Prediction with Pairwise Interactions}
-\begin{itemize}
-    \item Each selected pair $(x_i, x_j)$ is modeled by $M$ boosted predictors trained on their residual interaction
-    \item These are aggregated into a single bivariate function $f_{ij}(x_i, x_j)$
-    \item The function is visualized as a 2D heatmap: 
-    \begin{itemize}
-        \item Axes: feature values of $x_i$ and $x_j$
-        \item Color: contribution to the final prediction
-        \item Preserves human interpretability 
-    \end{itemize}
-    \item One heatmap is generated per selected pairwise interaction
-\end{itemize}
-
-\vspace{0.3cm}
-\centering
-\includegraphics[width=0.42\linewidth]{figure/3D Heatmap.png}
-\end{frame}
+\begin{framev}[align=top]{EBM - Prediction with Pairwise Interactions}
+\begin{itemizeM}
+\item Each selected pair $(x_i, x_j)$ is modeled by $M$ boosted predictors trained on their residual interaction
+\item These are aggregated into a single bivariate function $f_{ij}(x_i, x_j)$
+\item The function is visualized as a 2D heatmap:
+\begin{itemizeS}
+\item Axes: feature values of $x_i$ and $x_j$
+\item Color: contribution to the final prediction
+\item Preserves human interpretability
+\end{itemizeS}
+\item One heatmap is generated per selected pairwise interaction
+\end{itemizeM}
+\spacer[0.25]
+\imageC[0.42]{figure/3D Heatmap.png}
+\end{framev}
 
 
-\begin{frame}{EBM - Final Model Structure}
-
-\begin{itemize}
-    \item \textbf{Main effects:} One shape function $f_j(x_j)$ per feature \\(visualized as 1D plots)
-    \item \textbf{Pairwise interactions:} Selected functions $f_{ij}(x_i, x_j)$ added for top $K$ pairs (visualized as 2D heatmaps)
-    \item \textbf{Prediction:} Additive sum of all univariate and selected bivariate contributions
-\end{itemize}
-
-\vspace{0.3cm}
-\centering
-\includegraphics[width=\linewidth]{figure/final_ebm.png}
-
-\end{frame}
+\begin{framev}[align=top]{EBM - Final Model Structure}
+\begin{itemizeM}
+\item \textbf{Main effects:} One shape function $f_j(x_j)$ per feature\\
+(visualized as 1D plots)
+\item \textbf{Pairwise interactions:} Selected functions $f_{ij}(x_i, x_j)$ added for top $K$ pairs (visualized as 2D heatmaps)
+\item \textbf{Prediction:} Additive sum of all univariate and selected bivariate contributions
+\end{itemizeM}
+\spacer[0.25]
+\image{figure/final_ebm.png}
+\end{framev}
 
 
 
@@ -1708,84 +1631,71 @@ $\Delta\text{RSS}(c_i,c_j)$.
 % \end{tabular}
 % \end{frame}
 %------------- SLIDE 1 -------------------------------------------------
-\begin{frame}{EBM \textit{vs.} Model-based Boosting}
-\small
-\begin{itemize}
-  %-- BASE LEARNER -----------------------------------------------------
-  \item \textbf{Base learner}
-        \begin{itemize}
-          \item \textbf{EBM}: bagged 2--4-leaf trees, \emph{one feature} per tree  
-                $\Rightarrow$ step-function shape $f_j$  % ASCII arrow macro
-                % OLD
+\begin{framei}[align=top]{EBM \textit{vs.} Model-based Boosting}
+%-- BASE LEARNER -----------------------------------------------------
+\item \textbf{Base learner}
+\begin{itemizeS}
+\item \textbf{EBM}: bagged 2--4-leaf trees, \emph{one feature} per tree\\
+$\Rightarrow$ step-function shape $f_j$  % ASCII arrow macro
+% OLD
 %\citebutton{Lou et al.\ 2012}{https://www.cs.cornell.edu/~yinlou/papers/lou-kdd12.pdf}
 % new
 \furtherreading{LOU2012}
-          \item \textbf{MB-boost}: user chooses component-wise learner  
-                (linear term, P-spline, tree, random effect, \dots)  
-                % OLD
+\item \textbf{MB-boost}: user chooses component-wise learner\\
+(linear term, P-spline, tree, random effect, \dots)
+% OLD
 %\citebutton{B\"uhlmann \& Hothorn 2007}{https://doi.org/10.1214/07-STS242}
 % new
 \furtherreading{BÜHLMANNHOTHORN2007}
-        \end{itemize}
+\end{itemizeS}
 \pause
-  %-- ITERATION POLICY -------------------------------------------------
-  \item \textbf{Iteration policy}
-        \begin{itemize}
-          \item \textbf{EBM}: round-robin ($\forall j$) each boosting pass; \\tiny
-                learning rate $\eta \approx 0.01$.
-          \item \textbf{MB-boost}: greedy; update the \emph{single} component that yields the largest loss reduction.
-        \end{itemize}
+%-- ITERATION POLICY -------------------------------------------------
+\item \textbf{Iteration policy}
+\begin{itemizeS}
+\item \textbf{EBM}: round-robin ($\forall j$) each boosting pass; \\
+tiny learning rate $\eta \approx 0.01$.
+\item \textbf{MB-boost}: greedy; update the \emph{single} component that yields the largest loss reduction.
+\end{itemizeS}
 \pause
-  %-- REGULARISATION ---------------------------------------------------
-  \item \textbf{Regularisation}
-        \begin{itemize}
-          \item \textbf{EBM}: many iterations $M$ (5--10k);  
-                early stopping via \emph{internal} CV on out-of-bag samples;  
-                bagging further lowers variance.
-          \item \textbf{MB-boost}: shrinkage $\nu \in (0,1]$;  
-                early stop by CV/AIC; component selection acts like an
-                $L_0/L_1$ penalty $\rightarrow$ sparsity.
-        \end{itemize}
-\end{itemize}
-\end{frame}
+%-- REGULARISATION ---------------------------------------------------
+\item \textbf{Regularisation}
+\begin{itemizeS}
+\item \textbf{EBM}: many iterations $M$ (5--10k); early stopping via \emph{internal} CV on out-of-bag samples; bagging further lowers variance.
+\item \textbf{MB-boost}: shrinkage $\nu \in (0,1]$; early stop by CV/AIC; component selection acts like an $L_0/L_1$ penalty $\rightarrow$ sparsity.
+\end{itemizeS}
+\end{framei}
 
 %------------- SLIDE 2 -------------------------------------------------
-\begin{frame}{EBM \textit{vs.} Model-based Boosting}
-\small
-\begin{itemize}
-  %-- INTERACTIONS -----------------------------------------------------
-  \item \textbf{Interactions}
-        \begin{itemize}
-          \item \textbf{EBM}: FAST ranks and selects top-$K$ interaction pairs, fitted as bivariate trees $\Rightarrow$ GA2M  
-                % OLD
+\begin{framei}[align=top]{EBM \textit{vs.} Model-based Boosting}
+%-- INTERACTIONS -----------------------------------------------------
+\item \textbf{Interactions}
+\begin{itemizeS}
+\item \textbf{EBM}: FAST ranks and selects top-$K$ interaction pairs, fitted as bivariate trees $\Rightarrow$ GA2M
+% OLD
 %\citebutton{Lou et~al.\ 2013}{https://www.cs.cornell.edu/~yinlou/papers/lou-kdd13.pdf}
 % new
 \furtherreading{LOU2013}
-          \item \textbf{MB-boost}: interactions are modelled only when the
-                user supplies dedicated interaction base learners;
-                no automatic pairwise search
-        \end{itemize}
+\item \textbf{MB-boost}: interactions are modelled only when the user supplies dedicated interaction base learners; no automatic pairwise search
+\end{itemizeS}
 \pause
-  %-- INTERPRETABILITY -------------------------------------------------
-  \item \textbf{Interpretability}
-        \begin{itemize}
-          \item \textbf{EBM}:
-          \begin{itemize}
-              \item one\;1-D step plot for each $f_{j}$
-              \item small number of 2-D heat-maps for selected $f_{ij}$
-          \end{itemize} 
-          \item \textbf{MB-boost}: depends on selected learner: linear
-                coefficients, smooth splines, random-effect curves, etc. %; statistical inference (confidence intervals, $p$-values) available for many bases
-        \end{itemize}
+%-- INTERPRETABILITY -------------------------------------------------
+\item \textbf{Interpretability}
+\begin{itemizeS}
+\item \textbf{EBM}:
+\begin{itemizeS}
+\item one\;1-D step plot for each $f_{j}$
+\item small number of 2-D heat-maps for selected $f_{ij}$
+\end{itemizeS}
+\item \textbf{MB-boost}: depends on selected learner: linear coefficients, smooth splines, random-effect curves, etc. %; statistical inference (confidence intervals, $p$-values) available for many bases
+\end{itemizeS}
 \pause
-  %-- TAKE-AWAY --------------------------------------------------------
-  \item \textbf{Take-away}  
-  \begin{itemize}
-      \item \emph{EBM} provides fast, interpretable, and interaction-sparse models
-      \item \emph{MB-boost} offers flexible stat modeling with built-in variable selection %and formal inference
-  \end{itemize}
-\end{itemize}
-\end{frame}
+%-- TAKE-AWAY --------------------------------------------------------
+\item \textbf{Take-away}
+\begin{itemizeS}
+\item \emph{EBM} provides fast, interpretable, and interaction-sparse models
+\item \emph{MB-boost} offers flexible stat modeling with built-in variable selection %and formal inference
+\end{itemizeS}
+\end{framei}
 
 
 \endlecture

--- a/slides/interpretable-models/slides08-im-rpf.tex
+++ b/slides/interpretable-models/slides08-im-rpf.tex
@@ -10,11 +10,10 @@
 \input{../../latex-math/basic-ml}
 \input{../../latex-math/basic-math}
 % Defines macros and environments
- 
+
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lectureml/}{compstat-lmu.github.io/lecture\ml}}
-\date{}
 
 \begin{document}
 
@@ -45,154 +44,127 @@ figure/2023_paper_skizze_Planted_Tree.jpg
 %------------------------------------------------------------------
 %------------------------------------------------------------------
 
-\begin{frame}{Random Planted Forests (RPF) % OLD
+\begin{framev}[align=top]{Random Planted Forests (RPF) % OLD
 %\citebutton{Hiabu et al. 2023}{https://arxiv.org/abs/2012.14563}
 % new
 \furtherreading{HIABUETAL2023}}
-
-\textbf{Goal:} Create a powerful tree ensemble, but still interpretable
-
+\textbf{Goal:} Create a powerful tree ensemble, but still interpretable\\
+\spacer[0.25]
 \textbf{Idea:}
-\begin{itemize}
-    \item GAMs easily interpretable, because no interaction $\leadsto$ Plot 1D functions
-    
-    \begin{columns}[T, totalwidth=\textwidth]
-    \begin{column}{0.5\textwidth}
-    $$
-    \hat{f}(x) = \theta_0 + f_1(x_{1}) + f_2(x_{2}) + \ldots + f_p(x_{p}),
-    $$
-    \end{column}
-    \hspace*{0.4cm}\hfill
-    \centering
-    \begin{column}{0.5\textwidth}
-    \includegraphics[width = .4\textwidth]{figure/gam_effects.pdf}
-    \end{column}
-    \end{columns}
-    
-    \item Same for function containing interactions between max. 2 features 
-    \\ $\leadsto$ function of 2 features, Plot 2D functions (i.e. 3D plot)
-
-    $$
-    \hat{f}(x) = \theta_0 + f_1(x_{1}) + f_2(x_{2}) + \ldots + f_p(x_{p}) + f_{1,2}(x_{1}, x_{2}) + \ldots + f_{1,p}(x_{1}, x_{p}) + \ldots + f_{p-1,p}(x_{p-1}, x_{p}),
-    $$
-
-    $\leadsto$ Visualize single functions $f_1, f_2, f_{1,2}(x_{1}, x_{2}), f_{1,3}(x_{1}, x_{3}) \ldots$
-
-    % TODO Also figures ?
-    
-\end{itemize}
-
-$\Rightarrow$ Interpretability possible via restricting degree of interactions
-
-\textbf{Problem:} How to know degree of interactions?
-
+\begin{itemizeM}
+\item GAMs easily interpretable, because no interaction $\leadsto$ plot 1D functions\\
+\spacer[0.25]
+\splitVCC[0.725]{
+\spacer[0]
+$$
+\hat{f}(x) = \theta_0 + f_1(x_1) + f_2(x_2) + \ldots + f_p(x_p)
+$$
+\spacer[0]
+}{
+\spacer[0]
+\imageC[0.8]{figure/gam_effects.pdf}
+\spacer[0]
+}
+\item Same for functions containing interactions between max. 2 features\\
+$\leadsto$ function of 2 features, plot 2D functions (i.e. 3D plot)
+$$
+\hat{f}(x) = \theta_0 + f_1(x_1) + f_2(x_2) + \ldots + f_p(x_p) + f_{1,2}(x_1, x_2) + \ldots + f_{1,p}(x_1, x_p) + \ldots + f_{p-1,p}(x_{p-1}, x_p)
+$$
+$\leadsto$ Visualize single functions $f_1$, $f_2$, $f_{1,2}(x_1, x_2)$, $f_{1,3}(x_1, x_3)$, $\ldots$
+% TODO Also figures ?
+\end{itemizeM}
+$\Rightarrow$ Interpretability possible via restricting degree of interactions\\
+\spacer[0.25]
+\textbf{Problem:} How to know degree of interactions?\\
+\spacer[0.25]
 \textbf{Solution:} Easy to determine for trees / tree ensembles!
+\end{framev}
 
-\end{frame}
 
-\begin{frame}{RPF: Determine interaction type in trees}
-
-Define the \textit{interaction type $t$} of a node as the subset of features involved in constructing this node.
-
+\begin{framev}[align=top]{RPF: Determine interaction type in trees}
+Define the \textit{interaction type $t$} of a node as the subset of features involved in constructing this node.\\
+\spacer[0.25]
 \textbf{Example:}
-
 \begin{center}
-    \begin{tikzpicture}[
-    node/.style = {scale=1},
-    scale = 1
-    ]
-        
+\begin{tikzpicture}[
+node/.style = {scale=1},
+scale = 1
+]
         % \node[node] at (0,0)(root){\(x_2 \leq 0\)};
-        % 
+        %
         % \node[node] at (3,-1)(right_child){\(x_3 \leq 1\)};
         % \node[node] at (4,-2)(rightright_grandchild){$0.6$};
         % \node[node] at (2,-2)(rightleft_grandchild){\(-0.3\)};
-        % 
+        %
         % \node[node] at (-3,-1)(left_child){\(x_4 \leq -1\)};
         % \node[node] at (-4,-2)(leftleft_grandchild){$0.2$};
         % \node[node] at (-2,-2)(leftright_grandchild){\(x_1 \leq -0.5\)};
-        % 
+        %
         % \node[node] at (-2.5,-3)(low_child_1){$-0.1$};
         % \node[node] at (-1.5,-3)(low_child_2){$0.7$};
-        
-        \node[node] at (0,2)(root){\(\R^d\)};
-        
-        \node[node] at (3,.5)(right_child){\(x_2 > 0\)};
-        \node[node] at (4,-1)(rightright_grandchild){$x_3 > 1$};
-        \node[node] at (2,-1)(rightleft_grandchild){\(x_3 \leq 1\)};
-        
-        \node[node] at (-3,.5)(left_child){\(x_2 \leq 0\)};
-        \node[node] at (-4,-1)(leftleft_grandchild){$x_4 \leq -1$};
-        \node[node] at (-1,-1)(leftright_grandchild){\(x_4 > -1\)};
-        
-        \node[node] at (-2,-2.5)(low_child_1){$x_1 \leq -0.5$};
-        \node[node] at (-0,-2.5)(low_child_2){$x_1 > -0.5$};
-
-        \draw[->, shorten >= 1pt, shorten <= 1pt] (root) -- (left_child);
-        \draw[->, shorten >= 1pt, shorten <= 1pt] (root) -- (right_child);
-        \draw[->, shorten >= 1pt, shorten <= 1pt] (left_child) -- (leftleft_grandchild);
-        \draw[->, shorten >= 1pt, shorten <= 1pt] (left_child) -- (leftright_grandchild);
-        \draw[->, shorten >= 1pt, shorten <= 1pt] (right_child) -- (rightright_grandchild);
-        \draw[->, shorten >= 1pt, shorten <= 1pt] (right_child) -- (rightleft_grandchild);
-        
-        \draw[->, shorten >= 1pt, shorten <= 1pt] (leftright_grandchild) -- (low_child_1);
-        \draw[->, shorten >= 1pt, shorten <= 1pt] (leftright_grandchild) -- (low_child_2);
-
-        \only<2>{
-        \node[node, color=red] at (0,1.5)(root_type){$t=\{\}$};
-        
-        \node[node, color=red] at (3,0)(right_child_type){$t=\{2\}$};
-        \node[node, color=red] at (4,-1.5)(rightright_grandchild_type){$t=\{2,3\}$};
-        \node[node, color=red] at (2,-1.5)(rightleft_grandchild_type){$t=\{2,3\}$};
-        
-        \node[node, color=red] at (-3,0)(left_child_type){$t=\{2\}$};
-        \node[node, color=red] at (-4,-1.5)(leftleft_grandchild_type){$t=\{2,4\}$};
-        \node[node, color=red] at (-1,-1.5)(leftright_grandchild_type){$t=\{2,4\}$};
-        
-        \node[node, color=red] at (-2,-3)(low_child_1_type){$t=\{1,2,4\}$};
-        \node[node, color=red] at (0,-3)(low_child_2_type){$t=\{1,2,4\}$};
+\node[node] at (0,2)(root){$\R^d$};
+\node[node] at (3,.5)(right_child){$x_2 > 0$};
+\node[node] at (4,-1)(rightright_grandchild){$x_3 > 1$};
+\node[node] at (2,-1)(rightleft_grandchild){$x_3 \leq 1$};
+\node[node] at (-3,.5)(left_child){$x_2 \leq 0$};
+\node[node] at (-4,-1)(leftleft_grandchild){$x_4 \leq -1$};
+\node[node] at (-1,-1)(leftright_grandchild){$x_4 > -1$};
+\node[node] at (-2,-2.5)(low_child_1){$x_1 \leq -0.5$};
+\node[node] at (0,-2.5)(low_child_2){$x_1 > -0.5$};
+\draw[->, shorten >= 1pt, shorten <= 1pt] (root) -- (left_child);
+\draw[->, shorten >= 1pt, shorten <= 1pt] (root) -- (right_child);
+\draw[->, shorten >= 1pt, shorten <= 1pt] (left_child) -- (leftleft_grandchild);
+\draw[->, shorten >= 1pt, shorten <= 1pt] (left_child) -- (leftright_grandchild);
+\draw[->, shorten >= 1pt, shorten <= 1pt] (right_child) -- (rightright_grandchild);
+\draw[->, shorten >= 1pt, shorten <= 1pt] (right_child) -- (rightleft_grandchild);
+\draw[->, shorten >= 1pt, shorten <= 1pt] (leftright_grandchild) -- (low_child_1);
+\draw[->, shorten >= 1pt, shorten <= 1pt] (leftright_grandchild) -- (low_child_2);
+\only<2>{
+\node[overlay, node, color=red] at (0,1.5)(root_type){$t=\{\}$};
+\node[overlay, node, color=red] at (3,0)(right_child_type){$t=\{2\}$};
+\node[overlay, node, color=red] at (4,-1.5)(rightright_grandchild_type){$t=\{2,3\}$};
+\node[overlay, node, color=red] at (2,-1.5)(rightleft_grandchild_type){$t=\{2,3\}$};
+\node[overlay, node, color=red] at (-3,0)(left_child_type){$t=\{2\}$};
+\node[overlay, node, color=red] at (-4,-1.5)(leftleft_grandchild_type){$t=\{2,4\}$};
+\node[overlay, node, color=red] at (-1,-1.5)(leftright_grandchild_type){$t=\{2,4\}$};
+\node[overlay, node, color=red] at (-2,-3)(low_child_1_type){$t=\{1,2,4\}$};
+\node[overlay, node, color=red] at (0,-3)(low_child_2_type){$t=\{1,2,4\}$};
         % \draw (-2,-3.3) ellipse (1.1cm and 0.6cm);
         % \draw (0,0) ellipse (2cm and 1cm);
-        }
-
-        
-    \end{tikzpicture}
+}
+\end{tikzpicture}
 \end{center}
-
+% use of \spacer[1] since it doesn't look good with \spacer[0.25]
+\spacer[1]
 \only<2>{
 $\Rightarrow$ Degree of interaction in each node is \(|t|\).
 }
-    
-\end{frame}
+\end{framev}
 
-\begin{frame}{RPF: bounded interaction order + Planted trees}
 
-    Goal: restrict this interaction degree
-    
-    $\leadsto$ In RPFs: 
+\begin{framev}[align=top]{RPF: bounded interaction order + Planted trees}
+\textbf{Goal}: restrict this interaction degree\\
+$\leadsto$ In RPFs:
+\begin{itemizeM}
+\item Always keep track of the interaction type in each node
+\item For each new split, make sure the max. degree of interactions is not exceeded\\ $\Rightarrow$ When max. number of feat reached, no new feat are allowed
+\end{itemizeM}
+\spacer[0.25]
+\textbf{Problem:} For small interaction order, single trees quickly become limited
+\begin{itemizeM}
+\item E.g. interaction order 1: every tree uses only one feature
+\item[$\Rightarrow$] Many trees are needed for a more complex model
+\end{itemizeM}
 
-    \begin{itemize}
-        \item Always keep track of interaction type in each node
-        
-        \item For each new split, make sure max. degree of interactions is not exceeded $\Rightarrow$ When max. number of feat reached, no new feat are allowed
-    \end{itemize}
-
-    \textbf{Problem: } For small interaction order, single trees quickly limited
-
-    \begin{itemize}
-        \item E.g. interaction order 1: Every tree only one feature
-        \item[$\Rightarrow$] Many trees needed for more complex model
-    \end{itemize}
-
-    \textbf{Idea:} Allow inner nodes to split again
-
-    Define \textit{Planted Trees}: Decision trees where each inner nodes can be \textit{leaves}:
-    \begin{itemize}
-        \item Add prediction to final output
-        \item Can be split again $\Rightarrow$ several splits possible
-    \end{itemize}
-    
-\end{frame}
+\spacer[0.25]
+\textbf{Idea:} Allow inner nodes to split again\\
+\spacer[0.25]
+Define \textit{Planted Trees}: decision trees where each inner node can be a \textit{leaf}:
+\begin{itemizeM}
+\item Add prediction to final output
+\item Can be split again $\Rightarrow$ several splits possible
+\end{itemizeM}
+\end{framev}
 
 % \begin{frame}{RPF: Example}
 
@@ -207,74 +179,58 @@ $\Rightarrow$ Degree of interaction in each node is \(|t|\).
 
 % \end{frame}
 
-\begin{frame}{RPF: Example}
-
+\begin{framev}[align=top]{RPF: Example}
 \begin{center}
-    \begin{figure}[h]
-    
-    \begin{tikzpicture}[
-    node/.style = {scale=.5},
-    scale = 1
-    ]
-        \node[anchor=south west,inner sep=0] (image) at (0,0) {\includegraphics[width=1.1\linewidth]{figure/2023_paper_skizze_Planted_Tree.jpg}};
-        
-        \only<2>{
-        \node[node, color=red] at (8,6)(root_type){$t=\{\}$};
-        
-        \node[node, color=red] at (3.35,4.8)(leftleft_type){$\{1\}$};
-        \node[node, color=red] at (5.55,4.8)(leftright_type){$\{1\}$};
-        
-        \node[node, color=red] at (3.95,4.1)(leftleft_right_type){$\{1,2\}$};
-        \node[node, color=red] at (2.75,4.1)(leftleft_left_type){$\{1,2\}$};
-        
-        \node[node, color=red] at (3.35,2.8)(leftleft_right_left_type){$\{1,2\}$};
-        \node[node, color=red] at (4.35,2.8)(leftleft_right_right_type){$\{1,2\}$};
-        
-        \node[node, color=red] at (3.95,1.9)(leftright_leftleft_type){$\{1,3\}$};
-        \node[node, color=red] at (4.95,1.9)(leftright_leftright_type){$\{1,3\}$};
-        
+\begin{figure}[h]
+\begin{tikzpicture}[
+node/.style = {scale=.5},
+scale = 1
+]
+\node[anchor=south west,inner sep=0] (image) at (0,0) {\includegraphics[width=1.1\linewidth]{figure/2023_paper_skizze_Planted_Tree.jpg}};
+\only<2>{
+\node[node, color=red] at (8,6)(root_type){$t=\{\}$};
+\node[node, color=red] at (3.35,4.8)(leftleft_type){$\{1\}$};
+\node[node, color=red] at (5.55,4.8)(leftright_type){$\{1\}$};
+\node[node, color=red] at (3.95,4.1)(leftleft_right_type){$\{1,2\}$};
+\node[node, color=red] at (2.75,4.1)(leftleft_left_type){$\{1,2\}$};
+\node[node, color=red] at (3.35,2.8)(leftleft_right_left_type){$\{1,2\}$};
+\node[node, color=red] at (4.35,2.8)(leftleft_right_right_type){$\{1,2\}$};
+\node[node, color=red] at (3.95,1.9)(leftright_leftleft_type){$\{1,3\}$};
+\node[node, color=red] at (4.95,1.9)(leftright_leftright_type){$\{1,3\}$};
         % \node[node, color=red] at (5,1)(left_right_type_dummy){$\{1\}$};
-        \node[node, color=red] at (5.15,1.25)(leftright_rightleft_type){$\{1\}$};
-        \node[node, color=red] at (6.15,1.25)(leftright_rightright_type){$\{1\}$};
-        
-        \node[node, color=red] at (7.75,.65)(midright_type){$\{3\}$};
-        \node[node, color=red] at (6.15,.65)(midleft_type){$\{3\}$};
-        }
-        
-    \end{tikzpicture}
-    
-    \caption{Example of a single fully grown planted tree, green nodes: ``leaves''}
-    \label{fig:Planted_Tree_example_paper}
-    \end{figure}
-
+\node[node, color=red] at (5.15,1.25)(leftright_rightleft_type){$\{1\}$};
+\node[node, color=red] at (6.15,1.25)(leftright_rightright_type){$\{1\}$};
+\node[node, color=red] at (7.75,.65)(midright_type){$\{3\}$};
+\node[node, color=red] at (6.15,.65)(midleft_type){$\{3\}$};
+}
+\end{tikzpicture}
+\caption{Example of a single fully grown planted tree, green nodes: ``leaves''}
+\label{fig:Planted_Tree_example_paper}
+\end{figure}
 \end{center}
-    
-\end{frame}
+\end{framev}
 
-\begin{frame}{RPF: Algo}
 
-\begin{itemize}
-    \item Max. interaction degree is a hyperparameter
-    \item Total number of trees is a hyperparameter
-    \item End growing tree after max. total number of splits instead of max. depth \\
-    (min. number of samples also possible, but then higher nodes would split too often)
-    \item Randomization as in Random Forests:
-    \begin{itemize}
-        \item Only optimize over subset of features, randomly chosen
-        \item Only optimize over subset of possible split values
-    \end{itemize}
-    \item Make an inner leaf an inner node (i.e. delete ``leaf'' property), if it has children with the same type
-\end{itemize}
-    
-\end{frame}
+\begin{framei}[align=top]{RPF: Algo}
+\item Max. interaction degree is a hyperparameter
+\item Total number of trees is a hyperparameter
+\item End growing tree after the maximum total number of splits instead of the maximum depth\\
+(Minimum number of samples is also possible, but then higher nodes would split too often)
+\item Randomization as in random forests:
+\begin{itemizeS}
+\item Only optimize over a randomly chosen subset of features
+\item Only optimize over a subset of possible split values
+\end{itemizeS}
+\item Make an inner leaf an inner node (i.e.\ delete the ``leaf'' property) if it has children with the same type
+\end{framei}
 
-\begin{frame}{RPF: Example results and interpretation}
-    
-\end{frame}
 
-\begin{frame}{RPF: Conclusion}
-    
-\end{frame}
+\begin{framev}[align=top]{RPF: Example results and interpretation}
+\end{framev}
+
+
+\begin{framev}[align=top]{RPF: Conclusion}
+\end{framev}
 
 \endlecture
 \end{document}


### PR DESCRIPTION
## Summary
This PR cleans up the `interpretable-models` slide deck.

The branch keeps the cleanup split into one commit per slide file so the review stays easy to follow.

## Included changes
- clean up the "Inherently Interpretable Models - Motivation" slides
- clean up the "Linear Regression Model" slides
- clean up the "Extensions of Linear Regression Models" slides
- clean up the "Generalized Linear Models (GLMs)" slides
- clean up the "Rule-based Models" slides
- clean up the "GAM & Boosting" slides
- clean up the "Explainable Boosting Machines (EBM)" slides
- clean up the "Random Planted Forests" slides

## Scope
Files touched:
- `slides/interpretable-models/slides01-im-motivation.tex`
- `slides/interpretable-models/slides02-im-lm-simple.tex`
- `slides/interpretable-models/slides03-im-lm-extensions.tex`
- `slides/interpretable-models/slides04-im-glm.tex`
- `slides/interpretable-models/slides05-im-rule-based.tex`
- `slides/interpretable-models/slides06-im-gam-boosting.tex`
- `slides/interpretable-models/slides07-im-ebm.tex`
- `slides/interpretable-models/slides08-im-rpf.tex`
