### PR TITLE
cleanup(slides): refactor functional decompostion

### DIFF
--- a/slides/functional-decompositions_interactions/slides01-fd-intro-motivation.tex
+++ b/slides/functional-decompositions_interactions/slides01-fd-intro-motivation.tex
@@ -4,13 +4,12 @@
 \input{../../latex-math/basic-math}
 \input{../../latex-math/basic-ml}
 % Defines macros and environments
- \newcommand{\open}{}
+\newcommand{\open}{}
 \newcommand{\close}{}
 
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
 
@@ -35,27 +34,24 @@ figure/25-05-31_Hooker_2004_graph_fANOVA
 }
 
 
-
-\begin{frame}{Preliminaries}
-
-    \textbf{Recap: Interactions}
-    \begin{itemize}
-        \item Interactions between features: Effect of one feature on the prediction output depends on (one or more) other features
-        \item Definition: Features $x_j$  and $x_k$ are considered to interact, if
-        $$
-        \mathbb{E} \left[ \left( \frac{\partial^2 f(\xv)}{\partial x_j \partial x_k} \right)^2 \right] > 0
-        $$
-    \end{itemize}
-    
-    \pause
-    \textbf{Recap: GAMs}
-    \begin{itemize}
-        \item Decomposition into only main effects
-        \item Do not contain any interactions
-    \end{itemize}
-    $$
-    \fh (\xv) = \theta_0 + g_1(x_1) + g_2(x_2) + \ldots + g_p(x_p)
-    $$
+\begin{framev}[align=top]{Preliminaries}
+\textbf{Recap: Interactions}
+\begin{itemizeM}
+\item Interactions between features: Effect of one feature on the prediction output depends on (one or more) other features
+\item Definition: Features $x_j$ and $x_k$ are considered to interact, if
+$$
+\mathbb{E} \left[ \left( \frac{\partial^2 f(\xv)}{\partial x_j \partial x_k} \right)^2 \right] > 0
+$$
+\end{itemizeM}
+\pause
+\textbf{Recap: GAMs}
+\begin{itemizeM}
+\item Decomposition into only main effects
+\item Do not contain any interactions
+\end{itemizeM}
+$$
+\fh (\xv) = \theta_0 + g_1(x_1) + g_2(x_2) + \ldots + g_p(x_p)
+$$
     % Recap: Interactions between features: The effect of some features on the prediction output depends on (one or more) other features \\
     % This cannot be captured by the main feature effects alone (i.e. by a GAM).
     % We want to know, which parts are attributed to effects of single features (s.o. feature effect methods), and which to interactions.
@@ -68,55 +64,49 @@ figure/25-05-31_Hooker_2004_graph_fANOVA
     % Remember EBMs at this point: There, strong interactions were defined via reduction in RSS compared to a univariate model / a GAM -> exactly same idea / same formula
     % }
 
-\end{frame}
+\end{framev}
 
-\begin{frame}{First Example: Additive decomposition}
 
-    \begin{example}
-
-    Consider
-    $$
-    \fh(x_1, x_2) = 4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2
-    $$
+\begin{framev}[align=top]{First Example: Additive decomposition}
+\begin{example}
+Consider
+$$
+\fh(x_1, x_2) = 4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2
+$$
     % The function \( \fh(x_1, x_2) = 4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2 \) depends on two features, and contains the interaction \( |x_1|x_2 \) between the two features.
 
-    \begin{itemize}
-    
-        \item Idea: Additive decomposition depending on which features used:
-        
-        \pause
-        \begin{equation}\label{eq:func_decomp_first_min_example}
-        \begin{aligned}
-            & g_\emptyset(x_1, x_2) = 4 & \text{ Part depending on no features at all (intercept)}  \\
-            &
-            \left.\begin{aligned}
-                & g_1(x_1, x_2) = 2x_1 \\
-                & g_2(x_1, x_2) = 0.3 e^{x_2}
-            \end{aligned}\right\}
-                & \text{ Parts depending on a single feature (main effects)}  \\
-            & g_{1,2}(x_1, x_2) = |x_1|x_2 & \text{ Part depending on both features (interaction)}  \\
-        \end{aligned}
+\begin{itemizeM}
+\item Idea: Additive decomposition depending on which features used:
+\pause
+\begin{equation}\label{eq:func_decomp_first_min_example}
+\begin{aligned}
+& g_\emptyset(x_1, x_2) = 4 & \text{ Part depending on no features at all (intercept)}  \\
+&
+\left.\begin{aligned}
+& g_1(x_1, x_2) = 2x_1 \\
+& g_2(x_1, x_2) = 0.3 e^{x_2}
+\end{aligned}\right\}
+& \text{ Parts depending on a single feature (main effects)}  \\
+& g_{1,2}(x_1, x_2) = |x_1|x_2 & \text{ Part depending on both features (interaction)}  \\
+\end{aligned}
         % \begin{matrix}
         %     g_\emptyset(x_1, x_2) = 4 &  \text{ Parts depending on no features at all (constant)}  \\
         %     g_1(x_1, x_2) = 2x_1 & \text{ Parts depending on a single feature (main effects)} \\
         %     g_1(x_1, x_2) =  0.3 e^{x_2} & \\
         %     g_{1,2}(x_1, x_2) = |x_1|x_2 & \text{ Part depending on both features (interaction)}  \\
         % \end{matrix}
-        \end{equation}
-        \item[$\leadsto$] Single terms with immediate interpretation, full model understanding 
-
-        \pause
-        \item[$\leftrightarrow$] Not possible with effects of single features (e.g. PDPs) or GAM surrogate model (miss interaction part)
-    
+\end{equation}
+\item[$\leadsto$] Single terms with immediate interpretation, full model understanding
+\pause
+\item[$\leftrightarrow$] Not possible with effects of single features (e.g. PDPs) or GAM surrogate model (miss interaction part)
         % Using a GAM or looking at the effects of single features will not allow us to fully understand the function. 
         
         % The single terms enable immediate interpretation (effects of single features, single interactions etc). \\
         
-    \end{itemize}
+\end{itemizeM}
+\end{example}
 
-    \end{example}
-
-\end{frame}
+\end{framev}
 
 % \begin{frame}{First Example: Additive decomposition}
 
@@ -131,18 +121,16 @@ figure/25-05-31_Hooker_2004_graph_fANOVA
     
 % \end{frame}
 
-\begin{frame}{Another example: Additive decomposition}
-
-    \textbf{Goal} in general:
-    Given a black-box model \(\fh: \R^2 \to \R\), find a decomposition
-    \begin{equation}
-        \fh(x_1, x_2) =  g_\emptyset + g_1(x_1) + g_2(x_2) + g_{\open 1, 2 \close}(x_1, x_2)
-    \end{equation}
-    
+\begin{framev}[align=top]{Another example: Additive decomposition}
+\textbf{Goal} in general:
+Given a black-box model \(\fh: \R^2 \to \R\), find a decomposition
+\begin{equation}
+\fh(x_1, x_2) =  g_\emptyset + g_1(x_1) + g_2(x_2) + g_{\open 1, 2 \close}(x_1, x_2)
+\end{equation}
     % \textit{TO DO: Better use a real-world example, only image here necessary for illustration purposes}
 
-    \pause
-    \begin{example}
+\pause
+\begin{example}
     % \textbf{Example:}
     % $\fh(\xv) = 2 + x_1^2 - x_2^2 + x_1 \cdot x_2$ (e.g., for $x_1 = 5$ and $x_2 = 10$ we get $\fh(\xv) = -23$)
     
@@ -150,65 +138,56 @@ figure/25-05-31_Hooker_2004_graph_fANOVA
     %     \item Computation of components using feature values $x_1 = x_2 = (-10, -9, \ldots, 10)^\top$ gives:
     %         \includegraphics[width = \textwidth]{figure/decomposition}
     % \end{itemize}
-    
-    \includegraphics[width = \textwidth]{figure/decomposition}
-    
-    $\leadsto$ More details on this example later
-        
-    \end{example}
-    
-\end{frame}
+\image{figure/decomposition}
+$\leadsto$ More details on this example later
+\end{example}
+\end{framev}
 
-\begin{frame}{Another example: Additive decomposition}
 
-    \begin{example}
-
-        % Consider the function
-
-        $$
-        \fh(x_1, x_2, x_3) = - 2x_1 - 2\sin(x_3) + |x_1|x_2 + 0.5 x_1 x_2 x_3 - \sin(x_2 x_3) + 1
-        $$
-
-        % We can again find the additive decomposition by reading from the functional formula, but some terms are empty, because certain types of effects and interactions are not present:
-        Again, read additive decomposition from formula:
-        \pause
-        \begin{equation}\label{eq:func_decomp_second_min_example}
-        \begin{aligned}
-            & g_\emptyset(x_1, x_2, x_3) = 1 & \text{ constant part, no effects}  \\
-            &
-            \left.\begin{aligned}
-                & g_1(x_1, x_2, x_3) = - 2x_1 \\
-                & g_2(x_1, x_2, x_3) = 0 \\
-                & g_3(x_1, x_2, x_3) = - 2\sin(x_3)
-            \end{aligned}\right\}
-                & \text{ main effects, no interactions}  \\
-            &
-            \left.\begin{aligned}
-                & g_{1,2}(x_1, x_2, x_3) = |x_1|x_2 \\
-                & g_{1,3}(x_1, x_2, x_3) = 0 \\
-                & g_{2,3}(x_1, x_2, x_3) = - \sin(x_2 x_3)
-            \end{aligned}\right\}
-                & \text{ 2-way interactions (depending on 2 features)}  \\
-            & g_{1,2,3}(x_1, x_2, x_3) = 0.5 x_1 x_2 x_3 & \text{ 3-way interactions}  \\
-        \end{aligned}
+\begin{framev}[align=top]{Another example: Additive decomposition}
+\begin{example}
+% Consider the function
+$$
+\fh(x_1, x_2, x_3) = - 2x_1 - 2\sin(x_3) + |x_1|x_2 + 0.5 x_1 x_2 x_3 - \sin(x_2 x_3) + 1
+$$
+% We can again find the additive decomposition by reading from the functional formula, but some terms are empty, because certain types of effects and interactions are not present:
+Again, read additive decomposition from formula:
+\pause
+\begin{equation}\label{eq:func_decomp_second_min_example}
+\begin{aligned}
+& g_\emptyset(x_1, x_2, x_3) = 1 & \text{ constant part, no effects}  \\
+&
+\left.\begin{aligned}
+& g_1(x_1, x_2, x_3) = - 2x_1 \\
+& g_2(x_1, x_2, x_3) = 0 \\
+& g_3(x_1, x_2, x_3) = - 2\sin(x_3)
+\end{aligned}\right\}
+& \text{ main effects, no interactions}  \\
+&
+\left.\begin{aligned}
+& g_{1,2}(x_1, x_2, x_3) = |x_1|x_2 \\
+& g_{1,3}(x_1, x_2, x_3) = 0 \\
+& g_{2,3}(x_1, x_2, x_3) = - \sin(x_2 x_3)
+\end{aligned}\right\}
+& \text{ 2-way interactions (depending on 2 features)}  \\
+& g_{1,2,3}(x_1, x_2, x_3) = 0.5 x_1 x_2 x_3 & \text{ 3-way interactions}  \\
+\end{aligned}
         % \begin{matrix}
         %     g_\emptyset(x_1, x_2) = 4 &  \text{ Parts depending on no features at all (constant)}  \\
         %     g_1(x_1, x_2) = 2x_1 & \text{ Parts depending on a single feature (main effects)} \\
         %     g_1(x_1, x_2) =  0.3 e^{x_2} & \\
         %     g_{1,2}(x_1, x_2) = |x_1|x_2 & \text{ Part depending on both features (interaction)}  \\
         % \end{matrix}
-        \end{equation}
-        \(\Rightarrow\) 8 components in total, but some empty $\leadsto$ Certain interactions not present
-        
-    \end{example}
-    
-\end{frame}
+\end{equation}
+\(\Rightarrow\) 8 components in total, but some empty $\leadsto$ Certain interactions not present
+\end{example}
+\end{framev}
 
-\begin{frame}{General Form of Functional Decomposition
+
+\begin{framev}[align=top]{General Form of Functional Decomposition
 \furtherreading{RABITZ2011}
 \furtherreading{CHASTAING2012}
 }
-
 \begin{definition}
 \textit{Functional decomposition}: Additive decomposition of a function $\fh: \R^p \mapsto \R$ into a sum of components of different dimensions w.r.t. inputs $x_1, \ldots, x_p$: 
 \begin{equation*}
@@ -225,16 +204,15 @@ g_{\open 1,\ldots,p \close}(x_1, \ldots, x_p)
 \end{equation*}
 $\leadsto$ one component for every possible combination $S$ of indices, allowed to formally only depend on these features / be a function of these features
 \end{definition}
-
 \textbf{Problems:}
-\begin{itemize}
-    \item How to find / compute such a decomposition for any black-box models $\fh$?
-    \item \dots such that the decomposition is useful / has nice properties (w.r.t. the model / w.r.t. the data)?
-\end{itemize}
+\begin{itemizeM}
+\item How to find / compute such a decomposition for any black-box models $\fh$?
+\item \dots such that the decomposition is useful / has nice properties (w.r.t. the model / w.r.t. the data)?
+\end{itemizeM}
+\end{framev}
 
-\end{frame}
 
-\begin{frame}{General Form of Functional Decomposition
+\begin{framev}[align=top]{General Form of Functional Decomposition
 %\\
 %\furtherreading{SOBOL1993}
 % \furtherreading{SOBOL2003}
@@ -242,9 +220,7 @@ $\leadsto$ one component for every possible combination $S$ of indices, allowed 
 \furtherreading{RABITZ2011}
 \furtherreading{CHASTAING2012}
 }
-
 %\textbf{High-Dimensional Model Representation (HDMR):} 
-
 \begin{definition}
 % For interpretation purposes, one might be interested in decomposing a square-integrable function $\fh: \R^p \mapsto \R$ into sum of components of different dimensions w.r.t. inputs $x_1, \ldots, x_p$: %
 \textit{Functional decomposition}: Additive decomposition of a function $\fh: \R^p \mapsto \R$ into a sum of components of different dimensions w.r.t. inputs $x_1, \ldots, x_p$: 
@@ -271,40 +247,39 @@ g_{\open 1,\ldots,p \close}(x_1, \ldots, x_p)
 $\leadsto$ one component for every possible combination $S$ of indices
 \end{definition}
 Sort terms according to degree of interaction:
-\begin{itemize}
+\begin{itemizeM}
 \item $g_{\open \emptyset \close} \hat = $ Constant mean (intercept) %$\mathbb{E}_X (\fh(\xv)) $
 \item $g_{\open j \close} \hat = $ first-order or main effect of $j$-th feature alone on $\fh(\xv)$
 \item $g_{\open j, k \close} \hat = $ second-order interaction effect of features $j$ and $k$ w.r.t. $\fh(\xv)$%, etc.
 \item $g_{S}(\xv_S) \hat = $ $|S|$-order effect, depends \textbf{only} on features in $S$ %$x_j$ for all $j \in S$
-\end{itemize}
-\lz
-\end{frame}
+\end{itemizeM}
+\end{framev}
 
 % TO DO: Put an example from a real-world dataset here for illustration purposes
 
-\begin{frame}{Properties of the definition}
-\begin{itemize}
-    \item \textbf{Interpretability}: Extremely powerful decomposition, reveals complete interaction structure
-    \pause
-    \item Compare to GAM: Same decomposition, but without interactions \\
-    $\implies$ Any GAM already comes with its decomposition
-    $$
-    \fh (\xv) = g_\emptyset + g_1(x_1) + g_2(x_2) + \ldots + g_p(x_p)
-    $$
-    \item Same for LMs: Decomposition explicitly modeled
-    \pause
-    \item Easy decomp. also for decision trees and tree ensembles (see below)
-    \pause
-    \item \textbf{Problem 1:} Calculating decomposition extremely difficult, often infeasible
-    \begin{itemize}
-        \item For \(p\) features: Decomposition with \(2^p\) terms \(\rightarrow\) too many different terms, difficult to interpret
-    \end{itemize}
-    \pause
-    \item \textbf{Problem 2:} Definition not complete: Decomposition not unique, many trivial decompositions not useful
-    \begin{itemize}
-        \item[$\rightarrow$] More requirements or constraints needed to ensure decomposition is meaningful
-        \item Even worse once features are dependent or correlated (see later)
-    \end{itemize}
+\begin{framev}[align=top]{Properties of the definition}
+\begin{itemizeM}
+\item \textbf{Interpretability}: Extremely powerful decomposition, reveals complete interaction structure
+\pause
+\item Compare to GAM: Same decomposition, but without interactions \\
+$\implies$ Any GAM already comes with its decomposition
+$$
+\fh (\xv) = g_\emptyset + g_1(x_1) + g_2(x_2) + \ldots + g_p(x_p)
+$$
+\item Same for LMs: Decomposition explicitly modeled
+\pause
+\item Easy decomp. also for decision trees and tree ensembles (see below)
+\pause
+\item \textbf{Problem 1:} Calculating decomposition extremely difficult, often infeasible
+\begin{itemizeS}
+\item For \(p\) features: Decomposition with \(2^p\) terms \(\rightarrow\) too many different terms, difficult to interpret
+\end{itemizeS}
+\pause
+\item \textbf{Problem 2:} Definition not complete: Decomposition not unique, many trivial decompositions not useful
+\begin{itemizeS}
+\item[$\rightarrow$] More requirements or constraints needed to ensure decomposition is meaningful
+\item Even worse once features are dependent or correlated (see later)
+\end{itemizeS}
     % This 
     % Compare to GAM: The same decomposition is used, but in case of GAM, no interactions at all are considered, only main effects. I.p. any GAM already comes with its decomposition! \\
     % Same for linear models / linear regression and GLMs: The decomposition is explicitly modeled and directly follows from the model structure.
@@ -325,146 +300,121 @@ Sort terms according to degree of interaction:
     %     \item Calculating such a decomposition is super, super hard in practice \\
     %         See for example: For \(p\) features, the decomposition has \(2^p\) terms \(\Rightarrow\) not very meaningful to interpret so many different terms \\
     % \end{itemize}
-\end{itemize}
-\end{frame}
+\end{itemizeM}
+\end{framev}
 
-\begin{frame}{Problem 2: Definition not enough}
 
-    \begin{example}
-        Again consider
-        $$
-        \fh(x_1, x_2, x_3) = - 2x_1 - 2\sin(x_3) + |x_1|x_2 + 0.5 x_1 x_2 x_3 - \sin(x_2 x_3) + 1
-        $$
-        \pause
-        Two possible decompositions (valid according to definition):
-        $$
-            g_{1, \dots, p}(x_1, \dots, x_p) := \fh(\xv) \text{ and for all other terms } g_S(\xv_S) := 0 ,
-        $$
-        or:
-        \begin{align*}
-            g_\emptyset & = 1 \,;\quad
-            g_1(x_1) = x_1 \,;\;
-            g_2(x_2) = 2x_2 \,;\;
-            g_3(x_3) = 3x_3 \,;\quad \\
-            g_{1,2}(x_1, x_2) & = \frac{1}{2} x_1 x_2 \,;\;
-            g_{1,3}(x_1, x_3) = \frac{1}{3} x_1 x_3 \,;\;
-            g_{2,3}(x_2, x_3) = \frac{2}{3} x_2 x_3 \,;\; \\
-            \text{ and} \quad
-            & g_{1,2,3}(x_1, x_2, x_3) = \fh(x_1, x_2, x_3) - \sum_{S \subsetneqq \{1,2,3\}} g_S(\xv_S)
-        \end{align*}
-    \end{example}
-    % Use $g_{1, \dots, p}(x_1, \dots, x_p) := \fh(\xv)$ and $g_S(\xv_S) := 0$ for all other terms
-    \pause
-    \(\implies\) Definition of decomposition not unique \\
-    
-\end{frame}
+\begin{framev}[align=top]{Problem 2: Definition not enough}
+\begin{example}
+Again consider
+$$
+\fh(x_1, x_2, x_3) = - 2x_1 - 2\sin(x_3) + |x_1|x_2 + 0.5 x_1 x_2 x_3 - \sin(x_2 x_3) + 1
+$$
+\pause
+Two possible decompositions (valid according to definition):
+$$
+g_{1, \dots, p}(x_1, \dots, x_p) := \fh(\xv) \text{ and for all other terms } g_S(\xv_S) := 0 ,
+$$
+or:
+\begin{align*}
+g_\emptyset & = 1 \,;\quad
+g_1(x_1) = x_1 \,;\;
+g_2(x_2) = 2x_2 \,;\;
+g_3(x_3) = 3x_3 \,;\quad \\
+g_{1,2}(x_1, x_2) & = \frac{1}{2} x_1 x_2 \,;\;
+g_{1,3}(x_1, x_3) = \frac{1}{3} x_1 x_3 \,;\;
+g_{2,3}(x_2, x_3) = \frac{2}{3} x_2 x_3 \,;\; \\
+\text{ and} \quad
+& g_{1,2,3}(x_1, x_2, x_3) = \fh(x_1, x_2, x_3) - \sum_{S \subsetneqq \{1,2,3\}} g_S(\xv_S)
+\end{align*}
+\end{example}
+% Use $g_{1, \dots, p}(x_1, \dots, x_p) := \fh(\xv)$ and $g_S(\xv_S) := 0$ for all other terms
+\pause
+\(\implies\) Definition of decomposition not unique \\
+\end{framev}
 
-\begin{frame}{Example: Decision Trees}
 
+\begin{framev}[align=top]{Example: Decision Trees}
 \only<1,2>{
-Define \textit{interaction type $t$} of a node: subset of features used to build this node.
-
+Define \textit{interaction type $t$} of a node: subset of features used to build this node.\\
 \textbf{Example:}
-
 \begin{center}
-    \begin{tikzpicture}[
-    node/.style = {scale=1},
-    scale = 1
-    ]
-        
-        \node[node] at (0,2)(root){\(\R^d\)};
-        
-        \node[node] at (3,.5)(right_child){\(x_2 > 0\)};
-        \node[node] at (4,-1)(rightright_grandchild){$x_3 > 1$};
-        \node[node] at (2,-1)(rightleft_grandchild){\(x_3 \leq 1\)};
-        
-        \node[node] at (-3,.5)(left_child){\(x_2 \leq 0\)};
-        \node[node] at (-4,-1)(leftleft_grandchild){$x_4 \leq -1$};
-        \node[node] at (-1,-1)(leftright_grandchild){\(x_4 > -1\)};
-        
-        \node[node] at (-2,-2.5)(low_child_1){$x_1 \leq -0.5$};
-        \node[node] at (-0,-2.5)(low_child_2){$x_1 > -0.5$};
-
-        \draw[->, shorten >= 1pt, shorten <= 1pt] (root) -- (left_child);
-        \draw[->, shorten >= 1pt, shorten <= 1pt] (root) -- (right_child);
-        \draw[->, shorten >= 1pt, shorten <= 1pt] (left_child) -- (leftleft_grandchild);
-        \draw[->, shorten >= 1pt, shorten <= 1pt] (left_child) -- (leftright_grandchild);
-        \draw[->, shorten >= 1pt, shorten <= 1pt] (right_child) -- (rightright_grandchild);
-        \draw[->, shorten >= 1pt, shorten <= 1pt] (right_child) -- (rightleft_grandchild);
-        
-        \draw[->, shorten >= 1pt, shorten <= 1pt] (leftright_grandchild) -- (low_child_1);
-        \draw[->, shorten >= 1pt, shorten <= 1pt] (leftright_grandchild) -- (low_child_2);
-
-        \only<2>{
-        \node[node, color=red] at (0,1.5)(root_type){$t=\{\}$};
-        
-        \node[node, color=red] at (3,0)(right_child_type){$t=\{2\}$};
-        \node[node, color=red] at (4,-1.5)(rightright_grandchild_type){$t=\{2,3\}$};
-        \node[node, color=red] at (2,-1.5)(rightleft_grandchild_type){$t=\{2,3\}$};
-        
-        \node[node, color=red] at (-3,0)(left_child_type){$t=\{2\}$};
-        \node[node, color=red] at (-4,-1.5)(leftleft_grandchild_type){$t=\{2,4\}$};
-        \node[node, color=red] at (-1,-1.5)(leftright_grandchild_type){$t=\{2,4\}$};
-        
-        \node[node, color=red] at (-2,-3)(low_child_1_type){$t=\{1,2,4\}$};
-        \node[node, color=red] at (0,-3)(low_child_2_type){$t=\{1,2,4\}$};
-        
-        }
-
-    \end{tikzpicture}
+\begin{tikzpicture}[
+node/.style = {scale=1},
+scale = 1
+]
+\node[node] at (0,2)(root){\(\R^d\)};
+\node[node] at (3,.5)(right_child){\(x_2 > 0\)};
+\node[node] at (4,-1)(rightright_grandchild){$x_3 > 1$};
+\node[node] at (2,-1)(rightleft_grandchild){\(x_3 \leq 1\)};
+\node[node] at (-3,.5)(left_child){\(x_2 \leq 0\)};
+\node[node] at (-4,-1)(leftleft_grandchild){$x_4 \leq -1$};
+\node[node] at (-1,-1)(leftright_grandchild){\(x_4 > -1\)};
+\node[node] at (-2,-2.5)(low_child_1){$x_1 \leq -0.5$};
+\node[node] at (-0,-2.5)(low_child_2){$x_1 > -0.5$};
+\draw[->, shorten >= 1pt, shorten <= 1pt] (root) -- (left_child);
+\draw[->, shorten >= 1pt, shorten <= 1pt] (root) -- (right_child);
+\draw[->, shorten >= 1pt, shorten <= 1pt] (left_child) -- (leftleft_grandchild);
+\draw[->, shorten >= 1pt, shorten <= 1pt] (left_child) -- (leftright_grandchild);
+\draw[->, shorten >= 1pt, shorten <= 1pt] (right_child) -- (rightright_grandchild);
+\draw[->, shorten >= 1pt, shorten <= 1pt] (right_child) -- (rightleft_grandchild);
+\draw[->, shorten >= 1pt, shorten <= 1pt] (leftright_grandchild) -- (low_child_1);
+\draw[->, shorten >= 1pt, shorten <= 1pt] (leftright_grandchild) -- (low_child_2);
+\only<2>{
+\node[node, color=red] at (0,1.5)(root_type){$t=\{\}$};
+\node[node, color=red] at (3,0)(right_child_type){$t=\{2\}$};
+\node[node, color=red] at (4,-1.5)(rightright_grandchild_type){$t=\{2,3\}$};
+\node[node, color=red] at (2,-1.5)(rightleft_grandchild_type){$t=\{2,3\}$};
+\node[node, color=red] at (-3,0)(left_child_type){$t=\{2\}$};
+\node[node, color=red] at (-4,-1.5)(leftleft_grandchild_type){$t=\{2,4\}$};
+\node[node, color=red] at (-1,-1.5)(leftright_grandchild_type){$t=\{2,4\}$};
+\node[node, color=red] at (-2,-3)(low_child_1_type){$t=\{1,2,4\}$};
+\node[node, color=red] at (0,-3)(low_child_2_type){$t=\{1,2,4\}$};
+}
+\end{tikzpicture}
 \end{center}
 }
-
 \only<2>{
 $\Rightarrow$ Degree of interaction in each node is \(|t|\).
 }
-    
-\end{frame}
+\end{framev}
 
-\begin{frame}{Decomposition for Decision Trees}
-    
+
+\begin{framev}[align=top]{Decomposition for Decision Trees}
 % [show that one decision tree directly comes with its functional decomposition using indicator functions]\\
-
 Here: Decomposition via indicator functions
 $$
 \fh(\xv) = g_\emptyset + g_{2,4}(x_2, x_4) + g_{2,3}(x_2, x_3) + g_{1, 2, 4}(x_1, x_2, x_4)
 $$
-$\implies$ Decomposition has no main effect, but model certainly contains an effect of e.g. $x_2$
-
-$\implies$ Lower-order effects ``hidden'' inside higher-order terms
-
-$\leadsto$ reading from decision tree not enough, ``bad decomposition''
+$\implies$ Decomposition has no main effect, but model certainly contains an effect of e.g. $x_2$\\
+\spacer[0.25]
+$\implies$ Lower-order effects ``hidden'' inside higher-order terms\\
+\spacer[0.25]
+$\leadsto$ reading from decision tree not enough, ``bad decomposition''\\
 
 % \textbf{Problem again: uniqueness} If only reading from decision tree using indicator functions, lower-order effects may be hidden inside higher-order terms? \\
 
 % Above example: Decomposition no main effect, but model certainly contains main effect of e.g. $x_2$.\\
 
 \pause
-\medskip
+\spacer[0.25]
 \textbf{Note:} \furtherreading{YANG2024} propose a (quite complicated) solution for this case
 % \(\Rightarrow\) Too complicated? Rather explain this in constraint-chapter or in other methods-chapter?
-
-\end{frame}
-
+\end{framev}
 
 
-\begin{frame}{Example: EBM}
-
-    \begin{itemize}
-        \item See before: \textbf{GAMs} have functional decomposition by definition
-        \item \textbf{EBMs:} Sum of the final one- and two-dimensional components
-        % \item \textbf{Similar: EBMs} Use the final one- and two-dimensional components % visualized in the end
-        {
-        \centering
-        \includegraphics[width=\linewidth]{figure/final_ebm.png}
-        }
-        \only<2>{
-        \item In general: Model with functional decomposition up to max. order 2 is always ``inherently interpretable''
-        \item \textbf{Reason:} Visualization of all components
-        } 
-    \end{itemize}
-    
-\end{frame}
+\begin{framev}[align=top]{Example: EBM}
+\begin{itemizeM}
+\item See before: \textbf{GAMs} have functional decomposition by definition
+\item \textbf{EBMs:} Sum of the final one- and two-dimensional components
+% \item \textbf{Similar: EBMs} Use the final one- and two-dimensional components % visualized in the end
+\imageC[0.9]{figure/final_ebm.png}
+\only<2>{
+\item In general: Model with functional decomposition up to max. order 2 is always ``inherently interpretable''
+\item \textbf{Reason:} Visualization of all components
+}
+\end{itemizeM}
+\end{framev}
 
 % \begin{frame}{High-dimensional modl representation (HDMR)}
 %     [explain link to HDMR?? Or at end of chapter ?]

--- a/slides/functional-decompositions_interactions/slides02-fd-standard-fANOVA.tex
+++ b/slides/functional-decompositions_interactions/slides02-fd-standard-fANOVA.tex
@@ -4,7 +4,7 @@
 \input{../../latex-math/basic-math}
 \input{../../latex-math/basic-ml}
 % Defines macros and environments
- \newcommand{\open}{}
+\newcommand{\open}{}
 \newcommand{\close}{}
 
 \newcommand{\predvar}{Var\left[\hat{f}(\xv)\right]}
@@ -13,7 +13,6 @@
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
 
@@ -24,164 +23,141 @@ Functional ANOVA
 }{
 figure/25-05-31_Hooker_2004_graph_fANOVA
 }{
-
 \item One method for functional decomposition: Classical functional ANOVA (fANOVA)
 \item Algorithm for calculating the components in a fANOVA
 \item Variance decomposition in fANOVA
-
 }
 
 
-\begin{frame}{Introduction and History of fANOVA}
-
-\begin{itemize}
-    \item One possible method to obtain functional decomposition
-    \item Since 1940's: Developed under different names in mathematics and sensitivity analysis
-    \item Since 1990's: Developed for probability distributions or statistical data
-    \item Since 2000's: Applied to machine learning, subsequently alternatives developed extending applicability
-    \item \textbf{Assumption}: Independent features
-\end{itemize}
-
+\begin{framei}[align=top]{Introduction and History of fANOVA}
+\item One possible method to obtain functional decomposition
+\item Since 1940's: Developed under different names in mathematics and sensitivity analysis
+\item Since 1990's: Developed for probability distributions or statistical data
+\item Since 2000's: Applied to machine learning, subsequently alternatives developed extending applicability
+\item \textbf{Assumption}: Independent features
 % @ Sobol-Hoeffding Decomposition: erstes Paper von (Sobol? Hoeffding?) in 1950, nur im Unit Cube, allererste HDMR \\
-
 % Sobol in 90'ern
-
 % Sensitivity analysis
-
 % Hooker paper
-    
-\end{frame}
+\end{framei}
 
-\begin{frame}{Standard fANOVA: Idea}
 
-    \begin{itemize}
-        \item Example:
-        \begin{equation*}
-            \fh(x_1, x_2) = 4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2
-        \end{equation*}
-        \pause
-        \item \textbf{First idea:} Make sure higher-order terms don't contain lower-order terms \\
-        \(\Rightarrow\) First compute lower-order terms, then higher-order terms. \\
-        % \pause
-        % \item \textbf{Question:} How to compute lower-order terms? \\
-        % \(\leadsto\) First step: Use feature effect methods for main effects, here: PDP
-        \pause
-        \item \textbf{Second idea:} In 1st step, compute main effects using feat effect methods \\
-        Here: PDP + more general PD-functions
-        \pause
-        \item \textbf{Idea for fANOVA:} PD-function $\fh_{S;PD} =$ sum of all components $g_{\tilde{S}}$ up to this order
-        $$
-        \fh_{S;PD}(\xv_S) \; = \; \sum_{V \subseteq S} g_{V}(\xv_V)
-        $$
-        \pause
-        \item \textbf{Remember:} \\ Idea of PDPs or general PD-functions: Average out all other features
-        \item[$\Rightarrow$] Total formula for calculating the components \(g_S\) in the fANOVA algorithm:
-        % $$
-        % \begin{aligned}
-        \begin{multline*}
-            g_{S} (\xv_S)
-            \;=\; (\text{average out all features not contained in } S) \\
-            \;-\; (\text{All lower-order components})
-        \end{multline*}
-        % \end{aligned}
-        % $$
-    \end{itemize}
+\begin{framei}[align=top]{Standard fANOVA: Idea}
+\item Example:
+$$
+\fh(x_1, x_2) = 4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2
+$$
+\pause
+\item \textbf{First idea:} Make sure higher-order terms don't contain lower-order terms \\
+$\Rightarrow$ First compute lower-order terms, then higher-order terms. \\
+% \pause
+% \item \textbf{Question:} How to compute lower-order terms? \\
+% \(\leadsto\) First step: Use feature effect methods for main effects, here: PDP
+\pause
+\item \textbf{Second idea:} In 1st step, compute main effects using feat effect methods \\
+Here: PDP + more general PD-functions
+\pause
+\item \textbf{Idea for fANOVA:} PD-function $\fh_{S;PD} =$ sum of all components $g_{\tilde{S}}$ up to this order
+$$
+\fh_{S;PD}(\xv_S) \; = \; \sum_{V \subseteq S} g_{V}(\xv_V)
+$$
+\pause
+\item \textbf{Remember:} \\ Idea of PDPs or general PD-functions: Average out all other features
+\item[$\Rightarrow$] Total formula for calculating the components $g_S$ in the fANOVA algorithm:
+% $$
+% \begin{aligned}
+\begin{multline*}
+g_{S} (\xv_S)
+\;=\; (\text{average out all features not contained in } S) \\
+\;-\; (\text{All lower-order components})
+\end{multline*}
+% \end{aligned}
+% $$
+% \textbf{Idea:} Main effects via feature effect methods, here: PDP\\
+% Starting with the main effects: % One can use one of the global feature effect plots, since they exactly provide a function only depending on one feature, which models the effect of this feature on \(\fh\).
+% \textit{Link to PDP??} \\
+% $g_{S'}$
+% \(\Rightarrow\) fANOVA uses the same idea as PDPs, but also for higher-order terms: the resp. feature is fixed and all other features are simply averaged out. \\
+\end{framei}
 
-    % \textbf{Idea:} Main effects via feature effect methods, here: PDP\\
-    % Starting with the main effects: % One can use one of the global feature effect plots, since they exactly provide a function only depending on one feature, which models the effect of this feature on \(\fh\).
-    % \textit{Link to PDP??} \\
-    
-    % $g_{S'}$
-    % \(\Rightarrow\) fANOVA uses the same idea as PDPs, but also for higher-order terms: the resp. feature is fixed and all other features are simply averaged out. \\
-    
-\end{frame}
 
-\begin{frame}{Formal Definition and Computation
+\begin{framev}[align=top]{Formal Definition and Computation
 \furtherreading{HOOKER2004}
 }
-
 % Components are recursively defined using marginals (here $-S = \{1, \ldots, p \} \setminus S$ denotes the set of all indizes not contained in \(S\)):
 \begin{definition}
-    Recursive computation using PD-functions \\
-    (here $-S = \{1, \ldots, p \} \setminus S$ denotes all indices not contained in \(S\)):
-    \begin{align*}
-    g_{S}(\xv_S)
-        & = \fh_{S;PD}(\xv_S) - \sum_{V \subsetneqq S} g_V(\xv_V)
-        % = \mathbb{E}_{\Xv_{-S}} \left[\fh(\xv_S, \Xv_{-S}) \; \middle\vert \; \xv_S \right] - \sum_{V \subsetneqq S} g_V(\xv_V)
-        = \mathbb{E}_{\Xv_{-S}} \left[ \; \fh(\xv_S, \Xv_{-S}) \; \right] - \sum_{V \subsetneqq S} g_V(\xv_V) \\
-        & = \int \fh(\xv_S, \xv_{-S}) d \mathbb{P}(\xv_{-S}) - \sum_{V \subsetneqq S} g_V(\xv_V)
-    \end{align*}
+Recursive computation using PD-functions \\
+(here $-S = \{1, \ldots, p \} \setminus S$ denotes all indices not contained in \(S\)):
+\begin{align*}
+g_{S}(\xv_S)
+& = \fh_{S;PD}(\xv_S) - \sum_{V \subsetneqq S} g_V(\xv_V)
+% = \mathbb{E}_{\Xv_{-S}} \left[\fh(\xv_S, \Xv_{-S}) \; \middle\vert \; \xv_S \right] - \sum_{V \subsetneqq S} g_V(\xv_V)
+= \mathbb{E}_{\Xv_{-S}} \left[ \; \fh(\xv_S, \Xv_{-S}) \; \right] - \sum_{V \subsetneqq S} g_V(\xv_V) \\
+& = \int \fh(\xv_S, \xv_{-S}) d \mathbb{P}(\xv_{-S}) - \sum_{V \subsetneqq S} g_V(\xv_V)
+\end{align*}
 \end{definition}
+\begin{itemizeM}
+\item Expectation integrates $\fh(\xv)$ over all input features except $\xv_S$
+% \item Subtract all components $g_V$ with $V \subsetneqq S$ to remove all lower-order effects and center the effect
+\item Subtract sum of $g_V$ to remove all lower-order effects and center the effect
+\item \textbf{Note:} If no distribution given: Uniform distribution or plain integral
+\end{itemizeM}
+\end{framev}
 
-\begin{itemize}
-    \item Expectation integrates $\fh(\xv)$ over all input features except $\xv_S$
-    % \item Subtract all components $g_V$ with $V \subsetneqq S$ to remove all lower-order effects and center the effect
-    \item Subtract sum of $g_V$ to remove all lower-order effects and center the effect
-    \item \textbf{Note:} If no distribution given: Uniform distribution or plain integral
-\end{itemize}
 
-\end{frame}
-
-\begin{frame}{Formal Definition and Computation
+\begin{framev}[align=top]{Formal Definition and Computation
 \furtherreading{HOOKER2004}
 }
-
 % Components are recursively defined using marginals (here $-S = \{1, \ldots, p \} \setminus S$ denotes the set of all indizes not contained in \(S\)):
 \begin{definition}
-    Recursive computation using PD-functions \\
-    (here $-S = \{1, \ldots, p \} \setminus S$ denotes all indices not contained in \(S\)):
-    \begin{align*}
-    g_{S}(\xv_S)
-        & = \fh_{S;PD}(\xv_S) - \sum_{V \subsetneqq S} g_V(\xv_V)
-        % = \mathbb{E}_{\Xv_{-S}} \left[\fh(\xv_S, \Xv_{-S}) \; \middle\vert \; \xv_S \right] - \sum_{V \subsetneqq S} g_V(\xv_V)
-        = \mathbb{E}_{\Xv_{-S}} \left[ \; \fh(\xv_S, \Xv_{-S}) \; \right] - \sum_{V \subsetneqq S} g_V(\xv_V)
-    \end{align*}
+Recursive computation using PD-functions \\
+(here $-S = \{1, \ldots, p \} \setminus S$ denotes all indices not contained in \(S\)):
+\begin{align*}
+g_{S}(\xv_S)
+& = \fh_{S;PD}(\xv_S) - \sum_{V \subsetneqq S} g_V(\xv_V)
+% = \mathbb{E}_{\Xv_{-S}} \left[\fh(\xv_S, \Xv_{-S}) \; \middle\vert \; \xv_S \right] - \sum_{V \subsetneqq S} g_V(\xv_V)
+= \mathbb{E}_{\Xv_{-S}} \left[ \; \fh(\xv_S, \Xv_{-S}) \; \right] - \sum_{V \subsetneqq S} g_V(\xv_V)
+\end{align*}
 \end{definition}
+\begin{itemizeM}
+% \pause
+\item Recursive computation:
+\begin{align*}
+g_{\open \emptyset \close} &= \mathbb{E}_\Xv\left[\fh(\Xv)\right] \\
+g_{\open j \close}(x_j) &= \mathbb{E}_{\Xv_{-j}}\left[\fh(\Xv) \; \vert  \; X_j = x_j \right] - g_{\open \emptyset \close}, \; \forall j \in \{1, \ldots, p\} \\% \text{ and } g_{\open 2 \close}(x_2) = \mathbb{E}_{X_{-2}}\left[\fh(\xv) \; \vert  \; x_2 \right] - g_{\open \emptyset \close}  \\
+%g_{\open 2 \close}(x_2) &= \mathbb{E}_{X_{-2}}\left[\fh(\xv) \; \vert  \; x_2 \right] - g_{\open \emptyset \close} \\
+% g_{\open j, k \close}(x_j, x_k)
+% &= \mathbb{E}_{X_{-\{ j,k \}}}\left[\fh(\xv) \; \vert \; x_j, x_k \right] - g_{\open k \close}(x_k) - g_{\open j \close}(x_j) - g_{\open \emptyset \close}, \; \forall j < k\\%,  \text{ etc.}\\
+& \vdots \\
+g_{\open 1, \dots, p \close}(\xv)
+& = \fh(\xv) -
+\textstyle\sum_{S \subsetneqq \{1,\ldots,p\}} g_{S}(\xv_S) \\
+& = \fh(\xv) -
+%\textstyle\sum_{S \subsetneqq \{1,\ldots,p\}} g_{S}(\xv_S)
+g_{\open 1, \dots, p-1 \close}(x_{1}, \dots x_{p-1}) - \dots - g_{\open 1, 2 \close}(x_1, x_2) \\
+%&\phantom{{}={}}
+& \quad - g_{\open p \close}(x_p)  - \dots - g_{\open 2 \close}(x_2) - g_{\open 1 \close}(x_1) - g_{\open \emptyset \close}
+\end{align*}
+\end{itemizeM}
+\end{framev}
 
-\begin{itemize}
-    % \pause
-    \item Recursive computation:
-    \begin{align*}
-        g_{\open \emptyset \close} &= \mathbb{E}_\Xv\left[\fh(\Xv)\right] \\
-        g_{\open j \close}(x_j) &= \mathbb{E}_{\Xv_{-j}}\left[\fh(\Xv) \; \vert  \; X_j = x_j \right] - g_{\open \emptyset \close}, \; \forall j \in \{1, \ldots, p\} \\% \text{ and } g_{\open 2 \close}(x_2) = \mathbb{E}_{X_{-2}}\left[\fh(\xv) \; \vert  \; x_2 \right] - g_{\open \emptyset \close}  \\
-        %g_{\open 2 \close}(x_2) &= \mathbb{E}_{X_{-2}}\left[\fh(\xv) \; \vert  \; x_2 \right] - g_{\open \emptyset \close} \\
-        % g_{\open j, k \close}(x_j, x_k)
-        % &= \mathbb{E}_{X_{-\{ j,k \}}}\left[\fh(\xv) \; \vert \; x_j, x_k \right] - g_{\open k \close}(x_k) - g_{\open j \close}(x_j) - g_{\open \emptyset \close}, \; \forall j < k\\%,  \text{ etc.}\\
-        & \vdots \\
-        g_{\open 1, \dots, p \close}(\xv)
-        & = \fh(\xv) -
-        \textstyle\sum_{S \subsetneqq \{1,\ldots,p\}} g_{S}(\xv_S) \\
-        & = \fh(\xv) -
-        %\textstyle\sum_{S \subsetneqq \{1,\ldots,p\}} g_{S}(\xv_S) 
-        g_{\open 1, \dots, p-1 \close}(x_{1}, \dots x_{p-1}) - \dots - g_{\open 1, 2 \close}(x_1, x_2) \\
-        %&\phantom{{}={}} 
-        & \quad - g_{\open p \close}(x_p)  - \dots - g_{\open 2 \close}(x_2) - g_{\open 1 \close}(x_1) - g_{\open \emptyset \close}
-    \end{align*}
 
-\end{itemize}
-        
-\end{frame}
-
-\begin{frame}{Standard fANOVA -- Example}
+\begin{framev}[align=top]{Standard fANOVA -- Example}
 \textbf{Example:} $\fh(\xv) = 2 + x_1^2 - x_2^2 + x_1 \cdot x_2$ (e.g., for $x_1 = 5$ and $x_2 = 10$ we have $\fh(\xv) = -23$)
-
-\begin{itemize}
-    \item Computation of components using feature values $x_1 = x_2 = (-10, -9, \ldots, 10)^\top$ gives:
-    \begin{columns}[c, totalwidth=\linewidth]
-    \begin{column}{0.75\textwidth}
-        \includegraphics[width = \textwidth]{figure/decomposition}
-    \end{column}
-    \begin{column}{0.25\textwidth}
-    For $x_1 = 5$ and $x_2 = 10$:\\
-    \begin{itemize}
-        \item $g_{\open \emptyset \close} = 2$
-        \item $g_{\open 1 \close}(x_1) = -9.67$
-        \item $g_{\open 2 \close}(x_2) = -65.33$
-        \item $g_{\open 1,2 \close}(x_1, x_2) = 50$
-        \item[$\Rightarrow$] $\fh(\xv) = -23$
-    \end{itemize}
-    \end{column}
-    \end{columns}
+\begin{itemizeM}
+\item Computation of components using feature values $x_1 = x_2 = (-10, -9, \ldots, 10)^\top$ gives:
+\splitVCC[0.7]{
+\image{figure/decomposition}
+}{
+For $x_1 = 5$ and $x_2 = 10$:\\
+\begin{itemizeM}
+\item $g_{\open \emptyset \close} = 2$
+\item $g_{\open 1 \close}(x_1) = -9.67$
+\item $g_{\open 2 \close}(x_2) = -65.33$
+\item $g_{\open 1,2 \close}(x_1, x_2) = 50$
+\item[$\Rightarrow$] $\fh(\xv) = -23$
+\end{itemizeM}
+}
 % \pause
 %     \item Vanishing condition means:
 %     \begin{itemize}
@@ -189,130 +165,112 @@ figure/25-05-31_Hooker_2004_graph_fANOVA
 %         \item Integral of $g_{1,2}$ over marginal distribution $x_1$ (or $x_2$) is always 0.
 %         %, i.e., for each slice at $x_1$ (and $x_2$), the integral of $g_{1,2}$ 
 %     \end{itemize}
-\end{itemize} 
-\end{frame}
+\end{itemizeM}
+\end{framev}
 
-\begin{frame}{Standard fANOVA - Example}
 
+\begin{framev}[align=top]{Standard fANOVA - Example}
 \textit{In-class task}
-
 %     [calculate a full complete example] \\
-
 %     Analytic examples from Sobol (1993), Sobol (2001) or Hooker(2004))
-
 %     [several examples needed, can also include those from beginning]
-    
 %     [problem with examples from beginning: If using fANOVA, we do not get the original components out of it again, right?]
-
 %     -> exactly that is the case, explain the reason here: some averaged part of interaction term is moved into lower order, we need this in fANOVA, because we need a data-driven / formula-agnostic way of computing the components
-
 %     -> use the in-class calculation task here to illustrate this
-    
-\end{frame}
+\end{framev}
 
-\begin{frame}{Standard fANOVA - Example revisited}
 
+\begin{framev}[align=top]{Standard fANOVA - Example revisited}
 \begin{example}
-
-    % $$
-    % \fh(x_1, x_2) = x_1^2 + \sin(\pi x_1) \cos(\pi x_2)
-    % \qquad (x_1, x_2) \in [0,2]^2,
-    % $$
-
-    % Use fANOVA algorithm on example from the beginning:
-    
-    $$
-        \fh(x_1, x_2) = 4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2 \qquad (x_1, x_2) \in [0,1]^2 \qquad \text{uniformly distributed}
-    $$
-    
-    \begin{itemize}
-        \item
-        \only<1>{
-        \textbf{Intercept:}
-        \begin{align*}
-        g_\emptyset
-        &= \mathbb{E} \Bigl[ \fh(x_1, x_2) \Bigr]
-        = \int_0^1 \! \int_0^1 4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2 \,dx_1\,dx_2 \\
-        &= 4
-            - \Bigl( \int_0^1 2x_1 \,dx_1 \Bigr)
-            + \Bigl( \int_0^1 0.3 e^{x_2} \,dx_2 \Bigr)
-            + \Bigl( \int_0^1 |x_1| \,dx_1 \Bigr) \Bigl( \int_0^1 x_2 \,dx_2 \Bigr) \\
-        &= 4
-            - 1
-            + 0.3 (e - 1)
-            + 0.5^2
-        = 2.95 + 0.3 e.
-        \end{align*}
-        }
-        \only<2>{
-        \textbf{First-order components:}
-        \begin{align*}
-        g_{1}(x_1)
-        &= \fh_{1;PD}(x_1) - g_\emptyset 
-        = \Bigl( \int_0^1 4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2 \,dx_2 \Bigr) - g_\emptyset \\
-        &= 4 - 2x_1 + 0.3 (e-1) + |x_1| \cdot \frac{1}{2} - (2.95 + 0.3e) \\
-        &= -2x_1 + 0.5|x_1| + 0.75 \\
-        % \end{align*}
-        % }
-        % \only<2>{
-        % \textbf{First-order components:}
-        % \begin{align*}
-        g_{2}(x_2)
-        &= \fh_{2;PD}(x_2) - g_\emptyset 
-        = \Bigl( \int_0^1 4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2 \,dx_1  \Bigr) - g_\emptyset \\
-        &= 4 - 1 + 0.3 e^{x_2} + \frac{1}{2} \cdot x_2 - (2.95 + 0.3e) \\
-        &= 0.3 e^{x_2} + 0.5x_2 - 0.3e + 0.05
-        \end{align*}
-        }
-        \only<3>{
-        \textbf{Second-order component:}
-        \begin{align*}
-        g_{12}(x_1, x_2)
-        &= \fh_{\{1,2\};PD}(x_1, x_2) - g_\emptyset - g_1(x_1) - g_2(x_2) \\
-        &= 4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2 - (2.95 + 0.3e) \\
-        &\quad - (-2x_1 + 0.5|x_1| + 0.75) - (0.3 e^{x_2} + 0.5x_2 - 0.3e + 0.05) \\
-        &= |x_1| x_2 - 0.5 |x_1| - 0.5 x_2 + 0.25
-        \end{align*}
-        \item[$\Rightarrow$] All components shifted to have mean 0
-        \item[$\Rightarrow$] Parts of $|x_1|x_2$, which intuitively seems to be the ``interaction term'', is attributed to the main effects (correctly, depends on distribution!)
-        }
-        
-    \end{itemize}
+% $$
+% \fh(x_1, x_2) = x_1^2 + \sin(\pi x_1) \cos(\pi x_2)
+% \qquad (x_1, x_2) \in [0,2]^2,
+% $$
+% Use fANOVA algorithm on example from the beginning:
+$$
+\fh(x_1, x_2) = 4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2 \qquad (x_1, x_2) \in [0,1]^2 \qquad \text{uniformly distributed}
+$$
+\begin{itemizeM}
+\item
+\only<1>{
+\textbf{Intercept:}
+\begin{align*}
+g_\emptyset
+&= \mathbb{E} \Bigl[ \fh(x_1, x_2) \Bigr]
+= \int_0^1 \! \int_0^1 4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2 \,dx_1\,dx_2 \\
+&= 4
+- \Bigl( \int_0^1 2x_1 \,dx_1 \Bigr)
++ \Bigl( \int_0^1 0.3 e^{x_2} \,dx_2 \Bigr)
++ \Bigl( \int_0^1 |x_1| \,dx_1 \Bigr) \Bigl( \int_0^1 x_2 \,dx_2 \Bigr) \\
+&= 4
+- 1
++ 0.3 (e - 1)
++ 0.5^2
+= 2.95 + 0.3 e.
+\end{align*}
+}
+\only<2>{
+\textbf{First-order components:}
+\begin{align*}
+g_{1}(x_1)
+&= \fh_{1;PD}(x_1) - g_\emptyset
+= \Bigl( \int_0^1 4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2 \,dx_2 \Bigr) - g_\emptyset \\
+&= 4 - 2x_1 + 0.3 (e-1) + |x_1| \cdot \frac{1}{2} - (2.95 + 0.3e) \\
+&= -2x_1 + 0.5|x_1| + 0.75 \\
+% \end{align*}
+% }
+% \only<2>{
+% \textbf{First-order components:}
+% \begin{align*}
+g_{2}(x_2)
+&= \fh_{2;PD}(x_2) - g_\emptyset
+= \Bigl( \int_0^1 4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2 \,dx_1  \Bigr) - g_\emptyset \\
+&= 4 - 1 + 0.3 e^{x_2} + \frac{1}{2} \cdot x_2 - (2.95 + 0.3e) \\
+&= 0.3 e^{x_2} + 0.5x_2 - 0.3e + 0.05
+\end{align*}
+}
+\only<3>{
+\textbf{Second-order component:}
+\begin{align*}
+g_{12}(x_1, x_2)
+&= \fh_{\{1,2\};PD}(x_1, x_2) - g_\emptyset - g_1(x_1) - g_2(x_2) \\
+&= 4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2 - (2.95 + 0.3e) \\
+&\quad - (-2x_1 + 0.5|x_1| + 0.75) - (0.3 e^{x_2} + 0.5x_2 - 0.3e + 0.05) \\
+&= |x_1| x_2 - 0.5 |x_1| - 0.5 x_2 + 0.25
+\end{align*}
+\item[$\Rightarrow$] All components shifted to have mean 0
+\item[$\Rightarrow$] Parts of $|x_1|x_2$, which intuitively seems to be the ``interaction term'', is attributed to the main effects (correctly, depends on distribution!)
+}
+\end{itemizeM}
 \end{example}
-    
-\end{frame}
+\end{framev}
 
-\begin{frame}{Estimate fANOVA in practice
+
+\begin{framev}[align=top]{Estimate fANOVA in practice
 % $\rightarrow$ Estimating Expectations
 }
-
 \textbf{Main part:} Calculate all PD-functions $\rightarrow$ \textbf{$2^p$ many PD-functions}
-
 Estimation of a single PD-function: \textbf{Sampling}
-
 (so-called \textbf{Monte-Carlo integration})
-\begin{itemize}
-    \item Same idea as for PDPs: Fix \textbf{grid values} for features $x_S$ \\
-    Here: Same grid for all features over the whole algorithm
-    \item Estimate integral by sampling: for grid value $\xv_S^*$:
-    $$
-    \fh_{S, PD}(\xv_S^*) 
-    = \mathbb{E}_{\Xv_{-S}} \left[ \; \fh(\xv_S^*, \Xv_{-S}) \; \right]
-    \approx \frac{1}{n} \sum_{i=1}^n \fh(\xv_S^*, \xv_{-S}^{(i)})
-    $$
-    \item Or: for each grid value $\xv_S^*$, sample only $n_s < n$ many random samples (e.g. sampling uniformly)
-\end{itemize}
-
+\begin{itemizeM}
+\item Same idea as for PDPs: Fix \textbf{grid values} for features $x_S$ \\
+Here: Same grid for all features over the whole algorithm
+\item Estimate integral by sampling: for grid value $\xv_S^*$:
+$$
+\fh_{S, PD}(\xv_S^*)
+= \mathbb{E}_{\Xv_{-S}} \left[ \; \fh(\xv_S^*, \Xv_{-S}) \; \right]
+\approx \frac{1}{n} \sum_{i=1}^n \fh(\xv_S^*, \xv_{-S}^{(i)})
+$$
+\item Or: for each grid value $\xv_S^*$, sample only $n_s < n$ many random samples (e.g. sampling uniformly)
+\end{itemizeM}
 % Estimating expectations over uniform distribution (or marginal distribution) using e.g. Monte-Carlo sampling
-
 % [explain Monte-Carlo integration]
-    
-\end{frame}
+\end{framev}
 
-\begin{frame}{Variance decomposition - Why ``functional ANOVA''?
+
+\begin{framev}[align=top]{Variance decomposition - Why ``functional ANOVA''?
 % Why is this method even called functional ANOVA?
 }
-
 \begin{itemize}[<+->]
 \item Decomp. of $\fh(\xv)$ allows for ``functional analysis of variance'' (fANOVA)
 %$$ \var\left[\hat{f}(\xv)\right] = \var\left[g_{\open \emptyset \close} + g_{\open 1 \close}(x_1) + \;\dots\; + g_{\open 1, 2 \close}(x_1, x_2) + \;\dots\; + g_{\open 1,\ldots,p \close}(\xv) \right]$$
@@ -325,12 +283,12 @@ Estimation of a single PD-function: \textbf{Sampling}
 If features independent $\Rightarrow$ additive decomposition of variance of $\fh$ possible without covariances:
 \begin{align*}
 \var & \left[ \hat{f}(\xv) \right]
- =  \var \Big[g_{\open \emptyset \close} + g_{\open 1 \close}(x_1) + \;\dots\; + g_{\open 1, 2 \close}(x_1, x_2) + \;\dots\; + g_{\open 1,\ldots,p \close}(\xv) \Big] \\
+=  \var \Big[g_{\open \emptyset \close} + g_{\open 1 \close}(x_1) + \;\dots\; + g_{\open 1, 2 \close}(x_1, x_2) + \;\dots\; + g_{\open 1,\ldots,p \close}(\xv) \Big] \\
 % &= \sum_{S \subseteq \{1, \dots, p\}} \var\left[g_{\open S \close}(\xv_S)\right]
 & = \var\left[g_{\open \emptyset \close}\right]
-    + \var\left[g_{\open 1 \close}(x_1)\right] + \;\dots\; 
-    + \var\left[g_{\open 1, 2 \close}(x_1, x_2)\right] + \;\dots\;
-    + \var\left[g_{\open 1,\ldots,p \close}(\xv)\right]
++ \var\left[g_{\open 1 \close}(x_1)\right] + \;\dots\;
++ \var\left[g_{\open 1, 2 \close}(x_1, x_2)\right] + \;\dots\;
++ \var\left[g_{\open 1,\ldots,p \close}(\xv)\right]
 \end{align*}
 % \begin{align*}
 % \var\left[\hat{f}(\xv)\right] &= \var\left[g_{\open \emptyset \close}\right] + \var\left[g_{\open 1 \close}(x_1)\right] + \var\left[g_{\open 2 \close}(x_2)\right] \\
@@ -338,11 +296,8 @@ If features independent $\Rightarrow$ additive decomposition of variance of $\fh
 % \end{align*}
 % \end{itemize}
 % \end{frame}
-
 \item In other words: Single components uncorrelated (see later)
-
 % \begin{frame}{Variance decomposition}
-
 % \begin{itemize}
 % \item Dividing by the prediction variance, yields fraction of variance explained by each term:
 % \item Fraction of variance explained by each term:
@@ -352,7 +307,6 @@ If features independent $\Rightarrow$ additive decomposition of variance of $\fh
 \;\dots\;
 \frac{\var\left[g_{\open 1, 2 \close}(x_1, x_2)\right]}{\predvar} \;\dots\; + \frac{\var\left[g_{\open 1,\ldots,p \close}(\xv)\right]}{\predvar}
 \end{align*}
-
 \item[$\rightarrow$] \textbf{Sobol index}: Fraction of variance explained by some component $g_{\open V \close}(\xv_V)$:
 $$
 S_V = \frac{\var\left[g_{\open V \close}(\xv_V)\right]}{\var\left[\hat{f}(\xv)\right]}
@@ -360,8 +314,7 @@ $$
 $\leadsto$ Usable as importance measure of component $g_{\open V \close}(\xv_V)$\\
 % $\leadsto$ Small $S_V$ values $\Rightarrow$ Component $g_{\open V \close}$ does not explain much of total variance of $\fh$
 \end{itemize}
-
-\end{frame}
+\end{framev}
 
 
 

--- a/slides/functional-decompositions_interactions/slides03-fd-h-statistic.tex
+++ b/slides/functional-decompositions_interactions/slides03-fd-h-statistic.tex
@@ -4,13 +4,12 @@
 \input{../../latex-math/basic-math}
 \input{../../latex-math/basic-ml}
 % Defines macros and environments
- 
+
 \newcommand{\Xv}{\mathbf{X}} % vector X (random variable, bold)
 
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
 
@@ -21,265 +20,224 @@ Friedman's H-Statistic
 }{
 figure/h-statistic
 }{
-
 \item Friedman's H-statistic with two purposes:
 \item Measure general $k$-way interactions between arbitrary features
 \item Measure a single feature's overall interaction strength
-
 }
 
 
-
-
-\begin{frame}{Idea \furtherreading{POPESCU2008}}
-
-    \textbf{2-way interaction:}
-    \begin{itemize}[<+->]
-        \item Two features $j$ and $k$ do not interact, if their 2-way interaction component in functional decomposition $g_{\{j,k\}}$ is 0
-        \item Idea from standard fANOVA: PD-function contains all components:
-        $$
-        \fh_{\{jk\}, PD}(x_j, x_k)
-        = g_\emptyset + g_j(x_j) + g_k(x_k) + g_{\{j,k\}}(x_j, x_k)
-        $$
-        \item Here: \textbf{Centered PD-functions} $\fh_{S,PD}^c(\xv_S) = \fh_{S,PD}(\xv_S) - g_\emptyset$
-        $$
-        \Rightarrow \fh^c_{\{jk\}, PD}(x_j, x_k)
-        = g_j(x_j) + g_k(x_k) + g_{\{j,k\}}(x_j, x_k)
-        $$
-        \item \textbf{Definition:} A function $\fh$ contains no 2-way interactions between $j$ and $k$, if there exists a decomposition
-        \begin{align*}
+\begin{framev}[align=top]{Idea \furtherreading{POPESCU2008}}
+\textbf{2-way interaction:}
+\begin{itemizeM}
+\item<+-> Two features $j$ and $k$ do not interact, if their 2-way interaction component in functional decomposition $g_{\{j,k\}}$ is 0
+\item<+-> Idea from standard fANOVA: PD-function contains all components:
+$$
+\fh_{\{jk\}, PD}(x_j, x_k)
+= g_\emptyset + g_j(x_j) + g_k(x_k) + g_{\{j,k\}}(x_j, x_k)
+$$
+\item<+-> Here: \textbf{Centered PD-functions} $\fh_{S,PD}^c(\xv_S) = \fh_{S,PD}(\xv_S) - g_\emptyset$
+$$
+\Rightarrow \fh^c_{\{jk\}, PD}(x_j, x_k)
+= g_j(x_j) + g_k(x_k) + g_{\{j,k\}}(x_j, x_k)
+$$
+\item<+-> \textbf{Definition:} A function $\fh$ contains no 2-way interactions between $j$ and $k$, if there exists a decomposition
+\begin{align*}
             % & \fh_{\{jk\}, PD}(x_j, x_k)
             % = g_\emptyset + g_j(x_j) + g_k(x_k) \\
             % \Leftrightarrow \quad
-            & \fh_{\{jk\}, PD}^c(x_xj, x_k)
-            = g_j(x_j) + g_k(x_k) \\
-            \Leftrightarrow \quad
-            & \fh_{\{jk\}, PD}^c(x_j, x_k)
-            = \fh^c_{j, PD}(x_j) + \fh^c_{k, PD}(x_k)
-        \end{align*}
-        \item This means: There are interactions \\
-        $\Leftrightarrow$ Every possible decomp. must contain some non 0 term $g_{\{j,k\}}(x_j, x_k)$
-        \item Again: remember GAMs
-    \end{itemize}
-    
+& \fh_{\{jk\}, PD}^c(x_j, x_k)
+= g_j(x_j) + g_k(x_k) \\
+\Leftrightarrow \quad
+& \fh_{\{jk\}, PD}^c(x_j, x_k)
+= \fh^c_{j, PD}(x_j) + \fh^c_{k, PD}(x_k)
+\end{align*}
+\item<+-> This means: There are interactions \\
+$\Leftrightarrow$ Every possible decomp. must contain some non 0 term $g_{\{j,k\}}(x_j, x_k)$
+\item<+-> Again: remember GAMs
+\end{itemizeM}
 % 	$$\fh_{jk, PD}(x_j, x_k) = \fh_{j, PD}(x_j) + \fh_{k, PD}(x_k)$$
-
 % \begin{itemize}
 % 	\item $\fh_{jk, PD}(x_j, x_k)$: joint 2-dim PD function of feature $j$ and $k$
 % 	\item $\fh_{j, PD}(x_j)$ and $\fh_{k, PD}(x_k)$: 1-dim PD functions of single features $j$ and $k$
 % \end{itemize}
-
-\end{frame}
-
+\end{framev}
 
 
-\begin{frame}{Idea \furtherreading{POPESCU2008}}
-
+\begin{framev}[align=top]{Idea \furtherreading{POPESCU2008}}
 \textbf{3-way interaction:}
-\begin{itemize}[<+->]
-    \item \textbf{Definition:} $\fh$ contains no 3-way interactions between features $ i, j, k $, if corresponding 3-dimensional PD-function can be decomposed into lower-order terms:
-    \begin{align*}
-        \fh_{\{ijk\}, PD}(x_i, x_j, x_k)
-        = g_\emptyset
-            &+ g_i(x_i) + g_j(x_j) + g_k(x_k) \\
-            &+ g_{\{i,j\}}(x_i, x_j) + g_{\{i,k\}}(x_i, x_k) + g_{\{i,j\}}(x_j, x_k)
-    \end{align*}
-    \item \textbf{Example}:
-    $$
-    \fh(x_1, x_2, x_3) = - 2x_1 - 2\sin(x_3) + |x_1|x_2 - \sin(x_2 x_3) + 1
-    $$
-    \item
-    \textbf{Note:} Again using centered PD-functions $\fh^c_{S, PD}$ instead of components $g_S$ \\
-    $\leadsto$ things get complicated, e.g. for 3 features, definition becomes:
-    \begin{align*}
-        \fh^c_{\{ijk\}, PD}(x_i, x_j, x_k)
-        = & \fh^c_{\{ij\}, PD}(x_i, x_j) + \fh^c_{\{ik\}, PD}(x_i, x_k) + \fh^c_{\{jk\}, PD}(x_j, x_k) \\
-        & - \fh^c_{i, PD}(x_i) - \fh^c_{j, PD}(x_j) - \fh^c_{k, PD}(x_k)
-    \end{align*}
-\end{itemize}
-
-\end{frame}
+\begin{itemizeM}
+\item<+-> \textbf{Definition:} $\fh$ contains no 3-way interactions between features $i, j, k$, if corresponding 3-dimensional PD-function can be decomposed into lower-order terms:
+\begin{align*}
+\fh_{\{ijk\}, PD}(x_i, x_j, x_k)
+= g_\emptyset
+&+ g_i(x_i) + g_j(x_j) + g_k(x_k) \\
+&+ g_{\{i,j\}}(x_i, x_j) + g_{\{i,k\}}(x_i, x_k) + g_{\{j,k\}}(x_j, x_k)
+\end{align*}
+\item<+-> \textbf{Example}:
+$$
+\fh(x_1, x_2, x_3) = - 2x_1 - 2\sin(x_3) + |x_1|x_2 - \sin(x_2 x_3) + 1
+$$
+\item<+-> \textbf{Note:} Again using centered PD-functions $\fh^c_{S, PD}$ instead of components $g_S$ \\
+$\leadsto$ things get complicated, e.g. for 3 features, definition becomes:
+\begin{align*}
+\fh^c_{\{ijk\}, PD}(x_i, x_j, x_k)
+= & \fh^c_{\{ij\}, PD}(x_i, x_j) + \fh^c_{\{ik\}, PD}(x_i, x_k) + \fh^c_{\{jk\}, PD}(x_j, x_k) \\
+& - \fh^c_{i, PD}(x_i) - \fh^c_{j, PD}(x_j) - \fh^c_{k, PD}(x_k)
+\end{align*}
+\end{itemizeM}
+\end{framev}
 
 
-
-\begin{frame}{Idea \furtherreading{POPESCU2008}}
-
+\begin{framev}[align=top]{Idea \furtherreading{POPESCU2008}}
 \textbf{$k$-way interaction:}
-\begin{itemize}
-    \item \textbf{Analogous} for $k$-way interactions between feat $S = \{ i_1, i_2, \dots, i_k \}$: No $k$-way interaction, if
-    \begin{align*}
-        &\fh_{S, PD}( x_{i_1}, x_{i_2}, \dots, x_{i_k} )
-        = \sum_{V \subsetneqq S} g_{V}(\xv_V)
-        = \sum_{\substack{V \subseteq S \\ |V|<k}} g_{V}(\xv_V)
-    \end{align*}
-\end{itemize}
+\begin{itemizeM}
+\item \textbf{Analogous} for $k$-way interactions between feat $S = \{i_1, i_2, \dots, i_k\}$: No $k$-way interaction, if
+\begin{align*}
+&\fh_{S, PD}(x_{i_1}, x_{i_2}, \dots, x_{i_k})
+= \sum_{V \subsetneqq S} g_{V}(\xv_V)
+= \sum_{\substack{V \subseteq S \\ |V| < k}} g_{V}(\xv_V)
+\end{align*}
+\end{itemizeM}
 \pause
 \textbf{Overall interaction:}
-\begin{itemize}
-    \item Question: Does feature $j$ interact with any other feature at all?
-    \item[$\Rightarrow$] H-statistic analogous to 2-way interactions, but for feature sets $S = \{j\}$ and $-S = \{1, \dots, p\}\setminus \{j\}$ instead of two single features: \\
+\begin{itemizeM}
+\item Question: Does feature $j$ interact with any other feature at all?
+\item[$\Rightarrow$] H-statistic analogous to 2-way interactions, but for feature sets $S = \{j\}$ and $-S = \{1, \dots, p\}\setminus \{j\}$ instead of two single features: \\
     % \item If feature $j$ does not interact with any other feature (denoted by index $-j$), the mean-centered prediction function can be decomposed by
-    \pause
-    $$
-    \fh(\xv) - g_\emptyset
-    = \fh^c_{\{1, \dots, p\}, PD}(\xv)
-    = \fh^c_{j, PD}(x_j) +  \fh^c_{-j, PD}(\xv_{-j})
-    = \sum_{\substack{S: j \in S \\ \mid S \mid \geq 2}} g_S(\xv_S)
-    $$
-    \begin{itemize}
-        \item $-j$ denotes $-S = \{1, \dots, p\}\setminus \{j\}$, i.e. all other features
+\pause
+$$
+\fh(\xv) - g_\emptyset
+= \fh^c_{\{1, \dots, p\}, PD}(\xv)
+= \fh^c_{j, PD}(x_j) + \fh^c_{-j, PD}(\xv_{-j})
+= \sum_{\substack{S: j \in S \\ |S| \geq 2}} g_S(\xv_S)
+$$
+\begin{itemizeS}
+\item $-j$ denotes $-S = \{1, \dots, p\}\setminus \{j\}$, i.e. all other features
     	% \item $\fh(\xv)$: mean-centered prediction function
     	% \item $\fh_{j, PD}(x_j)$: 1-dim PD function of feature $j$
-    	\item $\fh_{-j, PD}(\xv_{-j})$: $(p-1)$-dim PD function of all $p$ features except feature $j$
-    \end{itemize}
-\end{itemize}
-    
-\end{frame}
+\item $\fh_{-j, PD}(\xv_{-j})$: $(p - 1)$-dim PD function of all $p$ features except feature $j$
+\end{itemizeS}
+\end{itemizeM}
+\end{framev}
 
 
-
-\begin{frame}{2-way Interaction Strength}
-\begin{itemize}[<+->]
-    \item \textbf{Question:} How to measure interaction strength without computing functional decomposition components $g_S$?
-    \item \textbf{Idea:} Only use centered PD-functions
-
-    $$
-    \fh_{\{jk\}, PD}^c(x_j, x_k)
-            = \fh^c_{j, PD}(x_j) + \fh^c_{k, PD}(x_k) \text{ ?}
-    $$
-    
-    \item \textbf{H-statistic} for 2-way interaction between feature $j$ and $k$:
-    \begin{align*}
-    H^2_{jk}
-    & = \frac{
-        \var \left[ \fh^c_{jk,PD}(X_j, X_k) - \fh^c_{j, PD}(X_j) - \fh^c_{k, PD}(X_k) \right]
-    }{ \var \left[ \fh^c_{jk,PD}(X_j, X_k) \right] } \\
-    & = \frac{
-        \sum_{i=1}^n \left( \fh^c_{jk,PD}(x_j^{(i)}, x_k^{(i)})
-        - \fh^c_{j, PD}(x_j^{(i)}) - \fh^c_{k, PD}(x_k^{(i)}) \right)^2
-    }{
-        \sum_{i=1}^n \left( \fh^c_{jk,PD}(x_j^{(i)}, x_k^{(i)}) \right)^2
-    }
-    \end{align*}
-    \item[$\Rightarrow$]
-    $H^2_{jk}$ measures strength of this interaction quantitatively \\
+\begin{framei}[align=top]{2-way Interaction Strength}
+\item<+-> \textbf{Question:} How to measure interaction strength without computing functional decomposition components $g_S$?
+\item<+-> \textbf{Idea:} Only use centered PD-functions
+$$
+\fh_{\{jk\}, PD}^c(x_j, x_k)
+= \fh^c_{j, PD}(x_j) + \fh^c_{k, PD}(x_k) \text{ ?}
+$$
+\item<+-> \textbf{H-statistic} for 2-way interaction between feature $j$ and $k$:
+\begin{align*}
+H^2_{jk}
+& = \frac{
+\var \left[ \fh^c_{jk,PD}(X_j, X_k) - \fh^c_{j, PD}(X_j) - \fh^c_{k, PD}(X_k) \right]
+}{\var \left[ \fh^c_{jk,PD}(X_j, X_k) \right]} \\
+& = \frac{
+\sum_{i=1}^n \left( \fh^c_{jk,PD}(x_j^{(i)}, x_k^{(i)})
+- \fh^c_{j, PD}(x_j^{(i)}) - \fh^c_{k, PD}(x_k^{(i)}) \right)^2
+}{
+\sum_{i=1}^n \left( \fh^c_{jk,PD}(x_j^{(i)}, x_k^{(i)}) \right)^2
+}
+\end{align*}
+\item<+->[$\Rightarrow$]
+$H^2_{jk}$ measures strength of this interaction quantitatively \\
     % The smaller the values of $H^2_{jk}$, the weaker the interaction between $x_j$ and $x_k$.
-    $H^2_{jk}$ small (close to 0) for weak interaction, close to 1 for strong interaction
-    \item \textbf{Note:} Again, definition also usable without probabilities or data distrib.
-\end{itemize}
-
+$H^2_{jk}$ small (close to 0) for weak interaction, close to 1 for strong interaction
+\item<+-> \textbf{Note:} Again, definition also usable without probabilities or data distrib.
 % \textbf{Note}: The numerator is $0$ if the two features $x_j$ and $x_k$ do not interact, i.e., $\fh_{jk, PD}(x_j, x_k) - \fh_{j, PD}(x_j) - \fh_{k, PD}(x_k) = 0$.
-
-
 %\footnote[frame]{Friedman, Jerome H., and Bogdan E. Popescu (2008). Predictive learning via rule ensembles. The Annals of Applied Statistics. JSTOR, 916–54.}
-
-\end{frame}
-
+\end{framei}
 
 
-\begin{frame}{H-statistic: Examples}
+\begin{framev}[align=top]{H-statistic: Examples}
 \textbf{Note:} Again, definition also usable without any probability or data distribution
 \begin{example}
-    \begin{align*}
-    \fh(x_1, x_2) & = 4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2
-    \quad (x_1, x_2) \in [0,1]^2 \\
+\begin{align*}
+\fh(x_1, x_2) & = 4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2
+\quad (x_1, x_2) \in [0,1]^2 \\
     % g_\emptyset = 2.95 + 0.3 e. \\
-    \fh^c_{1, PD}(x_1) & = -2x_1 + 0.5|x_1| + 0.75 \\
-    \fh^c_{2, PD}(x_2) & = 0.3 e^{x_2} + 0.5x_2 - 0.3e + 0.05 \\
-    \fh^c_{1,2;PD}(x_1, x_2) & = 1.05 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2 - 0.3e \\
-    \only<2>{
-    \implies H^2_{12}
-    = & \frac{
-        \var \left[ \fh^c_{jk,PD}(X_j, X_k) - \fh^c_{j, PD}(X_j) - \fh^c_{k, PD}(X_k) \right]
-    }{ \var \left[ \fh^c_{jk,PD}(X_j, X_k) \right] }
+\fh^c_{1, PD}(x_1) & = -2x_1 + 0.5|x_1| + 0.75 \\
+\fh^c_{2, PD}(x_2) & = 0.3 e^{x_2} + 0.5x_2 - 0.3e + 0.05 \\
+\fh^c_{1,2;PD}(x_1, x_2) & = 1.05 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2 - 0.3e \\
+\only<2>{
+\implies H^2_{12}
+= & \frac{
+\var \left[ \fh^c_{jk,PD}(X_j, X_k) - \fh^c_{j, PD}(X_j) - \fh^c_{k, PD}(X_k) \right]
+}{\var \left[ \fh^c_{jk,PD}(X_j, X_k) \right]}
     % = \frac{
     %     \mathbb{E} \left[ \left( \fh^c_{jk,PD}(X_j, X_k) - \fh^c_{j, PD}(X_j) - \fh^c_{k, PD}(X_k) \right)^2 \right]
     % }{ \mathbb{E} \left[ \left( \fh^c_{jk,PD}(X_j, X_k) \right)^2 \right] }
-    \\
-    = & \frac{
-        \mathbb{E} \left[ \left( |x_1|x_2 - 0.5|x_1| - 0.5x_2 + 0.25 \right)^2 \right]
-    }{
-        \mathbb{E} \left[ \left( 1.05 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2 - 0.3e \right)^2 \right]
-    }
-    > 0
-    }
-    \end{align*}    
+\\
+= & \frac{
+\mathbb{E} \left[ \left( |x_1|x_2 - 0.5|x_1| - 0.5x_2 + 0.25 \right)^2 \right]
+}{
+\mathbb{E} \left[ \left( 1.05 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2 - 0.3e \right)^2 \right]
+}
+> 0
+}
+\end{align*}
 \end{example}
 % \begin{example}
 %     \textit{from in-class task}
 % \end{example}
-\end{frame}
+\end{framev}
 
 
-
-\begin{frame}{3-way Interaction Strength}
-\begin{itemize}
-    \item Same idea as for 2-way, but different formula (see before): %\\
+\begin{framei}[align=top]{3-way Interaction Strength}
+\item Same idea as for 2-way, but different formula (see before): %\\
     % No interaction, if
-    \begin{align*}
-        \fh^c_{\{ijk\}, PD}(x_i, x_j, x_k)
-        =\; & \fh^c_{\{ij\}, PD}(x_i, x_j) + \fh^c_{\{ik\}, PD}(x_i, x_k) + \fh^c_{\{jk\}, PD}(x_j, x_k) \\
-        & - \fh^c_{i, PD}(x_i) - \fh^c_{j, PD}(x_j) - \fh^c_{k, PD}(x_k)
-    \end{align*}
-    \item[$\Rightarrow$] H-statistic for a 3-way interaction between features $i$, $j$ and $k$:
-    \begin{align*}
-        H^2_{ijk}
-        & = \frac{ \var \left[ \substack{\textstyle
-        \fh^c_{ijk, PD}(X_i, X_j, X_k)
-        - \fh^c_{ij, PD}(X_i, X_j) - \fh^c_{ik, PD}(X_i, X_k) - \fh^c_{jk, PD}(X_j, X_k) \\ \textstyle
-        + \fh^c_{i, PD}(X_i) + \fh^c_{j, PD}(X_j) + \fh^c_{k, PD}(X_k)
-        }
-        \right]
-        }{ \var \left[ \fh^c_{ijk, PD}(X_i, X_j, X_k) \right] }
-    \end{align*}
-    \item Analogous for higher order interactions, but more complicated
-\end{itemize}
-\end{frame}
+\begin{align*}
+\fh^c_{\{ijk\}, PD}(x_i, x_j, x_k)
+=\; & \fh^c_{\{ij\}, PD}(x_i, x_j) + \fh^c_{\{ik\}, PD}(x_i, x_k) + \fh^c_{\{jk\}, PD}(x_j, x_k) \\
+& - \fh^c_{i, PD}(x_i) - \fh^c_{j, PD}(x_j) - \fh^c_{k, PD}(x_k)
+\end{align*}
+\item[$\Rightarrow$] H-statistic for a 3-way interaction between features $i$, $j$ and $k$:
+\begin{align*}
+H^2_{ijk}
+& = \frac{\var \left[ \substack{\textstyle
+\fh^c_{ijk, PD}(X_i, X_j, X_k)
+- \fh^c_{ij, PD}(X_i, X_j) - \fh^c_{ik, PD}(X_i, X_k) - \fh^c_{jk, PD}(X_j, X_k) \\ \textstyle
++ \fh^c_{i, PD}(X_i) + \fh^c_{j, PD}(X_j) + \fh^c_{k, PD}(X_k)
+}
+\right]
+}{\var \left[ \fh^c_{ijk, PD}(X_i, X_j, X_k) \right]}
+\end{align*}
+\item Analogous for higher order interactions, but more complicated
+\end{framei}
 
 
-
-\begin{frame}{Overall Interaction Strength}
-
-\begin{itemize}
-    \item Measure overall strength of interactions between feat $j$ and all other feats
-    \item[$\Rightarrow$] \textbf{H-statistic} analogous to 2-way interaction:
-    \begin{align*}
-        H^2_{j}
-        & = \frac{
-            \var \left[ \fh^c(\Xv) - \fh^c_{j, PD}(X_j) - \fh^c_{-j, PD}(\Xv_{-j}) \right]
-        }{ \var \left[ \fh^c(\Xv) \right] } \\
-        & = \frac{
-            \sum_{i=1}^n \left( \fh^c(\xv^{(i)}) - \fh^c_{j, PD}(x_j^{(i)}) - \fh^c_{-j, PD}(\xv_{-j}^{(i)})  \right)^2
-        }{
-            \sum_{i=1}^n \left( \fh^c(\xv^{(i)}) \right)^2
-        }
-    \end{align*}
-\end{itemize}
-
+\begin{framei}[align=top]{Overall Interaction Strength}
+\item Measure overall strength of interactions between feat $j$ and all other feats
+\item[$\Rightarrow$] \textbf{H-statistic} analogous to 2-way interaction:
+\begin{align*}
+H^2_{j}
+& = \frac{
+\var \left[ \fh^c(\Xv) - \fh^c_{j, PD}(X_j) - \fh^c_{-j, PD}(\Xv_{-j}) \right]
+}{\var \left[ \fh^c(\Xv) \right]} \\
+& = \frac{
+\sum_{i=1}^n \left( \fh^c(\xv^{(i)}) - \fh^c_{j, PD}(x_j^{(i)}) - \fh^c_{-j, PD}(\xv_{-j}^{(i)}) \right)^2
+}{
+\sum_{i=1}^n \left( \fh^c(\xv^{(i)}) \right)^2
+}
+\end{align*}
 % Similarly, it is possible to measure whether a feature $j$ interacts with any other feature (Overall interaction strength):
-
-\end{frame}
-
+\end{framei}
 
 
-\begin{frame}{H-statistic: Example}
-
+\begin{framev}[align=top]{H-statistic: Example}
 Measure interactions of a random forest for the bike data set
-
-\begin{center}
-	\includegraphics[width=\textwidth]{figure/h-statistic}
-\end{center}
-
+\imageC{figure/h-statistic}
 \pause
 \textbf{Remarks and Conclusion:}
-\begin{itemize}
-    \item H-statistic provides \textbf{general definition of interactions} + an \textbf{algorithm for computation} \\
-    Also adjustable to categorical / discrete features and / or function values
-    \item For interaction order $k$ still needs $¸\approx 2^k$ PD-functions
-    \item Statistical test for whether interactions are present using this statistic
-\end{itemize}
-
-\end{frame}
+\begin{itemizeM}
+\item H-statistic provides \textbf{general definition of interactions} + an \textbf{algorithm for computation} \\
+Also adjustable to categorical / discrete features and / or function values
+\item For interaction order $k$ still needs $\approx 2^k$ PD-functions
+\item Statistical test for whether interactions are present using this statistic
+\end{itemizeM}
+\end{framev}
 
 \endlecture
 \end{document}

--- a/slides/functional-decompositions_interactions/slides04-fd-constraints-and-theory.tex
+++ b/slides/functional-decompositions_interactions/slides04-fd-constraints-and-theory.tex
@@ -4,16 +4,13 @@
 \input{../../latex-math/basic-math}
 \input{../../latex-math/basic-ml}
 % Defines macros and environments
- \newcommand{\open}{}
+\newcommand{\open}{}
 \newcommand{\close}{}
-
 \newcommand{\Xv}{\mathbf{X}} % vector X (random variable, bold)
-
 
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 \begin{document}
 
@@ -24,137 +21,115 @@ Theory of Standard fANOVA
 }{
 figure/25-05-31_Hooker_2004_graph_fANOVA
 }{
-
 \item Properties of classical fANOVA, reason for its popularity
 \item Equivalent definition of classical fANOVA
 % \item Understanding why fANOVA theoretically works and what constraints it satisfies
 \item Understand the role constraints play for any functional decomposition
-
 }
 
 
-\begin{frame}{Example: fANOVA Algorithm}
-    \begin{itemize}
-        \item Remember: Functional decomposition in general not unique
-        \item \textbf{Standard fANOVA} only one possible approach
-        \item Example:
-        \begin{align*}
-            \fh(x_1, x_2) =\,&\,4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2 \\
-            =\,&\,\underbrace{2.95 + 0.3 e.}_{g_\emptyset} + \underbrace{-2x_1 + 0.5|x_1| + 0.75}_{g_1(x_1)} \\
-            \,&\,+ \underbrace{0.3 e^{x_2} + 0.5x_2 - 0.3e + 0.05}_{g_2(x_2)} + \underbrace{|x_1| x_2 - 0.5 |x_1| - 0.5 x_2 + 0.25}_{g_{1,2}(x_1, x_2)}
-        \end{align*}
-        $\leadsto$ seems arbitrarily chosen? \\
-        $\longleftrightarrow$ Show: Standard fANOVA fulfills specific desirable properties or \textbf{constraints}
-    \end{itemize}
-
+\begin{framei}[align=top]{Example: fANOVA Algorithm}
+\item Remember: Functional decomposition in general not unique
+\item \textbf{Standard fANOVA} only one possible approach
+\item Example:
+\begin{align*}
+\fh(x_1, x_2) =\,&\,4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2 \\
+=\,&\,\underbrace{2.95 + 0.3 e.}_{g_\emptyset} + \underbrace{-2x_1 + 0.5|x_1| + 0.75}_{g_1(x_1)} \\
+\,&\,+ \underbrace{0.3 e^{x_2} + 0.5x_2 - 0.3e + 0.05}_{g_2(x_2)} + \underbrace{|x_1| x_2 - 0.5 |x_1| - 0.5 x_2 + 0.25}_{g_{1,2}(x_1, x_2)}
+\end{align*}
+$\leadsto$ seems arbitrarily chosen? \\
+$\longleftrightarrow$ Show: Standard fANOVA fulfills specific desirable properties or \textbf{constraints}
     % See before: The definition of functional decompositions is by far not unique \\
-
     % BUT: The fANOVA Algo. yields a unique output / unique decomposition, seemingly "arbitrarily chosen".\\
-
     % \(\rightarrow\) Idea: Uniquely (Eindeutig?) characterize the solution of the fANOVA by its properties. These properties are expressed as mathematical constraints that describe the calculated decomposition.
-
     % \(\rightarrow\) Two equivalent ways of uniquely / completely defining this decomposition: Either by computation formula defining the single components, or by mathematical equations (the "constraints") defining what properties the components must fulfill
-    
-\end{frame}
+\end{framei}
 
-\begin{frame}{Constraints for standard fANOVA Algo.}
 
+\begin{framev}[align=top]{Constraints for standard fANOVA Algo.}
     % One can prove that our definition of the components fulfills the following conditions, called \textit{vanishing condition}:
-    \begin{theorem}
-    
-        Features independent $\implies$ The components defined by standard fANOVA fulfill the so-called \textit{vanishing conditions}:
-        \begin{align*}
-            \mathbb{E}_{X_j}\left[ g_{S}(\xv_S) \right]
-            = \int g_{S}(\xv_S) d \mathbb{P}(x_j) = 0 \quad \text{for any } j \in S \text{ and } S \subseteq \{1, \ldots, p\}
-        \end{align*}
-    \end{theorem}
-
+\begin{theorem}
+Features independent $\implies$ The components defined by standard fANOVA fulfill the so-called \textit{vanishing conditions}:
+\begin{align*}
+\mathbb{E}_{X_j}\left[ g_{S}(\xv_S) \right]
+= \int g_{S}(\xv_S) d \mathbb{P}(x_j) = 0 \quad \text{for any } j \in S \text{ and } S \subseteq \{1, \ldots, p\}
+\end{align*}
+\end{theorem}
     % For independent inputs, the \textit{vanishing condition} is required to obtain a unique solution:
     % $$\mathbb{E}_{X_j} (g_{S}(\xv_S)) = \int g_{S}(\xv_S) d \mathbb{P}(x_j) = 0, \forall j \in S, \forall S \subseteq \{1, \ldots, p\}$$
-
     % \textit{Proof that our definition fulfills these constraints? Not here}
-    
-    \pause 
+\pause
     % Vanishing conditions have the following implications:
-    \textbf{Implications:}
-    \begin{itemize}
-        \item 
-        For any component $g_{S}$, all its PD-functions are 0:
-        $$
-        \mathbb{E}_{X_V}\left[ g_{S}(\xv_S) \right]
-        = \int g_{S}(\xv_S) d \mathbb{P}(\xv_V) = 0 \quad \text{for any } V \subsetneqq S \text{ and } S \subseteq \{1, \ldots, p\}
-        $$
-        $\leadsto$ $g_{S}$ contains no lower-order effects, but only pure interaction term \\
-        (compare H-statistic)
+\textbf{Implications:}
+\begin{itemizeM}
+\item For any component $g_{S}$, all its PD-functions are 0:
+$$
+\mathbb{E}_{X_V}\left[ g_{S}(\xv_S) \right]
+= \int g_{S}(\xv_S) d \mathbb{P}(\xv_V) = 0 \quad \text{for any } V \subsetneqq S \text{ and } S \subseteq \{1, \ldots, p\}
+$$
+$\leadsto$ $g_{S}$ contains no lower-order effects, but only pure interaction term \\
+(compare H-statistic)
         % \item Marginalizing out $x_j, \forall j \in S$ for component $g_S(\xv_S)$ yields a constant 0\\
         % As we integrate out the marginal effect of $x_j, \forall j \in S$ on component $g_S(\xv_S)$ is zero (vanishes)\\
         % $\leadsto$ Makes sure that component $g_S(\xv_S)$ does not contain effects of $x_j, \forall j \in S$
         % For $|S| = 1$ this is equivalent to mean-centering the component $g_S(\xv_S)$. For $|S| > 1$
-        \pause
-        \item All components are orthogonal, i.e., mutually indep. and uncorrelated:
-        $$
-        \forall V \neq S: \quad \mathbb{E}_{\Xv} \bigl[ g_{V}(\xv_V) g_{S}(\xv_S) \bigr] = 0
-        $$
-        \item This implies variance decomposition used to define Sobol indices:
-    $ \var[ \fh(\xv) ] =  \textstyle\sum_{S \subseteq \{1,\ldots,p\}}  \var \left[ g_{S}(\xv_S) \right]$
-    \end{itemize}
-    
-\end{frame}
+\pause
+\item All components are orthogonal, i.e., mutually indep. and uncorrelated:
+$$
+\forall V \neq S: \quad \mathbb{E}_{\Xv} \bigl[ g_{V}(\xv_V) g_{S}(\xv_S) \bigr] = 0
+$$
+\item This implies variance decomposition used to define Sobol indices:
+$ \var[ \fh(\xv) ] = \textstyle\sum_{S \subseteq \{1,\ldots,p\}} \var \left[ g_{S}(\xv_S) \right]$
+\end{itemizeM}
+\end{framev}
 
-\begin{frame}{Examples revisited}
+
+\begin{framev}[align=top]{Examples revisited}
 \textbf{Example:} $\fh(\xv) = 2 + x_1^2 - x_2^2 + x_1 \cdot x_2$ (e.g., for $x_1 = 5$ and $x_2 = 10$ we have $\fh(\xv) = -23$)
-
-\begin{itemize}
-    \item Computation of components using feature values $x_1 = x_2 = (-10, -9, \ldots, 10)^\top$ gives:
-    \begin{columns}[c, totalwidth=\linewidth]
-    \begin{column}{0.75\textwidth}
-        \includegraphics[width = \textwidth]{figure/decomposition}
-    \end{column}
-    \begin{column}{0.25\textwidth}
-    For $x_1 = 5$ and $x_2 = 10$:\\
-    \begin{itemize}
-        \item $g_{\open \emptyset \close} = 2$
-        \item $g_{\open 1 \close}(x_1) = -9.67$
-        \item $g_{\open 2 \close}(x_2) = -65.33$
-        \item $g_{\open 1,2 \close}(x_1, x_2) = 50$
-        \item[$\Rightarrow$] $\fh(\xv) = -23$
-    \end{itemize}
-    \end{column}
-    \end{columns}
+\begin{itemizeM}
+\item Computation of components using feature values $x_1 = x_2 = (-10, -9, \ldots, 10)^\top$ gives:
+\splitVCC[0.7]{
+\image{figure/decomposition}
+\spacer[0]
+}{
+For $x_1 = 5$ \& $x_2 = 10$:\\
+\begin{itemizeM}
+\item $g_{\open \emptyset \close} = 2$
+\item $g_{\open 1 \close}(x_1) = -9.67$
+\item $g_{\open 2 \close}(x_2) = -65.33$
+\item $g_{\open 1,2 \close}(x_1, x_2) = 50$
+\item[$\Rightarrow$] $\fh(\xv) = -23$
+\end{itemizeM}
+}
 % \pause
-    \item Vanishing condition means:
-    \begin{itemize}
-        \item $g_1$ and $g_2$ are mean-centered w.r.t. marginal distribution of $x_1$ and $x_2$
-        \item Integral of $g_{1,2}$ over marginal distribution $x_1$ (or $x_2$) is always 0.
+\item Vanishing condition means:
+\begin{itemizeS}
+\item $g_1$ and $g_2$ are mean-centered w.r.t. marginal distribution of $x_1$ and $x_2$
+\item Integral of $g_{1,2}$ over marginal distribution $x_1$ (or $x_2$) is always 0.
         %, i.e., for each slice at $x_1$ (and $x_2$), the integral of $g_{1,2}$ 
-    \end{itemize}
-\end{itemize} 
-\end{frame}
+\end{itemizeS}
+\end{itemizeM}
+\end{framev}
 
-\begin{frame}{Examples revisited}
 
-    \begin{example}
-        \begin{align*}
-            \fh(x_1, x_2) =\,&\,4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2 \\
-                =\,&\,\underbrace{2.95 + 0.3 e.}_{g_\emptyset} + \underbrace{-2x_1 + 0.5|x_1| + 0.75}_{g_1(x_1)} \\
-                \,&\,+ \underbrace{0.3 e^{x_2} + 0.5x_2 - 0.3e + 0.05}_{g_2(x_2)} + \underbrace{|x_1| x_2 - 0.5 |x_1| - 0.5 x_2 + 0.25}_{g_{1,2}(x_1, x_2)}
-        \end{align*}
-        \begin{itemize}
-            \item[$\implies$] Main effect terms inside $g_{1,2}$ are chosen exactly such that the one-dimensional PDPs of $g_{1,2}$ vanish
-            \item[$\implies$] Same for constant terms inside $g_1$ and $g_2$: Ensure centering
-        \end{itemize}
-    \end{example}
-
-    \pause
-    \begin{example}
-        From in-class exercise:
-        $
-        g(x_1,x_2)
-         = \beta_{12}\,(x_1-\mu_1)(x_2-\mu_2)
-        $
-    \end{example}
-    
-\end{frame}
+\begin{framev}[align=top]{Examples revisited}
+\begin{example}
+\begin{align*}
+\fh(x_1, x_2) =\,&\,4 - 2x_1 + 0.3 e^{x_2} + |x_1|x_2 \\
+=\,&\,\underbrace{2.95 + 0.3 e.}_{g_\emptyset} + \underbrace{-2x_1 + 0.5|x_1| + 0.75}_{g_1(x_1)} \\
+\,&\,+ \underbrace{0.3 e^{x_2} + 0.5x_2 - 0.3e + 0.05}_{g_2(x_2)} + \underbrace{|x_1| x_2 - 0.5 |x_1| - 0.5 x_2 + 0.25}_{g_{1,2}(x_1, x_2)}
+\end{align*}
+\begin{itemizeM}
+\item[$\implies$] Main effect terms inside $g_{1,2}$ are chosen exactly such that the one-dimensional PDPs of $g_{1,2}$ vanish
+\item[$\implies$] Same for constant terms inside $g_1$ and $g_2$: Ensure centering
+\end{itemizeM}
+\end{example}
+\pause
+\begin{example}
+From in-class exercise:
+$g(x_1,x_2) = \beta_{12}\,(x_1-\mu_1)(x_2-\mu_2)$
+\end{example}
+\end{framev}
 
 % \begin{frame}{...}
 
@@ -162,22 +137,17 @@ figure/25-05-31_Hooker_2004_graph_fANOVA
     
 % \end{frame}
 
-\begin{frame}{Constraints: Equivalent characterization}
-
-    \begin{itemize}[<+->]
-    
-        \item So far: Definition of standard fANOVA implies vanishing conditions
-        \item Opposite is true as well: \\
-        Features independent $\implies$ Any functional decomposition fulfilling the vanishing conditions must be the standard fANOVA decomposition.
-        \item In other words: Vanishing conditions are equivalent characterization
-        \item In general: Functional decomp. can be defined by sets of constraints \\
-        \item Many other methods to compute decompositions exist, each with their set of constraints
-    
-    \end{itemize}
-
+\begin{framev}[align=top]{Constraints: Equivalent characterization}
+\begin{itemizeM}
+\item<+-> So far: Definition of standard fANOVA implies vanishing conditions
+\item<+-> Opposite is true as well: \\
+Features independent $\implies$ Any functional decomposition fulfilling the vanishing conditions must be the standard fANOVA decomposition.
+\item<+-> In other words: Vanishing conditions are equivalent characterization
+\item<+-> In general: Functional decomp. can be defined by sets of constraints \\
+\item<+-> Many other methods to compute decompositions exist, each with their set of constraints
+\end{itemizeM}
     % NB: One can also start the other way around, i.e. define fANOVA using the constraints it should fulfill, and then mathematically prove that the single components must have this form.
-    
-\end{frame}
+\end{framev}
 
 % \begin{frame}{Connection to PDP, H-statistics}
 
@@ -196,8 +166,5 @@ figure/25-05-31_Hooker_2004_graph_fANOVA
 %     More generally, the H-statistic is a measure of the strength of a specific interaction, which can in general be applied to any model or any function.
      
 % \end{frame}
-
-
-
 \endlecture
 \end{document}

--- a/slides/functional-decompositions_interactions/slides05-fd-other-methods.tex
+++ b/slides/functional-decompositions_interactions/slides05-fd-other-methods.tex
@@ -4,7 +4,7 @@
 \input{../../latex-math/basic-math}
 \input{../../latex-math/basic-ml}
 % Defines macros and environments
- \newcommand{\open}{}
+\newcommand{\open}{}
 \newcommand{\close}{}
 
 \newcommand{\Xv}{\mathbf{X}} % vector X (random variable, bold)
@@ -13,9 +13,8 @@
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
-\begin{document} 
+\begin{document}
 
 \titlemeta{
 Functional Decompositions
@@ -24,93 +23,77 @@ Further Methods
 }{
 figure/25-05-31_Hooker_2004_graph_fANOVA
 }{
-
 \item Limitations of classical fANOVA
 \item Alternatives: Generalized fANOVA and ALE
 % \item Overcoming these limitations with generalized fANOVA
 % \item How ALE Plots can be used as another, different approach to obtain functional decompositions
 % \item Sobol-Hoeffding decomposition ??
 \item Advantages and relevance of functional decompositions
-
 }
 
 
-\begin{frame}{Limitations of classical fANOVA}
+\begin{framev}[align=top]{Limitations of classical fANOVA}
+\begin{itemizeM}
+\item Standard fANOVA builds on PD-functions
+\item \textit{Remember:} Problems of PDPs for \textbf{correlated / dependent features}
+\item Here: Dependent features $\implies$ Standard fANOVA does NOT fulfill vanishing conditions %(Similar problem also for H-statistic, although may still offer some insight)
+% Without independence, the vanishing condition, the orthogonality condition and the variance decomposition all do not hold anymore, so the single components do not capture the pure interaction anymore.
+\end{itemizeM}
+\pause
+\begin{example}
+Assume dependency $2x_1^2 = x_2$ and
+$$
+\fh(x_1, x_2, x_3) = - 2x_1 - 2\sin(x_3) + |x_1|x_2 + 0.5 x_2 x_3 + 1.
+$$
+% $$
+% \fh(x_1, x_2, x_3) = - 2x_1 - 2\sin(x_3) + |x_1|x_2 + 0.5 x_1 x_2 x_3 - \sin(x_2 x_3) + 1
+% $$
+$\leadsto$ Following two decompositions would both ``make sense'':
+\begin{align*}
+\fh(x_1, x_2, x_3)
+= \underbrace{1}_{g_\emptyset}
++ \underbrace{(- 2x_1)}_{g_1(x_1)}
++ \underbrace{(- 2\sin(x_3))}_{g_3(x_3)}
++ \underbrace{|x_1|x_2}_{g_{1,2}(x_1, x_2)}
++ \underbrace{0.5 x_2 x_3}_{g_{2,3}(x_2, x_3)} \\
+\fh(x_1, x_2, x_3)
+= \underbrace{1}_{g_\emptyset}
++ \underbrace{(- 2x_1 + 2 |x_1|^3)}_{g_1(x_1)}
++ \underbrace{(- 2\sin(x_3))}_{g_3(x_3)}
++ \underbrace{x_1^2 x_3}_{g_{2,3}(x_1, x_3)}
+\end{align*}
+\end{example}
+\pause
+$\rightarrow$ Extreme example, but again: Problem of definition
+% [Example going wrong with correlated features]
+\end{framev}
 
-    \begin{itemize}
-    
-        \item Standard fANOVA builds on PD-functions
-        
-        \item \textit{Remember:} Problems of PDPs for \textbf{correlated / dependent features}
-        \item Here: Dependent features $\implies$ Standard fANOVA does NOT fulfill vanishing conditions %(Similar problem also for H-statistic, although may still offer some insight)
-        % Without independence, the vanishing condition, the orthogonality condition and the variance decomposition all do not hold anymore, so the single components do not capture the pure interaction anymore.
-    \end{itemize}
-    \pause
-    \begin{example}
-        Assume dependency \(2x_1^2 = x_2\) and
-        \begin{equation*}
-            \fh(x_1, x_2, x_3) = - 2x_1 - 2\sin(x_3) + |x_1|x_2 + 0.5 x_2 x_3 + 1.
-        \end{equation*}
-        % $$
-        % \fh(x_1, x_2, x_3) = - 2x_1 - 2\sin(x_3) + |x_1|x_2 + 0.5 x_1 x_2 x_3 - \sin(x_2 x_3) + 1
-        % $$
-        $\leadsto$ Following two decompositions would both ``make sense'':
-        \begin{align*}
-            \fh(x_1, x_2, x_3)
-            = \underbrace{1}_{g_\emptyset}
-                + \underbrace{(- 2x_1)}_{g_1(x_1)} 
-                + \underbrace{(- 2\sin(x_3))}_{g_3(x_3)}
-                + \underbrace{|x_1|x_2}_{g_{1,2}(x_1, x_2)} 
-                + \underbrace{0.5 x_2 x_3}_{g_{2,3}(x_2, x_3)} \\
-            \fh(x_1, x_2, x_3)
-            = \underbrace{1}_{g_\emptyset}
-                + \underbrace{(- 2x_1 + 2 |x_1|^3)}_{g_1(x_1)} 
-                + \underbrace{(- 2\sin(x_3))}_{g_3(x_3)}
-                + \underbrace{x_1^2 x_3}_{g_{2,3}(x_1, x_3)}
-        \end{align*}
-    \end{example}
-    \pause
-    $\rightarrow$ Extreme example, but again: Problem of definition
 
-    % [Example going wrong with correlated features]
-
-    
-    
-\end{frame}
-
-\begin{frame}{Alternative: Generalized Functional ANOVA}
-
-\begin{itemize}
-    \item Algorithm proposed by \furtherreading{HOOKER2007}
-    \item Generalizes standard fANOVA to situations with dependent features
-    \pause
-    \item Showed: Generalized fANOVA is solution to so-called ``relaxed vanishing conditions'' \\
-    (i.e., weaker form of vanishing condition) \\
-    \item ``Relaxed vanishing conditions'' do not imply orthogonality, but ``hierarchical orthogonality'':
-    $$
-    \mathbb{E}_{\Xv} \bigl[ g_{V}(\xv_V) g_{S}(\xv_S) \bigr] = 0 \quad \forall V \subsetneqq S
-    $$
-    \pause
-    $\leadsto$ Only components are orthogonal where $g_{V}(\xv_V)$ is ``lower in hierarchy'' than $g_{S}(\xv_S)$
-    \item[$\implies$] Generalized fANOVA provides functional decomp. for arbitrary settings
-    \item \textbf{Advantage:} Also provides a variance decomposition
-    \pause
-    \item \textbf{Problems:}
-    \item Difficult to estimate, involves manual choice of a ``weight function''
-    \item Computationally very costly
-    
-\end{itemize}
-
-    % \textbf{N.B.:} For dependent inputs, \furtherreading{HOOKER2007} showed the existence of a unique solution for the components under a ``relaxed vanishing condition'' which leads to a ``hierarchical orthogonality''
-    % $$\mathbb{E}_{\Xv} (g_{V}(\xv_V) g_{S}(\xv_S)) = 0, \forall V \subsetneqq S$$
-    % $\leadsto$ Only components are orthogonal where features involved in $g_{V}(\xv_V)$ also appear in $g_{S}(\xv_S)$
-    % Only components where all features involved in one component $g_{V}(\xv_V)$ also appear in the other component $g_{S}(\xv_S)$ are orthogonal
-
-    % \pause
-
-    % \textit{[Also talk about constraints corresponding to generalized fANOVA ?]}
-    
-\end{frame}
+\begin{framei}[align=top]{Alternative: Generalized Functional ANOVA}
+\item Algorithm proposed by \furtherreading{HOOKER2007}
+\item Generalizes standard fANOVA to situations with dependent features
+\pause
+\item Showed: Generalized fANOVA is solution to so-called ``relaxed vanishing conditions'' \\
+(i.e., weaker form of vanishing condition) \\
+\item ``Relaxed vanishing conditions'' do not imply orthogonality, but ``hierarchical orthogonality'':
+$$
+\mathbb{E}_{\Xv} \bigl[ g_{V}(\xv_V) g_{S}(\xv_S) \bigr] = 0 \quad \forall V \subsetneqq S
+$$
+\pause
+$\leadsto$ Only components are orthogonal where $g_{V}(\xv_V)$ is ``lower in hierarchy'' than $g_{S}(\xv_S)$
+\item[$\implies$] Generalized fANOVA provides functional decomp. for arbitrary settings
+\item \textbf{Advantage:} Also provides a variance decomposition
+\pause
+\item \textbf{Problems:}
+\item Difficult to estimate, involves manual choice of a ``weight function''
+\item Computationally very costly
+% \textbf{N.B.:} For dependent inputs, \furtherreading{HOOKER2007} showed the existence of a unique solution for the components under a ``relaxed vanishing condition'' which leads to a ``hierarchical orthogonality''
+% $$\mathbb{E}_{\Xv} (g_{V}(\xv_V) g_{S}(\xv_S)) = 0, \forall V \subsetneqq S$$
+% $\leadsto$ Only components are orthogonal where features involved in $g_{V}(\xv_V)$ also appear in $g_{S}(\xv_S)$
+% Only components where all features involved in one component $g_{V}(\xv_V)$ also appear in the other component $g_{S}(\xv_S)$ are orthogonal
+% \pause
+% \textit{[Also talk about constraints corresponding to generalized fANOVA ?]}
+\end{framei}
 
 % \begin{frame}{Generalized fANOVA: Example}
 
@@ -118,43 +101,33 @@ figure/25-05-31_Hooker_2004_graph_fANOVA
     
 % \end{frame}
 
-\begin{frame}{Revisiting ALE Plots}
+\begin{framev}[align=top]{Revisiting ALE Plots}
+$$
+\hat{\tilde{f}}_{S, ALE}(x) = \sum_{k = 1}^{k_S(x)}\frac{1}{n_S(k)}\sum_{i: \; x_S^{(i)} \in \; [z_{k-1, S}, z_{k, S}]}\left[\fh(z_{k, S}, \xi_{-S}) -\fh(z_{k-1, S}, \xi_{-S})\right]
+$$
+\splitVCC{
+% \includegraphics[width = \textwidth]{figure/decomposition}
+\image{figure/ale1d}
+}{
+\image{figure/ale2d}
+}
+% \splitV{
+% \image{figure/ale1d}
+% }{
+% \image{figure/ale2d}
+% }
+\end{framev}
 
-    \[
-    \hat{\tilde{f}}_{S, ALE}(x) = \sum_{k = 1}^{k_S(x)}\frac{1}{n_S(k)}\sum_{i: \; x_S^{(i)} \in \; [z_{k-1, S}, z_{k, S}]}\left[\fh(z_{k, S}, \xi_{-S}) -\fh(z_{k-1, S}, \xi_{-S})\right]
-    \]
 
-    \begin{columns}[c, totalwidth=\linewidth]
-    \begin{column}{0.5\textwidth}
-        % \includegraphics[width = \textwidth]{figure/decomposition}
-        \includegraphics{figure/ale1d}
-    \end{column}
-    \begin{column}{0.5\textwidth}
-        \includegraphics{figure/ale2d}
-    \end{column}
-    \end{columns}
-
-    % \splitV{
-        % \image{figure/ale1d}
-    % }{
-        % \image{figure/ale2d}
-    % }
-    
-\end{frame}
-
-\begin{frame}{ALE Decomposition}
-
-    \begin{itemize}
-        \item One can define ALE plots for arbitrary many variables \\
-        (similar to PDPs vs. PD-functions)
-        \item[$\rightarrow$] Gives full functional decomposition of ALE plots
-        \pause
-        \item \textbf{Advantages:} Handle dependencies well + computationally fast
-        \item Constraints / orthogonality properties more complicated
-        \item[$\implies$] ALE decomp. theoretically more involved, but good alternative in practice
-    \end{itemize}
-    
-\end{frame}
+\begin{framei}[align=top]{ALE Decomposition}
+\item One can define ALE plots for arbitrary many variables \\
+(similar to PDPs vs. PD-functions)
+\item[$\rightarrow$] Gives full functional decomposition of ALE plots
+\pause
+\item \textbf{Advantages:} Handle dependencies well + computationally fast
+\item Constraints / orthogonality properties more complicated
+\item[$\implies$] ALE decomp. theoretically more involved, but good alternative in practice
+\end{framei}
 
 % \begin{frame}{Sobol-Hoeffding decomposition}
     
@@ -166,57 +139,43 @@ figure/25-05-31_Hooker_2004_graph_fANOVA
     
 % \end{frame}
 
-\begin{frame}{Conclusion: How useful are functional decompositions?}
-
-    % Obwohl fDecompositions eigtl (aus Interpretability-Sicht) die Lösung für alles wären / theoretisch die Endlösung sind, sind alle anderen Methoden trotzdem nötig, weil fDecompositions sehr schwierig \& kompliziert zu berechnen sind
-    % - Computation time skaliert exponentiell mit der Dimension / Anzahl features  =>  i.a. ist Erzwingen einer sparsen decomposition (s. GAMs / RPFs) die einzige realisitische Möglichkeit
-
-    \begin{itemize}
-        
-        \item If computed, offer many insights into a model / function, i.p. high-dim.
-        \item[$\rightarrow$] Complete analysis of all interactions
-        \pause
-        \item Very important theoretical concept:
-        \begin{itemize}
-            \item Theoretical framework for general definition of interact.-s (H-statistic)
-            \item Theoretical background for many IML methods:
-                GAMs and EBMs, 
-                ICE, PDPs and PD-functions,
-                ALE plots,
-                Shapley values,
-                Feature importance methods (see later)
-            % \item GAMs and EBMs
-            % \item ICE, PDPs and PD-functions
-            % \item ALE plots
-            % \item Shapley values (see later)
-            % \item Feature importance methods (see later)
-        \end{itemize}
-        \pause
-        \item In practice often infeasible ($2^p$ components for $p$ features)
-        \item[$\implies$] Often only sparse decompositions feasible (e.g. EBMs)
-        \pause
-        \item All single methods have disadvantages:
-        \begin{itemize}
-            \item Standard fANOVA: Only independent features + compute intensive
-            \item Generalized fANOVA: Even more computational intensive, eventually infeasible
-            \item ALE: No variance decomposition
-        \end{itemize}
-        
-    \end{itemize}
-
-    \pause
-    % Nevertheless, functional decompositions are a very important concept in machine learning interpretability because they explain the idea behind many other methods and enable a much better understanding of other methods.
-    \textbf{Overall:} Very important concept and theoretical background, explains idea behind many other methods
-    
-\end{frame}
-
-
-
-
-
-
-
-
+\begin{framev}[align=top]{Conclusion: How useful are functional decompositions?}
+% Obwohl fDecompositions eigtl (aus Interpretability-Sicht) die Lösung für alles wären / theoretisch die Endlösung sind, sind alle anderen Methoden trotzdem nötig, weil fDecompositions sehr schwierig \& kompliziert zu berechnen sind
+% - Computation time skaliert exponentiell mit der Dimension / Anzahl features  =>  i.a. ist Erzwingen einer sparsen decomposition (s. GAMs / RPFs) die einzige realisitische Möglichkeit
+\begin{itemizeM}
+\item If computed, offer many insights into a model / function, i.p. high-dim.
+\item[$\rightarrow$] Complete analysis of all interactions
+\pause
+\item Very important theoretical concept:
+\begin{itemizeS}
+\item Theoretical framework for general definition of interact.-s (H-statistic)
+\item Theoretical background for many IML methods:
+GAMs and EBMs,
+ICE, PDPs and PD-functions,
+ALE plots,
+Shapley values,
+Feature importance methods (see later)
+% \item GAMs and EBMs
+% \item ICE, PDPs and PD-functions
+% \item ALE plots
+% \item Shapley values (see later)
+% \item Feature importance methods (see later)
+\end{itemizeS}
+\pause
+\item In practice often infeasible ($2^p$ components for $p$ features)
+\item[$\implies$] Often only sparse decompositions feasible (e.g. EBMs)
+\pause
+\item All single methods have disadvantages:
+\begin{itemizeS}
+\item Standard fANOVA: Only independent features + compute intensive
+\item Generalized fANOVA: Even more computational intensive, eventually infeasible
+\item ALE: No variance decomposition
+\end{itemizeS}
+\end{itemizeM}
+\pause
+% Nevertheless, functional decompositions are a very important concept in machine learning interpretability because they explain the idea behind many other methods and enable a much better understanding of other methods.
+\textbf{Overall:} Very important concept and theoretical background, explains idea behind many other methods
+\end{framev}
 
 
 \endlecture


### PR DESCRIPTION
## Summary

Clean up the Functional Decompositions / Interactions lecture slide sources across all five decks:

- Normalize slide frames to project helpers such as `framei` and `framev` with explicit top alignment
- Replace raw `itemize`, `columns`, and `includegraphics` usage with project helpers like `itemizeM`, `itemizeS`, `splitVCC`, `image`, and `imageC`
- Remove redundant `\date{}` metadata and tidy preamble/title metadata formatting
- Reformat equations, examples, overlays, spacing, and frame structure for more consistent LaTeX source
- Apply small mechanical fixes in math/text syntax while preserving slide content

Touched files:

- `slides01-fd-intro-motivation.tex`
- `slides02-fd-standard-fANOVA.tex`
- `slides03-fd-h-statistic.tex`
- `slides04-fd-constraints-and-theory.tex`
- `slides05-fd-other-methods.tex`