### PR TITLE
refactor(slides): cleanup regional effects

### DIFF
--- a/slides/regional-effects/slides01-fe-regional-main.tex
+++ b/slides/regional-effects/slides01-fe-regional-main.tex
@@ -1,11 +1,11 @@
-\documentclass[10pt,compress,t,notes=noshow, xcolor=table]{beamer}
+\documentclass[10pt,compress,t,notes=noshow,xcolor=table]{beamer}
 
 \input{../../style/preamble}
 \input{../../latex-math/basic-math}
 \input{../../latex-math/basic-ml}
 
 \usepackage[dvipsnames]{xcolor}
-% \usepackage{lmodern} 
+% \usepackage{lmodern}
 
 % %  New colors
 \definecolor{ggRed}{HTML}{F8766D}
@@ -21,59 +21,58 @@
 \newcommand{\highlightFG}[1]{\colorbox{ForestGreen!70}{$\displaystyle #1$}}
 
 \usepackage{tikz}
-\usetikzlibrary{shapes,arrows,automata,positioning,calc,chains,trees, shadows}
+\usetikzlibrary{shapes,arrows,automata,positioning,calc,chains,trees,shadows}
 \tikzset{
-  %Define standard arrow tip
-  >=stealth',
-  %Define style for boxes
-  punkt/.style={
-    rectangle,
-    rounded corners,
-    draw=black, very thick,
-    text width=6.5em,
-    minimum height=2em,
-    text centered},
-  % Define arrow style
-  pil/.style={
-    ->,
-    thick,
-    shorten <=2pt,
-    shorten >=2pt,}
+%Define standard arrow tip
+>=stealth',
+%Define style for boxes
+punkt/.style={
+rectangle,
+rounded corners,
+draw=black, very thick,
+text width=6.5em,
+minimum height=2em,
+text centered},
+% Define arrow style
+pil/.style={
+->,
+thick,
+shorten <=2pt,
+shorten >=2pt,}
 }
 
 % definition of the style
-\tikzset{exampleblock/.style={rounded corners,rectangle split, rectangle split parts=4, draw, 
+\tikzset{exampleblock/.style={rounded corners,rectangle split,rectangle split parts=4,draw,
 rectangle split part fill={gray!20, gray!20, cice!20, orange!20},minimum width=0.3\textwidth
 }}
 \tikzset{main node/.style={rectangle,draw,minimum size=1cm,inner sep=4pt},}
 \usetikzlibrary{calc}
-\usetikzlibrary{chains, positioning, arrows, trees, shadows}
+\usetikzlibrary{chains,positioning,arrows,trees,shadows}
 %\input{figure/gear.tex}
 %http://tex.stackexchange.com/questions/6135/how-to-make-beamer-overlays-with-tikz-node
 \tikzset{
-  %Style of the black box
-  bbox/.style={draw, fill=black, minimum size=3cm,
-  label={[white, yshift=-1.3em]above:$in$},
-  label={[white, yshift=1.3em]below:$out$},
-  label={[rotate = 90, xshift=1em, yshift=0.5em]left:Black-Box}
-  },
-  multiple/.style={double copy shadow={shadow xshift=1.5ex,shadow
-  yshift=-0.5ex,draw=black!30,fill=white}},
+%Style of the black box
+bbox/.style={draw, fill=black, minimum size=3cm,
+label={[white, yshift=-1.3em]above:$in$},
+label={[white, yshift=1.3em]below:$out$},
+label={[rotate = 90, xshift=1em, yshift=0.5em]left:Black-Box}
+},
+multiple/.style={double copy shadow={shadow xshift=1.5ex,shadow
+yshift=-0.5ex,draw=black!30,fill=white}},
 }
 
 % for overlay box
 \usetikzlibrary{backgrounds,shapes.multipart}
 \pgfdeclarelayer{myback}
-\pgfsetlayers{background,main,myback} %<= insert the myback 
+\pgfsetlayers{background,main,myback} %<= insert the myback
 % after the "main" to display the content in front of the usual content
 
 
 % Defines macros and environments
- 
+
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 
 
@@ -112,177 +111,129 @@ figure/ale_plot.pdf
 
 
 
-\begin{frame}{Why regional explanations?}
-    \textbf{Problem:} PD \& ICE plots can be confounded by feature interactions.\\
-    %How to produce plots in which feature effects are less confounded by interactions? \\
-    %\textbf{Goal:} Identify groups of instances where ICE curves are homogeneous.\\
+\begin{framev}[align=top]{Why regional explanations?}
+\textbf{Problem:} PD \& ICE plots can be confounded by feature interactions.\\
+%How to produce plots in which feature effects are less confounded by interactions? \\
+%\textbf{Goal:} Identify groups of instances where ICE curves are homogeneous.\\
 %\textbf{Regional Effect Plots (REPs):} Group similar ICE curves so that interactions within each group are minimized.
-    \textbf{Solution:} Group homogeneous ICE curves in such a way that reduces the presence of individual interaction effects within a group \\$\leadsto$ Regional effect plots (REPs).
-  \noindent\makebox[\linewidth]{\rule{\textwidth}{0.4pt}}
-  \begin{columns}
-      \column{0.33\textwidth}
-      \centering
-      \textbf{Global Effect}
-      \begin{figure}
-          \centering
-          \includegraphics[width=.9\linewidth]{figure/01_bike_sharing_dataset_18_1.png}
-      \end{figure}
-
-      \hspace{2.5cm} % Horizontal spacing before the line      
-      \column{0.33\textwidth}
-      \centering
-      \textbf{Regional Effect (1)}
-        \begin{figure}
-          \centering
-          \includegraphics[width=.9\linewidth]{figure/01_bike_sharing_dataset_28_0.png}
-      \end{figure}
-
-     \column{0.33\textwidth}
-     \centering
-      \textbf{Regional Effect (2)}
-        \begin{figure}
-          \centering
-          \includegraphics[width=.9\linewidth]{figure/01_bike_sharing_dataset_28_1.png}
-      \end{figure}     
-  \end{columns}
-  % \vspace{-1.5em}
-      \begin{itemize}
-      \item Splitting by the "workingday" revealed 2 different patterns that we're clashed together in the initial plot
-      \item $\cup_i (\texttt{regional\_explanation}_i) = \texttt{global\_explanation} $
-      \item $Fidelity (\texttt{regional\_explanation}_i ) > Fidelity(\texttt{global\_explanation} ) $
-      \end{itemize}
-      
-\end{frame}
+\textbf{Solution:} Group homogeneous ICE curves in such a way that reduces the presence of individual interaction effects within a group \\$\leadsto$ Regional effect plots (REPs).
+\noindent\makebox[\linewidth]{\rule{\textwidth}{0.4pt}}
+\spacer[0]
+\splitVThreeT[0.33]{0.33}{0.33}{
+\centering
+\textbf{Global Effect}
+\image[0.9]{figure/01_bike_sharing_dataset_18_1.png}
+}{
+\centering
+\textbf{Regional Effect (1)}
+\image[0.9]{figure/01_bike_sharing_dataset_28_0.png}
+}{
+\centering
+\textbf{Regional Effect (2)}
+\image[0.9]{figure/01_bike_sharing_dataset_28_1.png}
+}
+% \vspace{-1.5em}
+\begin{itemizeM}
+\item Splitting by the "workingday" revealed 2 different patterns that we're clashed together in the initial plot
+\item $\cup_i (\texttt{regional\_explanation}_i) = \texttt{global\_explanation} $
+\item $Fidelity (\texttt{regional\_explanation}_i ) > Fidelity(\texttt{global\_explanation} ) $
+\end{itemizeM}
+\end{framev}
 
 
-\begin{frame}{ICE Curve: Local Feature Effects}
+\begin{framev}[align=top]{ICE Curve: Local Feature Effects}
 %ICE curves show how different feature values of an observation affect its model prediction \newline $\Rightarrow$ \textbf{local interpretation method}
 %From a local perspective, one might be interested in how changing feature values of an observation affect model prediction
-
-\textbf{Question:} How do feature changes affect the prediction for \textbf{one obs.}?
-
+\textbf{Question:} How do feature changes affect the prediction for \textbf{one obs.}?\\
 %\smallskip
-
 %\textbf{Idea:} Change values of observation and feature of interest, and visualize how prediction changes
-
-% \textbf{Idea:} For each observation $\xv$, define individual conditional expectation $\fh({\color{red}\tilde x_j}, \xv_{-j})$ %ICE_j^\xv(\tilde x_j) := 
+% \textbf{Idea:} For each observation $\xv$, define individual conditional expectation $\fh({\color{red}\tilde x_j}, \xv_{-j})$ %ICE_j^\xv(\tilde x_j) :=
 % \begin{itemize}
 %     \item Partition $\xv = (x_j, \xv_{-j})$ into $x_j$ (feature of interest) and $\xv_{-j}$ (remaining features)
 %     \item Replace observed value $x_j$ with {\color{red} grid values $\tilde x_j$} while keeping values $\xv_{-j}$ fixed
 % \end{itemize}
-\textbf{Idea:} Split $\xv = (x_j, \xv_{-j})$ into $x_j$ (feat of interest) and $\xv_{-j}$ (remaining feats) 
-\begin{itemize}
-    \item Replace observed values $x_j$ with {\color{red} grid values $\tilde x_j$} while keeping $\xv_{-j}$ fixed
-    \item Visualize function $\fh({\color{red}\tilde x_j}, \xv_{-j})$ for varying ${\color{red}\tilde x_j}$ (ICE)%ICE_j^\xv(\tilde x_j) := 
-\end{itemize}
-
+\textbf{Idea:} Split $\xv = (x_j, \xv_{-j})$ into $x_j$ (feat of interest) and $\xv_{-j}$ (remaining feats)
+\begin{itemizeM}
+\item Replace observed values $x_j$ with {\color{red} grid values $\tilde x_j$} while keeping $\xv_{-j}$ fixed
+\item Visualize function $\fh({\color{red}\tilde x_j}, \xv_{-j})$ for varying ${\color{red}\tilde x_j}$ (ICE)%ICE_j^\xv(\tilde x_j) :=
+\end{itemizeM}
 \pause
-
 \textbf{Example:} SVM prediction surface (left), select obs. and visualize changes in prediction for varying $x_2$ while keeping $x_1$ fixed $\Rightarrow$ \textbf{local interpretation}
-
 \vfill
 \centering
 \includegraphics[width=\textwidth, page = 1]{figure/ice_motivation_bike}
-
 %$\Rightarrow$ Repeat for all observations and average the curves for global feature effect ($\leadsto$ PD plots)
-\end{frame}
+\end{framev}
 
 
-
-\begin{frame}{PD Plot - Global Feature Effects}
-
+\begin{framev}[align=top]{PD Plot - Global Feature Effects}
 \textbf{Question:} How do changes of feat values affect model prediction \textbf{on avg.}?
-
-%\textbf{Idea:} 
-
-\begin{itemize}
-    \item \textbf{PD function}: Integrate out effect of $X_{-j}$ to obtain marginal effect of $x_j$
-    
-    \medskip
-    
-    \centerline{$ \textstyle
-    f_j^{PD}(\tilde x_j) = \E_{X_{-j}}[\hat f(\tilde x_j, X_{-j})] = \int \hat f(\tilde x_j, X_{-j}) d \mathbb{P}(X_{-j})
-    $}
-        %with $C = S^\complement$. 
-
-    \smallskip
-    
-    \item \textbf{Estimate (MC integration):} Avgerage ICE curves at grid points $\tilde x_j$
-    
-    \medskip
-    
-    \centerline{$ \textstyle
-    \hat f_j^{PD}(\tilde x_j) = \frac{1}{n} \sum_{i=1}^{n} \hat f(\tilde x_j, \xv_{-j}^{(i)})
-    $}
-\end{itemize}
-
-
+%\textbf{Idea:}
+\begin{itemizeM}
+\item \textbf{PD function}: Integrate out effect of $X_{-j}$ to obtain marginal effect of $x_j$ \\
+\spacer[0.25]
+\centerline{$ \textstyle
+f_j^{PD}(\tilde x_j) = \E_{X_{-j}}[\hat f(\tilde x_j, X_{-j})] = \int \hat f(\tilde x_j, X_{-j}) d \mathbb{P}(X_{-j})
+$}
+%with $C = S^\complement$.
+% \spacer[0.25]
+\item \textbf{Estimate (MC integration):} Average ICE curves at grid points $\tilde x_j$ \\
+\spacer[0.25]
+\centerline{$ \textstyle
+\hat f_j^{PD}(\tilde x_j) = \frac{1}{n} \sum_{i=1}^{n} \hat f(\tilde x_j, \xv_{-j}^{(i)})
+$}
+\end{itemizeM}
 \vfill
 \centering
 \includegraphics[width=\textwidth, page = 2]{figure/ice_motivation_bike}
-
 %Aggregates to Global PD
 %point-wise average of ICE
 %Extrapolation?
-\end{frame}
+\end{framev}
 
 
-
-\begin{frame}{Feature Interactions}
-
+\begin{framev}[align=top]{Feature Interactions}
 \textbf{Hooker (2004, 2007):} Functional ANOVA decomp. of a function% into main and higher-order (interaction) effects
-
 \begin{center}
-    $\textstyle
-\hat{f}(\mathbf{x}) = g_0 + 
-\underbrace{\textstyle\sum_{j=1}^{p} {{g_j(x_j)}}}_{\text{{main effect}}} + 
-\underbrace{\textstyle\sum_{j \neq k} {\textcolor{blue}{g_{j,k}(x_j, x_k)}}}_{\text{\textcolor{blue}{two-way interaction effect}}} + 
-\cdots + 
+$\textstyle
+\hat{f}(\mathbf{x}) = g_0 +
+\underbrace{\textstyle\sum_{j=1}^{p} {{g_j(x_j)}}}_{\text{{main effect}}} +
+\underbrace{\textstyle\sum_{j \neq k} {\textcolor{blue}{g_{j,k}(x_j, x_k)}}}_{\text{\textcolor{blue}{two-way interaction effect}}} +
+\cdots +
 \underbrace{{\textcolor{blue}{g_{1,2,\ldots,p}(\mathbf{x})}}}_{\text{\textcolor{blue}{p-way interaction effect}}}
 $
 \end{center}
-
 %A function $f(\xv)$ is said to exhibit an interaction between two of its variables $x_j$ and $x_k$ if the difference in the value of $f(\xv)$ as a result of changing the value of $x_j$ depends on the value of $x_k$. For numeric variables, this can be expressed as
 \textbf{Friedman and Popescu (2008):} %From functional ANOVA decomposition it follows
 %A function $f(\xv)$ contains an interaction between $x_j$ and $x_k$ if a change in $f(\xv)$-values due to variations in $x_j$ also depend on $x_k$, i.e.: %, for numeric features:
-
 %\medskip
-
 %\centerline{$\mathbb{E} \left[ \tfrac{\partial^2 f(\xv)}{\partial x_j \partial x_k} \right]^2 > 0$}
-
 %\medskip
-\begin{itemize}
+\begin{itemizeM}
 %is a sum of two functions, each independent of $x_j$, $x_k$:
 % $f_{-j}$ and $f_{-k}$ that do not depend on $x_j$ and $x_k$, respectively:
-    \item[$\Rightarrow$] 
-    If $x_j$ and $\xv_{-j}$ don't interact, we can decomp. $f(\xv) = g_{j}(x_{j}) + g_{-j}(\xv_{-j})$\\
-    \item[$\Rightarrow$] 
-    If $x_j$ and $x_k$ don't interact, decomposition: $f(\xv) = g_{-j}(\xv_{-j}) + g_{-k}(\xv_{-k})$
-    %\item<3>[$\Rightarrow$] $\highlight{f(\xv) - g_{j}(x_{j}) - g_{-j}(\xv_{-j})} = 0$ %if there are no interactions between feature $j$ and any other feature $-j$
-\end{itemize}
-
-
+\item[$\Rightarrow$]
+If $x_j$ and $\xv_{-j}$ don't interact, we can decomp. $f(\xv) = g_{j}(x_{j}) + g_{-j}(\xv_{-j})$\\
+\item[$\Rightarrow$]
+If $x_j$ and $x_k$ don't interact, decomposition: $f(\xv) = g_{-j}(\xv_{-j}) + g_{-k}(\xv_{-k})$
+%\item<3>[$\Rightarrow$] $\highlight{f(\xv) - g_{j}(x_{j}) - g_{-j}(\xv_{-j})} = 0$ %if there are no interactions between feature $j$ and any other feature $-j$
+\end{itemizeM}
 %\medskip
-
 %\centerline{$f(\xv) = f_{-j}(x_1, \ldots, x_{j-1}, x_{j+1}, \ldots, x_p) + f_{-k}(x_1, \ldots, x_{k-1}, x_{k+1}, \ldots, x_p)$}
-
-
 \only<1>{
 {
 \textbf{Example:} Not additively separable: \\
 {\footnotesize $f(\xv) = x_1 + x_2 + x_1 \cdot x_2 \neq g(x_1) + g(x_2)$}
-
-\includegraphics[width = 0.9\textwidth]{figure/interaction_separable_3}}
+\image[0.9]{figure/interaction_separable_3}}
 }
 \only<2>{\textbf{Example:} Separable: {\footnotesize $f(\xv) = x_1 + x_2 + \log(x_1 \cdot x_2)
- 	       = \left(x_1 + \log(x_1)\right) + \left(x_2 + \log(x_2)\right) = g_1(x_1) + g_2(x_2)$}
+= \left(x_1 + \log(x_1)\right) + \left(x_2 + \log(x_2)\right) = g_1(x_1) + g_2(x_2)$}
 % \begin{itemize}
 %     \item Not separable: $f(\xv) = x_1 + x_2 + x_1 \cdot x_2$
 %     \item Separable: {\small $f(\xv) = x_1 + x_2 + \log(x_1 \cdot x_2)
 % 	       = x_1 + \log(x_1) + x_2 + \log(x_2) = g_1(x_1) + g_2(x_2)$}
 % \end{itemize}
-
-\includegraphics[width = 0.9\textwidth]{figure/interaction_separable_2}
+\image[0.9]{figure/interaction_separable_2}
 %\pause\color{red}
 %$\Rightarrow$ \textbf{Different shapes of ICE curves indicate interactions}
 % ICE curves can be used to identify potential interactions (different shapes)
@@ -297,7 +248,7 @@ $
 % \medskip
 
 % \centerline{$ \displaystyle
-%     \mathcal{\hat H}_{j,k}^2 = \frac{\sum\nolimits_{i=1}^n \left( 
+%     \mathcal{\hat H}_{j,k}^2 = \frac{\sum\nolimits_{i=1}^n \left(
 %     \hat f_{j,k}^{PD,c}(\xi_{j,k}) -  \left(\hat f_{j}^{PD,c}(x_j) + \hat f_{k}^{PD,c}(x_k) \right)
 %     \right)^2}{\sum_{i=1}^n \left( \hat f_{j,k}^{PD,c}(\xi_{j,k}) \right)^2 }, \text{ where}$}
 
@@ -316,7 +267,7 @@ $
 
 
 % }
-\end{frame}
+\end{framev}
 
 
 
@@ -350,192 +301,185 @@ $
 %   \caption{ICE and regional PD (dashed) plot of $x_2$ clustered by VINE for $k = 2$ (left) and $k = 5$ (right). The
 %  5 clusters are reduced to 3 by post-hoc merging. Cluster
 %  numbers 0 and 3 still contain differing individual interaction effects, which are averaged and hence not represented
-%  well by the regional PD plot.}    
+%  well by the regional PD plot.}
 % \end{figure}
 
 % \end{frame}
 
 
-\begin{frame}{REPID: Regional Effect Plots \furtherreading{HERBINGER2022}}
-
+\begin{framev}[align=top]{REPID: Regional Effect Plots \furtherreading{HERBINGER2022}}
 \textbf{Recall:} Different shapes of ICE curves $\Rightarrow$ interactions (ignore vertical shifts)\\
-$\Rightarrow$ Focus on shape differences of {\color{cice}\bfseries mean-centered ICE curves}.
-    
+$\Rightarrow$ Focus on shape differences of {\color{cice}\bfseries mean-centered ICE curves}. \\
 %\includegraphics[width = 0.8\textwidth, trim={0cm 0cm 0cm 0cm}, clip]{figure/interaction_separable_2}
-
 Mean-centered ICE curve for obs. $\xv$ evaluated at $m$ grid points $\tilde x_j^{(1)}, \dots, \tilde x_j^{(m)}$ is:
-
 {\color{cice}
 $$\hat f^c(\tilde x_j, \xv_{-j}) = \hat{f}(\tilde x_j, \xv_{-j}) - \frac{1}{m} \sum\nolimits_{k=1}^m \hat{f}(\tilde x_j^{(k)}, \xv_{-j})$$}
  %and $g \in \{1,...,G\}$
-
-\begin{columns}
-    \begin{column}{0.39\textwidth}
-        \includegraphics[width = \textwidth, trim={13cm 0cm 0cm 0cm}, clip]{figure/interaction_separable_2}
-    \end{column}
-    \begin{column}{0.61\textwidth}
-        \includegraphics[width = \textwidth]{figure/ice_rep_distance0.png} 
-    \end{column}
-\end{columns}
-
+\splitVTT[0.39]{
+\spacer[0]
+\includegraphics[width=\textwidth,trim={13cm 0cm 0cm 0cm},clip]{figure/interaction_separable_2}
+}{
+\spacer[0]
+\image{figure/ice_rep_distance0.png}
+}
 %\includegraphics[width = 0.3\textwidth, trim={13cm 0cm 0cm 0cm}, clip]{figure/interaction_separable_2}
-\end{frame}
+\end{framev}
 
 
-
-\begin{frame}{Regional Effects - Synthetic Example}
-   
+\begin{framev}[align=top]{Regional Effects - Synthetic Example}
 %\textbf{How can we use ICE curves to find regions with representative PDPs?}
 %\vspace*{0.3cm}
-
 \textbf{Example:}
 %$X_1, X_2 \sim \mathcal{U}(-1,1), X_3, X_5 \sim \mathcal{B}(n, 0.5), X_4 \sim \mathcal{B}(n, 0.7), X_6 \sim \mathcal{N}(1,5)$ (all iid)\\
-$X_1, X_2, X_6 \sim \mathcal{U}(-1,1)$, 
-$X_3, X_4, X_5 \sim \mathcal{B}(n, 0.5)$ (all iid)
-
-\smallskip
-
+$X_1, X_2, X_6 \sim \mathcal{U}(-1,1)$,
+$X_3, X_4, X_5 \sim \mathcal{B}(n, 0.5)$ (all iid)\\
+\spacer[0.25]
 \only<1>{$\leadsto$ Ground truth:{
-    $f(X) = 0.2 X_1 \highlight{- 8 X_2 + {8 X_2  \mathbb{1}_{(X_1 > 0)}}+ {16 X_2  \mathbb{1}_{(X_3 = 0)}}} + \epsilon $}}
-    \only<2>{$\leadsto$ Ground truth:{
-    $f(X) = 0.2 X_1 - 8 X_2 + {8 X_2  \mathbb{1}_{(X_1 > 0)}} + \highlightFG{16 X_2  \mathbb{1}_{(X_3 = 0)}} \color{black}+ \epsilon $}}
-    \only<3>{$\leadsto$ Ground truth:{
-    $f(X) = 0.2 X_1 - 8 X_2 + \highlightYG{8 X_2  \mathbb{1}_{(X_1 > 0)}} \color{black}+ \highlightFG{16 X_2  \mathbb{1}_{(X_3 = 0)}} \color{black}+ \epsilon $}}
-
+$f(X) = 0.2 X_1 \highlight{- 8 X_2 + {8 X_2  \mathbb{1}_{(X_1 > 0)}}+ {16 X_2  \mathbb{1}_{(X_3 = 0)}}} + \epsilon $}} 
+\only<2>{$\leadsto$ Ground truth:{
+$f(X) = 0.2 X_1 - 8 X_2 + {8 X_2  \mathbb{1}_{(X_1 > 0)}} + \highlightFG{16 X_2  \mathbb{1}_{(X_3 = 0)}} \color{black}+ \epsilon $}} 
+\only<3>{$\leadsto$ Ground truth:{
+$f(X) = 0.2 X_1 - 8 X_2 + \highlightYG{8 X_2  \mathbb{1}_{(X_1 > 0)}} \color{black}+ \highlightFG{16 X_2  \mathbb{1}_{(X_3 = 0)}} \color{black}+ \epsilon $}}
+\\
 $\leadsto$ Model: Random forest
-
-\begin{columns}[T, totalwidth = \linewidth]
-    \begin{column}{0.46\textwidth}
-
+\begin{columns}[T,totalwidth=\linewidth]
+\begin{column}{0.46\textwidth}
 %$\leadsto$ True relationship: $f(X) = 0.2 X_1 - 8 X_2 + \color{YellowGreen}{8 X_2  \mathbb{1}_{(X_1 > 0)}} \color{black}+ \color{ForestGreen}{16 X_2  \mathbb{1}_{(X_3 = 0)}} \color{black}+ \epsilon, \; \epsilon \sim \mathcal{N}(0,1)$\\
-
 %\begin{itemize}
   %\setlength{\itemindent}{0em}
-\textbf{Problem:} 
-\begin{itemize}
-    \item \only<1>{PD curve of $\highlight{X_2}$ is misleading due to interactions $\leadsto$ ICE}
-    \only<2->{PD curve of $X_2$ is misleading due to interactions $\leadsto$ ICE}
-    \item ICE curves do not identify the interacting features
-\end{itemize}
-
-\only<2->{\medskip\textbf{Idea:} Find regions with similar ICE curves and aggregate them to regional effects}
+\textbf{Problem:}
+\begin{itemizeM}
+\item \only<1>{PD curve of $\highlight{X_2}$ is misleading due to interactions $\leadsto$ ICE}
+\only<2->{PD curve of $X_2$ is misleading due to interactions $\leadsto$ ICE}
+\item ICE curves do not identify the interacting features
+\end{itemizeM}
+\only<2->{
+\spacer[0.25]
+\textbf{Idea:} Find regions with similar ICE curves and aggregate them to regional effects \\
+}
 % \item<2-> \textbf{Idea:} Find regions where variance of ICE curves is minimized by recursive partitioning the feature space w.r.t. all other features $-j$\\
 %Find regions with similar ICE curves and aggregate them to regional effects\\
-%\item 
-%$\leadsto$ REP more representative due to less interactions  
+%\item
+%$\leadsto$ REP more representative due to less interactions
    %\item[$\leadsto$]\textbf{Idea} Recursively partition feature space w.r.t. $-j$ such that distance of ICE curves to REP is small}
-
-\only<3->{\medskip{\color{rep}\textbf{Regional effect}} (blue curves)   $\hat = $ Estimate PD curve in each region}
-
+\only<3->{
+\spacer[0.25]
+{\color{rep}\textbf{Regional effect}} (blue curves)   $\hat = $ Estimate PD curve in each region
+}
  % \centerline{$ \textstyle    \hat f_{j|\mathcal{N}_g}^{PD}(\tilde x_j) = \frac{1}{|\mathcal{N}_g|} \sum_{i \in \mathcal{N}_g} \hat f(\tilde x_j, \xv_{-j}^{(i)})$}
-  
-    \end{column}
-    \begin{column}{0.54\textwidth}
-    \footnotesize
-
+\end{column}
+\begin{column}{0.54\textwidth}
+\footnotesize
     %$, \; \epsilon \sim \mathcal{N}(0,1)$
 \only<1>{
-    \centering
-      \includegraphics[width=0.82\textwidth]{figure/sim1_allcurves.png} 
+\centering
+\image[0.82]{figure/sim1_allcurves.png}
 }
 \only<2->{
 \centering
      %\begin{minipage}[t]{.5\textwidth}
-     \hspace{-20pt}
-     \includegraphics<2>[width=0.5\textwidth]{figure/sim1_allcurves.png}
-     
-     \only<2>{
-           \begin{tikzpicture}
-      \usetikzlibrary{arrows}
-        \usetikzlibrary{shapes}
-         \tikzset{treenode/.style={draw}}
-         \tikzset{line/.style={draw, thick}}
+\only<2>{
+\makebox[\linewidth][r]{%
+\begin{minipage}{0.78\linewidth}
+\centering
+\includegraphics[width=0.64\linewidth]{figure/sim1_allcurves.png}\\[-0.1em]
+\makebox[\linewidth][c]{\hspace{0.4cm}%
+\begin{tikzpicture}
+\usetikzlibrary{arrows}
+\usetikzlibrary{shapes}
+\tikzset{treenode/.style={draw}}
+\tikzset{line/.style={draw, thick}}
      % Nodes
-    \node [treenode] (a0) {}; [below=1pt,at=(10,0)]  {};% Top node
-    \node [treenode, below=0.3cm of a0, xshift=-1.0cm] (a1) {}; % Bottom left node
-    \node [treenode, below=0.3cm of a0, xshift=1.0cm] (a2) {}; % Bottom right node
-
+\node[treenode] (a0) {}; % Top node
+\node [treenode, below=0.3cm of a0, xshift=-1.0cm] (a1) {}; % Bottom left node
+\node [treenode, below=0.3cm of a0, xshift=1.0cm] (a2) {}; % Bottom right node
     % Lines
-    \draw [thick] (a0) -- ++(0, -0.2cm) -| (a1);
-    \draw [thick] (a0) -- ++(0, -0.2cm) -| (a2);
-      \end{tikzpicture}
-     }
-     
-      %\fcolorbox{ForestGreen}{white}     {
-      \highlightFG{
-      \includegraphics[width=0.6\textwidth, trim = 0 0 0 25, clip]{figure/sim1_dt_split1.png}
-      }
-      %}
+\draw [thick] (a0) -- ++(0, -0.2cm) -| (a1);
+\draw [thick] (a0) -- ++(0, -0.2cm) -| (a2);
+\end{tikzpicture}}\\[-0.2em]
+%\fcolorbox{ForestGreen}{white}     {
+\spacer[0.25]
+\makebox[\linewidth][c]{\hspace{0.4cm}%
+\highlightFG{
+\includegraphics[width=0.77\linewidth,trim=0 0 0 25,clip]{figure/sim1_dt_split1.png}
+}}
+%}
+\end{minipage}
+}
 }
 \only<3->{
-      \scalebox{1}{
-      \hspace{15pt} 
-      \begin{tikzpicture}
-      \usetikzlibrary{arrows}
-        \usetikzlibrary{shapes}
-         \tikzset{treenode/.style={draw}}
-         \tikzset{line/.style={draw, thick}}
-        \node [treenode](a0) {} ; [below=1pt,at=(4,0)]  {};
-         \node [treenode, below=0.3cm, at=(a0.south), xshift=-2.0cm]  (a1) {};
-         \node [treenode, below=0.3cm, at=(a0.south), xshift=-0.4cm]  (a2) {};
-         \path [line] (a0.south) -- + (0,-0.2cm) -| (a1.north) node [midway, above] {};
-         \path [line] (a0.south) -- +(0,-0.2cm) -|  (a2.north) node [midway, above] {};
-      \end{tikzpicture}
-      \hspace{35pt}
-      \begin{tikzpicture}
-      \usetikzlibrary{arrows}
-        \usetikzlibrary{shapes}
-         \tikzset{treenode/.style={draw}}
-         \tikzset{line/.style={draw, thick}}
-        \node [treenode] (a01) {};[below=5pt,at=(node1.south) , xshift=3.5cm]
-         \node [treenode, below=0.3cm, at=(a01.south), xshift=0.4cm]  (a1) {};
-         \node [treenode, below=0.3cm, at=(a01.south), xshift=2.0cm]  (a2) {};
-         \path [line] (a01.south) -- + (0,-0.2cm) -| (a1.north) node [midway, above] {};
-         \path [line] (a01.south) -- +(0,-0.2cm) -|  (a2.north) node [midway, above] {};
-      \end{tikzpicture}
-      }
+      %\fcolorbox{ForestGreen}{white}     {
+\highlightFG{
+\includegraphics[width=0.6\textwidth,trim=0 0 0 25,clip]{figure/sim1_dt_split1.png}
+}
+      %}
+}
+}
+\only<3->{
+\scalebox{1}{
+\hspace{15pt}
+\begin{tikzpicture}
+\usetikzlibrary{arrows}
+\usetikzlibrary{shapes}
+\tikzset{treenode/.style={draw}}
+\tikzset{line/.style={draw, thick}}
+\node[treenode](a0) {};
+\node [treenode, below=0.3cm, at=(a0.south), xshift=-2.0cm]  (a1) {};
+\node [treenode, below=0.3cm, at=(a0.south), xshift=-0.4cm]  (a2) {};
+\path [line] (a0.south) -- + (0,-0.2cm) -| (a1.north) node [midway, above] {};
+\path [line] (a0.south) -- +(0,-0.2cm) -|  (a2.north) node [midway, above] {};
+\end{tikzpicture}
+\hspace{35pt}
+\begin{tikzpicture}
+\usetikzlibrary{arrows}
+\usetikzlibrary{shapes}
+\tikzset{treenode/.style={draw}}
+\tikzset{line/.style={draw, thick}}
+\node[treenode] (a01) {};
+\node [treenode, below=0.3cm, at=(a01.south), xshift=0.4cm]  (a1) {};
+\node [treenode, below=0.3cm, at=(a01.south), xshift=2.0cm]  (a2) {};
+\path [line] (a01.south) -- + (0,-0.2cm) -| (a1.north) node [midway, above] {};
+\path [line] (a01.south) -- +(0,-0.2cm) -|  (a2.north) node [midway, above] {};
+\end{tikzpicture}
+}
     %\fcolorbox{YellowGreen}{white}{
-    \highlightYG{
-    \includegraphics[width=0.52\textwidth, trim = 0 0 0 25, clip]{figure/sim1_dt_split2_1.png}
-    \includegraphics[width=0.46\textwidth, trim = 40 0 0 25, clip]{figure/sim1_dt_split2_2.png}
-    }
+\highlightYG{
+\includegraphics[width=0.52\textwidth,trim=0 0 0 25,clip]{figure/sim1_dt_split2_1.png}
+\includegraphics[width=0.46\textwidth,trim=40 0 0 25,clip]{figure/sim1_dt_split2_2.png}
+}
     %\vspace{.2in}
     %\caption{ICE curves for $\xv_2$ are grouped by REPID and REPs (blue) are illustrated. %The first split divides the ICE curves depending on $x_3$. The second level divides the ICE curves of each child node again into two sub-regions with respect to $x_1$.
     %}
     %\label{fig:sim1_dt}
-     %\end{minipage} 
-
-     \begin{columns}[T, totalwidth = \linewidth]
+     %\end{minipage}
+\begin{columns}[T,totalwidth=\linewidth]
      %\footnotesize
-            \begin{column}{0.12\linewidth}
-            \centering
-             $\hat{f}_2^{PD}(X_2)$ %, X_1 > 0 \land X_3 = 0\)\\
-         \end{column}
-         \begin{column}{0.16\linewidth}
-         \centering
-             $\approx 8X_2$ %, X_1 > 0 \land X_3 = 0\)\\
-         \end{column}
-        \begin{column}{0.2\linewidth}
+\begin{column}{0.12\linewidth}
 \centering
-            $\approx 16X_2$ %, X_1 \leq 0 \land X_3 = 0\)
-         \end{column}
-        \begin{column}{0.2\linewidth}
-        \centering
-            $ \approx -8X_2$ %, X_1 \leq 0 \land X_3 \neq 0\)
-         \end{column}        
-         \begin{column}{0.2\linewidth}
-         \centering
-             $\approx 0$%, X_1 > 0 \land X_3 \neq 0\)\\
-         \end{column}
-     \end{columns}
-     \medskip
-     $\Rightarrow$ Additive decomposition of global feat effect
+$\hat{f}_2^{PD}(X_2)$ %, X_1 > 0 \land X_3 = 0\)\\
+\end{column}
+\begin{column}{0.16\linewidth}
+\centering
+$\approx 8X_2$ %, X_1 > 0 \land X_3 = 0\)\\
+\end{column}
+\begin{column}{0.2\linewidth}
+\centering
+$\approx 16X_2$ %, X_1 \leq 0 \land X_3 = 0\)
+\end{column}
+\begin{column}{0.2\linewidth}
+\centering
+$ \approx -8X_2$ %, X_1 \leq 0 \land X_3 \neq 0\)
+\end{column}
+\begin{column}{0.2\linewidth}
+\centering
+$\approx 0$%, X_1 > 0 \land X_3 \neq 0\)\\
+\end{column}
+\end{columns}
+\spacer[0.25]
+$\Rightarrow$ Additive decomposition of global feat effect
      %$f_2(X_2) \approx \sum_{i: \textit{terminal node indices}} g_i(X_2) \mathbb{1}_{(X \in \mathcal{N}_i)}$
 }
-
-
-    \end{column}
-
+\end{column}
 \end{columns}
 
 % \begin{minipage}[htb]{0.48\linewidth}
@@ -544,11 +488,11 @@ $\leadsto$ Model: Random forest
 % \item \textbf{Problem:} PD plot (average of ICE) misleading
 
 % \item \textbf{Idea:} Find regions where ICE curves are similar in their shape\\
-% $\leadsto$ These regions have little interactions 
+% $\leadsto$ These regions have little interactions
 
 %     %\item<1-2> Grouping homogeneous ICE curves reduces individual interaction effects
 %     %\item<2> REP = group marginal effect for feature of interest $x_j$ in specific region
-  
+
 % \end{itemize}
 % \end{minipage}
 % \only<1>{
@@ -556,7 +500,7 @@ $\leadsto$ Model: Random forest
 %     \centering
 %      %\begin{minipage}[t]{.5\textwidth}
 %       \includegraphics[width=0.9\textwidth]{figure/sim1_allcurves.png}
-     
+
 % \end{minipage}
 % }
 % \only<2>{
@@ -565,7 +509,7 @@ $\leadsto$ Model: Random forest
 %      %\begin{minipage}[t]{.5\textwidth}
 %       \includegraphics[width=0.49\textwidth]{figure/sim1_dt_split1.png}
 %       \scalebox{1}{
-%       \hspace{15pt} 
+%       \hspace{15pt}
 %       \begin{tikzpicture}
 %       \usetikzlibrary{arrows}
 %         \usetikzlibrary{shapes}
@@ -596,73 +540,64 @@ $\leadsto$ Model: Random forest
 %     %\caption{ICE curves for $\xv_2$ are grouped by REPID and REPs (blue) are illustrated. %The first split divides the ICE curves depending on $x_3$. The second level divides the ICE curves of each child node again into two sub-regions with respect to $x_1$.
 %     %}
 %     \label{fig:sim1_dt}
-%      %\end{minipage} 
+%      %\end{minipage}
 %\end{minipage}
 %}
 
 
 %\footnote[frame]{\textbf{AISTATS 2022:} \textit{REPID - Regional Effect Plots with implicit Interaction Detection}}
+\end{framev}
 
-\end{frame}
 
-
-\begin{frame}{Regional Effects - Details}
-
-\begin{columns}[T, totalwidth=\textwidth]
-    \begin{column}{0.62\textwidth}
-    \textbf{Question:} How to split curves into regions?  
- Define risk as L2 loss of mean-centered\\ ICE curves:
+\begin{framev}[align=top]{Regional Effects - Details}
+\splitVTT[0.62]{
+\textbf{Question:} How to split curves into regions?
+Define risk as L2 loss of mean-centered\\ ICE curves:
 $$\textstyle
-    \mathcal{R}_j\left(\mathcal{N}\right) =
-    \sum\limits_{\xv \in \mathcal{N}} 
-     \sum\limits_{k = 1}^m
-     (\underbrace{{\color{cice}\hat f^{c}(\tilde x_j^{(k)}, \xv_{-j})} - \color{rep}\hat f_{j|\mathcal{N}}^{PD,c} (\tilde x_j^{(k)})}_\text{$\color{orange}{d_k}$})^2
-    %\mathcal{L}\left(\xv_j, i\right)
-    $$
-with the avg. feature effect in %region with associated index set 
+\mathcal{R}_j\left(\mathcal{N}\right) =
+\sum\limits_{\xv \in \mathcal{N}}
+\sum\limits_{k = 1}^m
+(\underbrace{{\color{cice}\hat f^{c}(\tilde x_j^{(k)}, \xv_{-j})} - \color{rep}\hat f_{j|\mathcal{N}}^{PD,c} (\tilde x_j^{(k)})}_\text{$\color{orange}{d_k}$})^2
+%\mathcal{L}\left(\xv_j, i\right)
+$$
+with the avg. feature effect in %region with associated index set
 region $\mathcal{N} \subseteq \Xspace$:
-
-\medskip
-
+\spacer[0.25]
 {\color{rep}
 \centerline{$ \displaystyle    \hat f_{j|\mathcal{N}}^{PD,c}(\tilde x_j) = \frac{1}{|\mathcal{N}|} \sum_{\xv \in \mathcal{N}} \hat f^c(\tilde x_j, \xv_{-j})$}}
-    \end{column}
-    \begin{column}{0.39\textwidth}
-            \centering
-    \includegraphics[width = \textwidth]{figure/ice_rep_distance2.pdf}
-    \end{column}
-\end{columns}
+\spacer[0]
+}{
+\spacer[0]
+\centering
+\image{figure/ice_rep_distance2.pdf}
+\spacer[0]
+}
 %\medskip
 % \begin{itemize}
-
-    % \item[$\Rightarrow$] 
-    $\leadsto$ Measures interaction-related heterogeneity (variance) of ICE curves in $\mathcal{N}$\\
     % \item[$\Rightarrow$]
-    $\leadsto$ Recursive partitioning (CART): Find best feat-split combo that solves
-    
-\medskip
-
+$\leadsto$ Measures interaction-related heterogeneity (variance) of ICE curves in $\mathcal{N}$\\
+    % \item[$\Rightarrow$]
+$\leadsto$ Recursive partitioning (CART): Find best feat-split combo that solves \\
+\spacer[0.25]
 \centerline{$\arg \min_{z, t} \; \mathcal{R}_j\left(\mathcal{N}_{left}\right) + \mathcal{R}_j\left(\mathcal{N}_{right}\right)$}
 % \end{itemize}
-
-      \begin{columns}[c, totalwidth=\textwidth]
-        \begin{column}{0.57\textwidth}
-    \begin{itemize}
-        \item $\mathcal{N}_{left} = \{\xv \in \mathcal{N}|x_z \leq t\}$
-        \item $\mathcal{N}_{right} = \{\xv \in \mathcal{N}|x_z > t\}$
-        \item Split point $t$ for feature $x_z, z \in -j$
-    \end{itemize}
-        \end{column}
-          \begin{column}{0.43\textwidth}
-          \centering
-          \textbf{Intuition:} Is another feature $x_z$ \\responsible for the heterogeneity (measured by $\mathcal{R}_j$)?
-        \end{column}
-    \end{columns}
-        %\item loss $\mathcal{L}$ for $i$-th ICE curve based on a grid of size $m$
-        %\item aggregate over all ICEs within region $\mathcal{N}$
-    %\end{itemize}
+\splitVTT[0.57]{
+\spacer[0.6]
+\begin{itemizeM}
+\item $\mathcal{N}_{left} = \{\xv \in \mathcal{N}|x_z \leq t\}$
+\item $\mathcal{N}_{right} = \{\xv \in \mathcal{N}|x_z > t\}$
+\item Split point $t$ for feature $x_z, z \in -j$
+\end{itemizeM}
+}{
+\centering
+\spacer[0.6]
+\textbf{Intuition:} Is another feature $x_z$ \\responsible for the heterogeneity (measured by $\mathcal{R}_j$)?
+}
+%\item loss $\mathcal{L}$ for $i$-th ICE curve based on a grid of size $m$
+%\item aggregate over all ICEs within region $\mathcal{N}$
+%\end{itemize}
 %\footnote[frame]{\textbf{AISTATS 2022:} \textit{REPID - Regional Effect Plots with implicit Interaction Detection}}
-\end{frame}
+\end{framev}
 
 
 % \begin{frame}{Regional Effect Plots - Real Example}
@@ -708,7 +643,7 @@ region $\mathcal{N} \subseteq \Xspace$:
 %                 \item Error: $\texttt{RMSE} \approx 45.35$
 %                 %counts ($0.25Y_\sigma$)
 %             \end{itemize}
-%             \vspace{0.5em} 
+%             \vspace{0.5em}
 %             \item Use global/regional effects to:
 %   \begin{itemize}
 %     \setlength\itemindent{-20pt}
@@ -723,7 +658,7 @@ region $\mathcal{N} \subseteq \Xspace$:
 %             %  \setlength\itemindent{-20pt}
 %             %     \item which feature(s) are the most important
 %             %     \item how each feature affects the output
-%             %     \item which feature effects are heterogeneous 
+%             %     \item which feature effects are heterogeneous
 %             %     \item try regional effects for better explanations
 %             % \end{itemize}
 %         \end{itemize}
@@ -732,66 +667,59 @@ region $\mathcal{N} \subseteq \Xspace$:
 % \end{frame}
 
 
-\begin{frame}{Regional Effect Plots - Real Example}
+\begin{framev}[align=top]{Regional Effect Plots - Real Example}
 \begin{figure}
-    \centering
+\centering
     %\includegraphics[width=0.325\linewidth]{figure/01_bike_sharing_dataset_18_0.png}
-    \includegraphics[width=0.325\linewidth]{figure/01_bike_sharing_dataset_18_4.png}
-    \includegraphics[width=0.325\linewidth]{figure/01_bike_sharing_dataset_18_1.png}
-    \includegraphics[width=0.325\linewidth]{figure/01_bike_sharing_dataset_18_2.png}%\\
+\image[0.325]{figure/01_bike_sharing_dataset_18_4.png}
+\image[0.325]{figure/01_bike_sharing_dataset_18_1.png}
+\image[0.325]{figure/01_bike_sharing_dataset_18_2.png}%\\
     %\includegraphics[width=0.325\linewidth]{figure/01_bike_sharing_dataset_18_5.png}\\
     %Global effect of features: month, hour, temperature, windspeed, humidity
     %\label{fig:enter-label}
 \end{figure}
-\begin{itemize}
+\begin{itemizeM}
 \item Identify feature with highly heterogeneous local effects\\
 $\leadsto$ \textcolor{ForestGreen}{\texttt{hour}: Most important; highly heterogeneous feat (highest variance)}
     %\item<1> \texttt{temperature}: Second most important feature (other features less important)
     %\item<1> Other features have less impact
 \item Find regions in feature space where this heterogeneity is minimal
-\begin{itemize}
-    \item[$\leadsto$] Partition feature space using CART to minimize variance of mean-centered ICE curves within each region
-\end{itemize}
-\end{itemize}
+\begin{itemizeS}
+\item[$\leadsto$] Partition feature space using CART to minimize variance of mean-centered ICE curves within each region
+\end{itemizeS}
+\end{itemizeM}
 % Now drawing the rectangle around the second image on the second slide
 \only<1>{
-    \begin{tikzpicture}[overlay, remember picture]
-        \draw[ForestGreen, thick] (4.1, 3.3) rectangle (4.1 + 4, 3.3 + 3.2); % Adjust these coordinates
-    \end{tikzpicture}
+\begin{tikzpicture}[overlay, remember picture]
+\draw[ForestGreen, thick] (4.1, 3.3) rectangle (4.1 + 4, 3.3 + 3.2); % Adjust these coordinates
+\end{tikzpicture}
 }
-\end{frame}
+\end{framev}
 
 
-
-\begin{frame}{Regional Effect Plots - Real Example}
+\begin{framev}[align=top]{Regional Effect Plots - Real Example}
 \resizebox{\linewidth}{!}{%
-    \begin{tikzpicture}[every node/.style={anchor=south, align=center}]
-
-        \node[draw, fill=yellow!20, text width=4cm] at (-4.5, 1.3) {Regional effects of \texttt{hour}};
-        % Root image
-        \node (root) {\includegraphics[width=0.25\textwidth]{figure/01_bike_sharing_dataset_18_1.png}};
-
-        % Depth 1 (Appears on Slide 2)
-        \node[below left=.3cm and -0.5cm of root] (child1) {\includegraphics[width=0.25\textwidth]{figure/01_bike_sharing_dataset_28_0.png}};
-        \node[below right=.3cm and -0cm of root] (child2) {\includegraphics[width=0.25\textwidth]{figure/01_bike_sharing_dataset_28_1.png}};
-        \draw (root) -- node[pos=0.15, left] {workingday=False} (child1);
-        \draw (root) -- node[pos=0.15, right] {workingday=True} (child2);
-
-
-        % Depth 2 (Appears on Slide 3)
-        \node[below left=0.3cm and -1.8cm of child1] (child11) {\includegraphics[width=0.25\textwidth]{figure/01_bike_sharing_dataset_29_0.png}};
-        \node[below right=0.3cm and -1.8cm of child1] (child21) {\includegraphics[width=0.25\textwidth]{figure/01_bike_sharing_dataset_29_1.png}};
-        \node[below left=0.3cm and -1.8cm of child2] (child12) {\includegraphics[width=0.25\textwidth]{figure/01_bike_sharing_dataset_29_2.png}};
-        \node[below right=.3cm and -1.8cm of child2] (child22) {\includegraphics[width=0.25\textwidth]{figure/01_bike_sharing_dataset_29_3.png}};
-        
-        \draw (child1) -- node[midway, left] {temp=cold} (child11);
-        \draw (child1) -- node[midway, right] {temp=hot} (child21);
-        \draw (child2) -- node[midway, left] {temp=cold} (child12);
-        \draw (child2) -- node[midway, right] {temp=hot} (child22);
-
-    \end{tikzpicture}
-    }
-\end{frame}
+\begin{tikzpicture}[every node/.style={anchor=south, align=center}]
+\node[draw, fill=yellow!20, text width=4cm] at (-4.5, 1.3) {Regional effects of \texttt{hour}};
+% Root image
+\node (root) {\includegraphics[width=0.25\textwidth]{figure/01_bike_sharing_dataset_18_1.png}};
+% Depth 1 (Appears on Slide 2)
+\node[below left=.3cm and -0.5cm of root] (child1) {\includegraphics[width=0.25\textwidth]{figure/01_bike_sharing_dataset_28_0.png}};
+\node[below right=.3cm and -0cm of root] (child2) {\includegraphics[width=0.25\textwidth]{figure/01_bike_sharing_dataset_28_1.png}};
+\draw (root) -- node[pos=0.15, left] {workingday=False} (child1);
+\draw (root) -- node[pos=0.15, right] {workingday=True} (child2);
+% Depth 2 (Appears on Slide 3)
+\node[below left=0.3cm and -1.8cm of child1] (child11) {\includegraphics[width=0.25\textwidth]{figure/01_bike_sharing_dataset_29_0.png}};
+\node[below right=0.3cm and -1.8cm of child1] (child21) {\includegraphics[width=0.25\textwidth]{figure/01_bike_sharing_dataset_29_1.png}};
+\node[below left=0.3cm and -1.8cm of child2] (child12) {\includegraphics[width=0.25\textwidth]{figure/01_bike_sharing_dataset_29_2.png}};
+\node[below right=.3cm and -1.8cm of child2] (child22) {\includegraphics[width=0.25\textwidth]{figure/01_bike_sharing_dataset_29_3.png}};
+\draw (child1) -- node[midway, left] {temp=cold} (child11);
+\draw (child1) -- node[midway, right] {temp=hot} (child21);
+\draw (child2) -- node[midway, left] {temp=cold} (child12);
+\draw (child2) -- node[midway, right] {temp=hot} (child22);
+\end{tikzpicture}
+}
+\end{framev}
 
 
 %we want to split $\mathcal{N}$ in such a way that ICE curves within the obtained regions have a similar shape meaning that the distance of these ICE curves to the REP estimate (i.e., $\hat{f}^{PD}_{S|\mathcal{N}_g} (\xv_j):= \frac{1}{|\mathcal{N}_g|}\sum_{i \in \mathcal{N}_g} \hat{f}\left(\xv_j, \xv_C^{(i)}\right)$) is small.

--- a/slides/regional-effects/slides02-fe-regional-intImp.tex
+++ b/slides/regional-effects/slides02-fe-regional-intImp.tex
@@ -1,4 +1,4 @@
-\documentclass[10pt,compress,t,notes=noshow, xcolor=table]{beamer}
+\documentclass[10pt,compress,t,notes=noshow,xcolor=table]{beamer}
 
 \input{../../style/preamble}
 \input{../../latex-math/basic-math}
@@ -20,59 +20,55 @@
 \newcommand{\highlightFG}[1]{\colorbox{ForestGreen!70}{$\displaystyle #1$}}
 
 \usepackage{tikz}
-\usetikzlibrary{shapes,arrows,automata,positioning,calc,chains,trees, shadows}
+\usetikzlibrary{shapes,arrows,automata,positioning,calc,chains,trees,shadows}
 \tikzset{
-  %Define standard arrow tip
-  >=stealth',
-  %Define style for boxes
-  punkt/.style={
-    rectangle,
-    rounded corners,
-    draw=black, very thick,
-    text width=6.5em,
-    minimum height=2em,
-    text centered},
-  % Define arrow style
-  pil/.style={
-    ->,
-    thick,
-    shorten <=2pt,
-    shorten >=2pt,}
+%Define standard arrow tip
+>=stealth',
+%Define style for boxes
+punkt/.style={
+rectangle,
+rounded corners,
+draw=black, very thick,
+text width=6.5em,
+minimum height=2em,
+text centered},
+% Define arrow style
+pil/.style={
+->,
+thick,
+shorten <=2pt,
+shorten >=2pt,}
 }
 
 % definition of the style
-\tikzset{exampleblock/.style={rounded corners,rectangle split, rectangle split parts=4, draw, 
+\tikzset{exampleblock/.style={rounded corners,rectangle split, rectangle split parts=4, draw,
 rectangle split part fill={gray!20, gray!20, cice!20, orange!20},minimum width=0.3\textwidth
 }}
 \tikzset{main node/.style={rectangle,draw,minimum size=1cm,inner sep=4pt},}
-\usetikzlibrary{calc}
-\usetikzlibrary{chains, positioning, arrows, trees, shadows}
 %\input{figure/gear.tex}
 %http://tex.stackexchange.com/questions/6135/how-to-make-beamer-overlays-with-tikz-node
 \tikzset{
-  %Style of the black box
-  bbox/.style={draw, fill=black, minimum size=3cm,
-  label={[white, yshift=-1.3em]above:$in$},
-  label={[white, yshift=1.3em]below:$out$},
-  label={[rotate = 90, xshift=1em, yshift=0.5em]left:Black-Box}
-  },
-  multiple/.style={double copy shadow={shadow xshift=1.5ex,shadow
-  yshift=-0.5ex,draw=black!30,fill=white}},
+%Style of the black box
+bbox/.style={draw, fill=black, minimum size=3cm,
+label={[white, yshift=-1.3em]above:$in$},
+label={[white, yshift=1.3em]below:$out$},
+label={[rotate = 90, xshift=1em, yshift=0.5em]left:Black-Box}
+},
+multiple/.style={double copy shadow={shadow xshift=1.5ex,shadow
+yshift=-0.5ex,draw=black!30,fill=white}},
 }
 
 % for overlay box
 \usetikzlibrary{backgrounds,shapes.multipart}
 \pgfdeclarelayer{myback}
-\pgfsetlayers{background,main,myback} %<= insert the myback 
+\pgfsetlayers{background,main,myback} %<= insert the myback
 % after the "main" to display the content in front of the usual content
 
 
 % Defines macros and environments
- 
 \title{Interpretable Machine Learning}
 % \author{LMU}
 %\institute{\href{https://compstat-lmu.github.io/lecture_iml/}{compstat-lmu.github.io/lecture\_iml}}
-\date{}
 
 
 \begin{document}
@@ -89,177 +85,163 @@ figure/sim1_dt_split1.png
 }
 
 
-\begin{frame}{Interaction quantification}
+\begin{framev}[align=top]{Interaction quantification}
 It's helpful to know not just how another feature changes the marginal effect of $x_S$ but how strong that interaction is and want to rank features by it.
-
+\\
+\spacer[0.25]
 \textbf{Approaches:}
-\begin{itemize}
-    \item \textbf{H-Statistics:} Variance of the deviation between the joint PDP and the sum of marginal PDPs (larger variance $\Rightarrow$ stronger interaction).
-    \item \textbf{Greenwell’s Interaction Index:} Difference between variance of the PDP and the mean variance of centered ICE curves for the same feature pair.
-    \item \textbf{SHAP interaction index (\furtherreading{HERBINGER2022}, \furtherreading{LUNDBERG2018}):} Proportion of all two-way interactions with $x_i$  to which the $j$-th feature contributes.
-\end{itemize}
-
+\begin{itemizeM}
+\item \textbf{H-Statistics:} Variance of the deviation between the joint PDP and the sum of marginal PDPs (larger variance $\Rightarrow$ stronger interaction).
+\item \textbf{Greenwell’s Interaction Index:} Difference between variance of the PDP and the mean variance of centered ICE curves for the same feature pair.
+\item \textbf{SHAP interaction index (\furtherreading{HERBINGER2022}, \furtherreading{LUNDBERG2018}):} Proportion of all two-way interactions with $x_i$ to which the $j$-th feature contributes.
+\end{itemizeM}
 \pause
-
 \textbf{Pitfalls:}
-\begin{itemize}
-    \item The values of H-Statistic and the Greenwell’s Interaction Index are influenced by the
- main effects of the two regarded features.
-    \item SHAP interaction index does not suffer from main effect problem. However, correlation between the two features can bias the interaction value. Same applies to the H-Statistic.  
-\end{itemize}
-
-\end{frame}
-
-\begin{frame}{REPID Interaction Importance}
+\begin{itemizeM}
+\item The values of H-Statistic and the Greenwell’s Interaction Index are influenced by the main effects of the two regarded features.
+\item SHAP interaction index does not suffer from main effect problem. However, correlation between the two features can bias the interaction value. Same applies to the H-Statistic.
+\end{itemizeM}
+\end{framev}
 
 
+\begin{framev}[align=top]{REPID Interaction Importance}
 \textbf{On parent node level (for {\color{mygreen}$\mathcal{N}_{parent}$}):}
 %Relative interaction importance for each parent node :
 $$
-   intImp({\color{mygreen}{\mathcal{N}_{parent}}}) = \frac{\mathcal{R}({\color{mygreen}\mathcal{N}_{parent}}) - (\mathcal{R}({\color{amber}\mathcal{N}_{left}}) + \mathcal{R}({\color{red}\mathcal{N}_{right}}))}{\mathcal{R}({\color{blue}\mathcal{N}})} 
+intImp({\color{mygreen}{\mathcal{N}_{parent}}}) = \frac{\mathcal{R}({\color{mygreen}\mathcal{N}_{parent}}) - (\mathcal{R}({\color{amber}\mathcal{N}_{left}}) + \mathcal{R}({\color{red}\mathcal{N}_{right}}))}{\mathcal{R}({\color{blue}\mathcal{N}})}
 $$
-\begin{columns}[T, totalwidth=\textwidth]
-    \begin{column}{0.55\textwidth}
-
+\splitVTT[0.55]{
 \textbf{Interpretation:}
-Reduction of ICE curve variance after one split of $\mathcal{N}_{parent}$ into $\mathcal{N}_{left}$ and $\mathcal{N}_{right}$ 
+Reduction of ICE curve variance after one split of $\mathcal{N}_{parent}$ into $\mathcal{N}_{left}$ and $\mathcal{N}_{right}$
 relative to the ICE curve variance in the root node $\mathcal{N}$.
-
-\medskip
-
+\\
+\spacer[0.25]
 \begin{center}
-      \resizebox{0.5\linewidth}{!}{
+\resizebox{0.5\linewidth}{!}{
 \begin{tikzpicture}
-    \usetikzlibrary{arrows}
-    \usetikzlibrary{shapes}
-
-    % Define node styles
-    \tikzset{
-        treenode/.style={draw, rectangle, minimum size=1cm, text centered},
-        N/.style={draw, rectangle, minimum size=1cm, text centered, color=blue, text=blue},
-        Np/.style={draw, rectangle, minimum size=1cm, text centered, color=mygreen, text=mygreen},
-        Nl/.style={draw, rectangle, minimum size=1cm, text centered, color=amber, text=amber},
-        Nr/.style={draw, rectangle, minimum size=1cm, text centered, color=red, text=red}
-    }
-
-    % Nodes
-    \node [N] (a0) {$\mathcal{N}$}; % Top node
-    \node [treenode, below right=1cm and 0.7cm of a0] (a1) {}; % Bottom right node
-    \node [Np, below left=0.7cm and 1cm of a0] (a2) {$\mathcal{N}_{parent}$}; % Bottom center node
-    \node [Nl, below=0.7cm of a2, xshift=-1cm] (a3) {$\mathcal{N}_{left}$}; % Bottom left node
-    \node [Nr, below=0.7cm of a2, xshift=1cm] (a4) {$\mathcal{N}_{right}$}; % Bottom right node from center
-
-    % Lines
-    \draw [thick] (a0) -- (a1);
-    \draw [thick] (a0) -- (a2);
-    \draw [thick] (a2) -- (a3);
-    \draw [thick] (a2) -- (a4);
+% Define node styles
+\tikzset{
+treenode/.style={draw, rectangle, minimum size=1cm, text centered},
+N/.style={draw, rectangle, minimum size=1cm, text centered, color=blue, text=blue},
+Np/.style={draw, rectangle, minimum size=1cm, text centered, color=mygreen, text=mygreen},
+Nl/.style={draw, rectangle, minimum size=1cm, text centered, color=amber, text=amber},
+Nr/.style={draw, rectangle, minimum size=1cm, text centered, color=red, text=red}
+}
+% Nodes
+\node [N] (a0) {$\mathcal{N}$}; % Top node
+\node [treenode, below right=1cm and 0.7cm of a0] (a1) {}; % Bottom right node
+\node [Np, below left=0.7cm and 1cm of a0] (a2) {$\mathcal{N}_{parent}$}; % Bottom center node
+\node [Nl, below=0.7cm of a2, xshift=-1cm] (a3) {$\mathcal{N}_{left}$}; % Bottom left node
+\node [Nr, below=0.7cm of a2, xshift=1cm] (a4) {$\mathcal{N}_{right}$}; % Bottom right node from center
+% Lines
+\draw [thick] (a0) -- (a1);
+\draw [thick] (a0) -- (a2);
+\draw [thick] (a2) -- (a3);
+\draw [thick] (a2) -- (a4);
 \end{tikzpicture}}
-
 \end{center}
-    \end{column}
+}{
 \pause
-    \begin{column}{0.45\textwidth}
-  %\centering\includegraphics[width = 0.6\textwidth]{figure/tree_expl.png}
- \centering
-\includegraphics[width = 0.95\textwidth]{figure/sim1_fake.png}
-
+\spacer[0]
+%\centering\includegraphics[width = 0.6\textwidth]{figure/tree_expl.png}
+\centering
+\image[0.95]{figure/sim1_fake.png}
+\\
+\spacer[0.25]
 Split reduces 83.5\% of variance.
-    \end{column}
-\end{columns}
-
-\end{frame}
+}
+\end{framev}
 
 
-\begin{frame}{REPID Interaction Importance}
-    
-\begin{columns}[T, totalwidth=\textwidth]%, totalwidth=\textwidth]
-    \begin{column}{0.53\textwidth}
-
-\textbf{On feature level (for $x_j$):} 
+\begin{framev}[align=top]{REPID Interaction Importance}
+\splitVTT[0.52]{
+\textbf{On feature level (for $x_j$):}
 %Relative interaction importance for feature $x_j$:
 %We denote this subset by $\mathcal{B}_j \subset \mathcal{B}_P$ and the relative interaction importance by
-\medskip
-
-\centerline{$\textstyle
-   intImp_j = \sum\nolimits_{i \in \mathcal{B}_j} intImp(\mathcal{N}_i)$}
-
-\medskip
-
+\\
+\spacer[0.25]
+$$
+\textstyle intImp_j = \sum\nolimits_{i \in \mathcal{B}_j} intImp(\mathcal{N}_i)
+$$
 %\textbf{$\bm{intImp(\mathcal{N}_P)}$: risk reduction after one split relative to the root node risk}
 %where $\mathcal{B}_j$ indexes parent nodes where splits are based on $x_j$.
 where $\mathcal{B}_j$ indexes parent nodes split by $x_j$.
-
-\medskip
-
+\\
+\spacer[0.25]
 \textbf{Interpretation:}
 Overall reduction of ICE curve variance due to splits by $X_j$ (in \%).
-
-\medskip
-
-\textbf{Example:} For $X_1 \Rightarrow$  {\color{orange} $\mathcal{B}_1 = \{0, 2, 3\}$}
-    \begin{center}
-      \resizebox{1\textwidth}{!}{
+\\
+\spacer[0.25]
+\textbf{Example:} For $X_1 \Rightarrow$ {\color{orange} $\mathcal{B}_1 = \{0, 2, 3\}$}
+\begin{center}
+\resizebox{1\textwidth}{!}{
 \begin{tikzpicture}[scale=0.7, transform shape]
-    \tikzset{treenode/.style={draw, rectangle, font=\LARGE}}
-    \tikzset{line/.style={draw, thick}}
-
-    % Root node
-    \node [treenode, fill=orange] (a0) {$\mathcal{N}_0$};
-
-    % Level 1 nodes
-    \node [treenode, below=1cm of a0, xshift=-3cm] (a1) {$\mathcal{N}_1$};
-    \node [treenode, fill=orange, below=1cm of a0, xshift=3cm] (a2) {$\mathcal{N}_2$};
-
-    % Level 2 nodes
-    \node [treenode, fill=orange, below=1cm of a1, xshift=-1.5cm] (a3) {$\mathcal{N}_3$};
-    \node [treenode, below=1cm of a1, xshift=1.5cm] (a4) {$\mathcal{N}_4$};
-    \node [treenode, below=1cm of a2, xshift=-1.5cm] (a5) {$\mathcal{N}_5$};
-    \node [treenode, below=1cm of a2, xshift=1.5cm] (a6) {$\mathcal{N}_6$};
-
-    % Level 3 nodes
-    \node [treenode, below=1cm of a3, xshift=-0.75cm] (a7) {$\mathcal{N}_7$};
-    \node [treenode, below=1cm of a3, xshift=0.75cm] (a8) {$\mathcal{N}_8$};
-    \node [treenode, below=1cm of a4, xshift=-0.75cm] (a9) {$\mathcal{N}_9$};
-    \node [treenode, below=1cm of a4, xshift=0.75cm] (a10) {$\mathcal{N}_{10}$};
-    \node [treenode, below=1cm of a5, xshift=-0.75cm] (a11) {$\mathcal{N}_{11}$};
-    \node [treenode, below=1cm of a5, xshift=0.75cm] (a12) {$\mathcal{N}_{12}$};
-    \node [treenode, below=1cm of a6, xshift=-0.75cm] (a13) {$\mathcal{N}_{13}$};
-    \node [treenode, below=1cm of a6, xshift=0.75cm] (a14) {$\mathcal{N}_{14}$};
-
-    % Edges and labels
-    \path [line] (a0.south) -- + (0,-0.5cm) -| (a1.north) node [pos=0.4, above, color=orange] {$X_1 < 5$};
-    \path [line] (a0.south) -- + (0,-0.5cm) -| (a2.north) node [pos=0.4, above, color=orange] {$X_1 \geq 5$};
-
-    \path [line] (a1.south) -- + (0,-0.5cm) -| (a3.north) node [pos=0.3, above, yshift = -0.05cm] {$X_2 < 3$};
-    \path [line] (a1.south) -- + (0,-0.5cm) -| (a4.north) node [pos=0.3, above, yshift = -0.05cm] {$X_2 \geq 3$};
-
-    \path [line] (a2.south) -- + (0,-0.5cm) -| (a5.north) node [pos=0.3, above, color=orange, yshift = -0.05cm] {$X_1 < 7$};
-    \path [line] (a2.south) -- + (0,-0.5cm) -| (a6.north) node [pos=0.3, above, color=orange, yshift = -0.05cm] {$X_1 \geq 7$};
-
-    \path [line] (a3.south) -- + (0,-0.5cm) -| (a7.north) node [pos=0.5, above, color=orange, yshift = -0.05cm] {\small $X_1 < 2$};
-    \path [line] (a3.south) -- + (0,-0.5cm) -| (a8.north) node [pos=0.5, above, color=orange, yshift = -0.05cm] {\small $X_1 \geq 2$};
-
-    \path [line] (a4.south) -- + (0,-0.5cm) -| (a9.north) node [pos=0.5, above, yshift = -0.05cm] {\small $X_3 < 4$};
-    \path [line] (a4.south) -- + (0,-0.5cm) -| (a10.north) node [pos=0.5, above, yshift = -0.05cm] {\small $X_3 \geq 4$};
-
-    \path [line] (a5.south) -- + (0,-0.5cm) -| (a11.north) node [pos=0.5, above, yshift = -0.05cm] {\small $X_2 < 5$};
-    \path [line] (a5.south) -- + (0,-0.5cm) -| (a12.north) node [pos=0.5, above, yshift = -0.05cm] {\small $X_2 \geq 5$};
-
-    \path [line] (a6.south) -- + (0,-0.5cm) -| (a13.north) node [pos=0.5, above, yshift = -0.05cm] {\small $X_4 < 7$};
-    \path [line] (a6.south) -- + (0,-0.5cm) -| (a14.north) node [pos=0.5, above, yshift = -0.05cm] {\small $X_4 \geq 7$};
-
+\tikzset{treenode/.style={draw, rectangle, font=\LARGE}}
+\tikzset{line/.style={draw, thick}}
+% Root node
+\node [treenode, fill=orange] (a0) {$\mathcal{N}_0$};
+% Level 1 nodes
+\node [treenode, below=1cm of a0, xshift=-3cm] (a1) {$\mathcal{N}_1$};
+\node [treenode, fill=orange, below=1cm of a0, xshift=3cm] (a2) {$\mathcal{N}_2$};
+% Level 2 nodes
+\node [treenode, fill=orange, below=1cm of a1, xshift=-1.5cm] (a3) {$\mathcal{N}_3$};
+\node [treenode, below=1cm of a1, xshift=1.5cm] (a4) {$\mathcal{N}_4$};
+\node [treenode, below=1cm of a2, xshift=-1.5cm] (a5) {$\mathcal{N}_5$};
+\node [treenode, below=1cm of a2, xshift=1.5cm] (a6) {$\mathcal{N}_6$};
+% Level 3 nodes
+\node [treenode, below=1cm of a3, xshift=-0.75cm] (a7) {$\mathcal{N}_7$};
+\node [treenode, below=1cm of a3, xshift=0.75cm] (a8) {$\mathcal{N}_8$};
+\node [treenode, below=1cm of a4, xshift=-0.75cm] (a9) {$\mathcal{N}_9$};
+\node [treenode, below=1cm of a4, xshift=0.75cm] (a10) {$\mathcal{N}_{10}$};
+\node [treenode, below=1cm of a5, xshift=-0.75cm] (a11) {$\mathcal{N}_{11}$};
+\node [treenode, below=1cm of a5, xshift=0.75cm] (a12) {$\mathcal{N}_{12}$};
+\node [treenode, below=1cm of a6, xshift=-0.75cm] (a13) {$\mathcal{N}_{13}$};
+\node [treenode, below=1cm of a6, xshift=0.75cm] (a14) {$\mathcal{N}_{14}$};
+% Edges and labels
+\path [line] (a0.south) -- + (0,-0.5cm) -| (a1.north) node [pos=0.4, above, color=orange] {$X_1 < 5$};
+\path [line] (a0.south) -- + (0,-0.5cm) -| (a2.north) node [pos=0.4, above, color=orange] {$X_1 \geq 5$};
+\path [line] (a1.south) -- + (0,-0.5cm) -| (a3.north) node [pos=0.3, above, yshift = -0.05cm] {$X_2 < 3$};
+\path [line] (a1.south) -- + (0,-0.5cm) -| (a4.north) node [pos=0.3, above, yshift = -0.05cm] {$X_2 \geq 3$};
+\path [line] (a2.south) -- + (0,-0.5cm) -| (a5.north) node [pos=0.3, above, color=orange, yshift = -0.05cm] {$X_1 < 7$};
+\path [line] (a2.south) -- + (0,-0.5cm) -| (a6.north) node [pos=0.3, above, color=orange, yshift = -0.05cm] {$X_1 \geq 7$};
+\path [line] (a3.south) -- + (0,-0.5cm) -| (a7.north) node [pos=0.5, above, color=orange, yshift = -0.05cm] {\small $X_1 < 2$};
+\path [line] (a3.south) -- + (0,-0.5cm) -| (a8.north) node [pos=0.5, above, color=orange, yshift = -0.05cm] {\small $X_1 \geq 2$};
+\path [line] (a4.south) -- + (0,-0.5cm) -| (a9.north) node [pos=0.5, above, yshift = -0.05cm] {\small $X_3 < 4$};
+\path [line] (a4.south) -- + (0,-0.5cm) -| (a10.north) node [pos=0.5, above, yshift = -0.05cm] {\small $X_3 \geq 4$};
+\path [line] (a5.south) -- + (0,-0.5cm) -| (a11.north) node [pos=0.5, above, yshift = -0.05cm] {\small $X_2 < 5$};
+\path [line] (a5.south) -- + (0,-0.5cm) -| (a12.north) node [pos=0.5, above, yshift = -0.05cm] {\small $X_2 \geq 5$};
+\path [line] (a6.south) -- + (0,-0.5cm) -| (a13.north) node [pos=0.5, above, yshift = -0.05cm] {\small $X_4 < 7$};
+\path [line] (a6.south) -- + (0,-0.5cm) -| (a14.north) node [pos=0.5, above, yshift = -0.05cm] {\small $X_4 \geq 7$};
 \end{tikzpicture}}
-    \end{center}
-    \end{column}
+\end{center}
+}{
 \pause
-    \begin{column}{0.54\textwidth}
-
-
-    \centering
-    \includegraphics[width=\textwidth]{figure/sim1}
-    
-    \textbf{Note:} \textit{intImp} can also be used as a stopping criterion.
+\spacer[0]
+\centering
+\begin{tikzpicture}
+\node[inner sep=0pt,anchor=north west] (simone) at (0,0) {\image[1]{figure/sim1}};
+\node[anchor=north west,inner sep=0pt] at ([xshift=0.75\linewidth,yshift=-0.13\linewidth]simone.north west) {
+\begin{minipage}{0.19\linewidth}
+\centering
+\begin{scriptsize}
+\setlength{\tabcolsep}{1pt}
+\begin{tabular}{|c|c|}
+\hline
+$x_j$ & $intImp_j$ \\\hline
+\rowcolor{ForestGreen!70}
+$\xv_3$ & 0.835 \\
+\rowcolor{YellowGreen!50}
+$\xv_1$ & 0.14\\\hline
+\end{tabular}
+\\[-0.2ex]
+$= 0.975$
+\end{scriptsize}
+\end{minipage}
+};
+\end{tikzpicture}
+\\
+\spacer[0.25]
+\textbf{Note:} \textit{intImp} can also be used as a stopping criterion.\\
      %\begin{minipage}[t]{.5\textwidth}
     %   \includegraphics[width=0.37\textwidth]{figure/sim1_dt_split1.png}
     %   \scalebox{1}{
@@ -290,126 +272,91 @@ Overall reduction of ICE curve variance due to splits by $X_j$ (in \%).
     %   }
     % \includegraphics[width=0.37\textwidth]{figure/sim1_dt_split2_1.png}
     % \includegraphics[width=0.37\textwidth]{figure/sim1_dt_split2_2.png}
-    
- \vspace{-200px}
-    \scriptsize
- \hspace{130px}
- \setlength{\tabcolsep}{1pt}
- \begin{tabular}{|c|c|}
-    \hline
-       $x_j$ & $intImp_j$  \\\hline
-       \rowcolor{ForestGreen!70}
-        $\xv_3$     & 0.835 \\
-        \rowcolor{YellowGreen!50}
-        $\xv_1$     &  0.14\\\hline
-    \end{tabular}\\
- \hspace{138px}= 0.975
       %\footnotesize\\
     %\vspace{150px}
-
-    \end{column}
-
-\end{columns}
-
-\end{frame}
+}
+\end{framev}
 
 
-
-
-
-\begin{frame}{Outperforming SOTA}
-
+\begin{framev}[align=top]{Outperforming SOTA}
 \textbf{Simulation setting}
-\begin{itemize}
-    \item Draw 1000 i.i.d. samples from $X_1, \ldots , X_4 \sim \mathcal{U}(-1,1)$
-    \item True underlying function: $f(\xv) = \sum\nolimits_{j=1}^4 \xv_j + \xv_1 \xv_2 + \xv_2 \xv_3 + \xv_1 \xv_3 + \xv_1 \xv_2 \xv_3 + \epsilon$ % , \epsilon \sim \mathbbm{N}(0, 0.01 \sigma(\mu(\xv))^2)
-    \item Fit a correctly specified linear model (interactions with $\xv_4$ are excluded)
-    \item 30 reps, measure interaction strength between $\xv_2$ and all other 3 features
-\end{itemize}
-
+\begin{itemizeM}
+\item Draw 1000 i.i.d. samples from $X_1, \ldots , X_4 \sim \mathcal{U}(-1,1)$
+\item True underlying function: $f(\xv) = \sum\nolimits_{j=1}^4 \xv_j + \xv_1 \xv_2 + \xv_2 \xv_3 + \xv_1 \xv_3 + \xv_1 \xv_2 \xv_3 + \epsilon$ % , \epsilon \sim \mathbbm{N}(0, 0.01 \sigma(\mu(\xv))^2)
+\item Fit a correctly specified linear model (interactions with $\xv_4$ are excluded)
+\item 30 reps, measure interaction strength between $\xv_2$ and all other 3 features
+\end{itemizeM}
 \textbf{Which methods are sensitive to changes in main effect sizes or feature correlations?}
-
-
-    \begin{table}[thb]
-\vspace{.1in}
-    \label{tab:simSummary}
-    \begin{center}
-    \begin{tabular}{|p{5.4cm}|p{1.6cm}|p{1.8cm}|p{1.6cm}|p{1.6cm}|}
-    \hline
-       Pitfall & REPID & H-Statistic & Greenwell & SHAP  \\\hline
-       sensitive to changes of main effect & No & Yes & Yes & No\\\hline
-       sensitive to changes of correlation between $\xv_j$ and other features & No & Yes & No & Yes\\
-  \hline
-    \end{tabular}
-    \end{center}
+\\
+\spacer[0.25]
+\begin{table}[thb]
+\label{tab:simSummary}
+\begin{center}
+\begin{tabular}{|p{5.4cm}|p{1.6cm}|p{1.8cm}|p{1.6cm}|p{1.6cm}|}
+\hline
+Pitfall & REPID & H-Statistic & Greenwell & SHAP \\\hline
+sensitive to changes of main effect & No & Yes & Yes & No\\\hline
+sensitive to changes of correlation between $\xv_j$ and other features & No & Yes & No & Yes\\
+\hline
+\end{tabular}
+\end{center}
 \end{table}
-\vspace*{0.2cm}
+\end{framev}
 
 
+\begin{framev}[align=top]{Outperforming SOTA}
+\begin{center}
+\includegraphics[width=0.4\textwidth,page=1]{figure/sim_sensi_linear.pdf}
+\includegraphics[width=0.4\textwidth,page=2]{figure/sim_sensi_linear.pdf}
+\end{center}
+\begin{itemizeM}
+\item \textbf{Left (initial setting)}: Interaction strength of $\xv_1$:$\xv_2$ and $\xv_3$:$\xv_2$ similar; $\xv_4$:$\xv_2$ no interaction
+\item \textbf{Right}: Set main effect $\beta_1$ = 0.1
+\begin{itemizeS}
+\item \textbf{Expectation}: Interaction strengths should not change
+\item \textbf{Fail}: H-statistic ($\xv_1$:$\xv_2$ > $\xv_3$:$\xv_2$) and Greenwell ($\xv_1$:$\xv_2$ < $\xv_3$:$\xv_2$)
+\end{itemizeS}
+\end{itemizeM}
+\end{framev}
 
 
-\end{frame}
-
-\begin{frame}{Outperforming SOTA}
-\centerline{
-\includegraphics[width=0.4\textwidth, page = 1]{figure/sim_sensi_linear.pdf}
-\includegraphics[width=0.4\textwidth, page = 2]{figure/sim_sensi_linear.pdf}
-}
-
-   \begin{itemize}
-       \item \textbf{Left (initial setting)}: Interaction strength of $\xv_1$:$\xv_2$ and $\xv_3$:$\xv_2$ similar; $\xv_4$:$\xv_2$ no interaction
-       \item \textbf{Right}: Set main effect $\beta_1$ = 0.1
-       
-   \begin{itemize}
-       \item \textbf{Expectation}: Interaction strengths should not change
-       \item \textbf{Fail}: H-statistic ($\xv_1$:$\xv_2$ > $\xv_3$:$\xv_2$) and Greenwell ($\xv_1$:$\xv_2$ < $\xv_3$:$\xv_2$) 
-   \end{itemize}
-   \end{itemize}
-\end{frame}
-
-\begin{frame}{Outperforming SOTA}
-\centerline{
-\includegraphics[width=0.4\textwidth, page = 1]{figure/sim_sensi_linear.pdf}
-\includegraphics[width=0.4\textwidth, page = 3]{figure/sim_sensi_linear.pdf}
-}
-  \begin{itemize}
-        \item \textbf{Left (initial setting)}: Interaction strength of $\xv_1$:$\xv_2$ and $\xv_3$:$\xv_2$ similar; $\xv_4$:$\xv_2$ no interaction
-       \item \textbf{Right}: Increase correlation $\rho(\xv_1, \xv_2) = 0.9$
-          \begin{itemize}
-       \item \textbf{Expectation}: Interaction strengths should not change
-       \item \textbf{Fail}: H-statistic ($\xv_1$:$\xv_2$ < $\xv_3$:$\xv_2$) and Shapley ($\xv_1$:$\xv_2$ > $\xv_3$:$\xv_2$)
-   \end{itemize}
-       \item[$\rightarrow$] \textbf{REPID is the only method which always leads to correct rankings for these settings}  
-   \end{itemize}
-   
-\end{frame}
+\begin{framev}[align=top]{Outperforming SOTA}
+\begin{center}
+\includegraphics[width=0.4\textwidth,page=1]{figure/sim_sensi_linear.pdf}
+\includegraphics[width=0.4\textwidth,page=3]{figure/sim_sensi_linear.pdf}
+\end{center}
+\begin{itemizeM}
+\item \textbf{Left (initial setting)}: Interaction strength of $\xv_1$:$\xv_2$ and $\xv_3$:$\xv_2$ similar; $\xv_4$:$\xv_2$ no interaction
+\item \textbf{Right}: Increase correlation $\rho(\xv_1, \xv_2) = 0.9$
+\begin{itemizeS}
+\item \textbf{Expectation}: Interaction strengths should not change
+\item \textbf{Fail}: H-statistic ($\xv_1$:$\xv_2$ < $\xv_3$:$\xv_2$) and Shapley ($\xv_1$:$\xv_2$ > $\xv_3$:$\xv_2$)
+\end{itemizeS}
+\item[$\rightarrow$] \textbf{REPID is the only method which always leads to correct rankings for these settings}
+\end{itemizeM}
+\end{framev}
 
 
-
-\begin{frame}{Limitations of REPID}
-
-\begin{columns}[T, totalwidth = \textwidth]
-    \begin{column}{0.6\textwidth}
-
+\begin{framev}[align=top]{Limitations of REPID}
+\splitVTT[0.5]{
 %\pause
 % \textbf{Limitations}:
-      \begin{itemize}
-  \item[1)] Restricted to one feature of interest \\
-  $\Rightarrow$ Different regions for different features \\
+\spacer[0.6]
+\begin{itemizeM}
+\item[1)] Restricted to one feature of interest \\
+$\Rightarrow$ Different regions for different features \\
   %$\Rightarrow$ No unique decomposition of $\hat{f}(x)$\\%iction function possible\\
   %\item Restricted to ICE curves and PDs $\rightarrow$ not flexible w.r.t. feature effect method
   %\pause
-  \item<2->[2)] Restricted to PD (global) and ICE (local) as feature effect methods\\
-  $\Rightarrow$ Inherits extrapolation problem\\
+\item<2->[2)] Restricted to PD (global) and ICE (local) as feature effect methods\\
+$\Rightarrow$ Inherits extrapolation problem\\
   %\phantom{$\Rightarrow$} 
-  (unlikely combinations of feature values)
+(unlikely combinations of feature values)
       %\item Feature effect methods based on integrating over marginal distributions such as ICE and PD might extrapolate in unseen or sparse regions (e.g., small $\xv_1$ and high $\xv_3$ values)
       %\item Global/regional effects are not representative w.r.t. the data distribution  
-   \item<2->[$\leadsto$] Follow-up GADGET %``Generalized Additive Decomposition of Global feature EffecTs based on interactions'' 
+\item<2->[$\leadsto$] Follow-up GADGET %``Generalized Additive Decomposition of Global feature EffecTs based on interactions''
 [under review]
-  \end{itemize}
-
-
+\end{itemizeM}
         % \begin{itemize}
         %     \item $f(X) = 3X_1\mathbbm{1}_{X_3>0} - 3X_1\mathbbm{1}_{X_3\leq 0} + X_3 + \epsilon$
         %     \item Features uniformly distributed
@@ -417,41 +364,40 @@ Overall reduction of ICE curve variance due to splits by $X_j$ (in \%).
         %     \item Right: $X_1$ and $X_3$ highly correlated
         %     \item First split: $\xv_3 \leq 0$ (blue) and $\xv_3 > 0$ (orange)
         % \end{itemize}
-    \end{column}
-
-    \only<1>{   \begin{column}{0.52\textwidth}
-    \centering
-    \includegraphics[width=0.95\textwidth]{figure/sim1}
-    \vspace{-8pt}
-        \begin{columns}[T, totalwidth = \linewidth]
-     \footnotesize
-            \begin{column}{0.125\linewidth}
-            \centering
-             $\hat{f}_2^{PD}(X_2)$ %, X_1 > 0 \land X_3 = 0\)\\
-         \end{column}
-         \begin{column}{0.175\linewidth}
-         \centering
-             $\approx 8X_2$ %, X_1 > 0 \land X_3 = 0\)\\
-         \end{column}
-        \begin{column}{0.225\linewidth}
+}{
+\spacer[0]
+\only<1>{
 \centering
-            $\approx 16X_2$ %, X_1 \leq 0 \land X_3 = 0\)
-         \end{column}
-        \begin{column}{0.225\linewidth}
-        \centering
-            $ \approx -8X_2$ %, X_1 \leq 0 \land X_3 \neq 0\)
-         \end{column}        
-         \begin{column}{0.225\linewidth}
-         \centering
-             $\approx 0$%, X_1 > 0 \land X_3 \neq 0\)\\
-         \end{column}
-        \begin{column}{0.025\linewidth}
-
-         \end{column}
-     \end{columns}
-    \end{column}
+\image[1]{figure/sim1}
+\\
+\spacer[-0.5]
+\begin{footnotesize}
+\begin{columns}[T,totalwidth=\linewidth]
+\begin{column}{0.15\linewidth}
+\centering
+$\hat{f}_2^{PD}(X_2)$ %, X_1 > 0 \land X_3 = 0\)\\
+\end{column}
+\begin{column}{0.17\linewidth}
+$\text{    } \approx 8X_2$ %, X_1 > 0 \land X_3 = 0\)\\
+\end{column}
+\begin{column}{0.22\linewidth}
+\centering
+$\approx 16X_2$ %, X_1 \leq 0 \land X_3 = 0\)
+\end{column}
+\begin{column}{0.22\linewidth}
+\centering
+$ \approx -8X_2$ %, X_1 \leq 0 \land X_3 \neq 0\)
+\end{column}
+\begin{column}{0.22\linewidth}
+\centering
+$\approx 0$%, X_1 > 0 \land X_3 \neq 0\)\\
+\end{column}
+\begin{column}{0.02\linewidth}
+\end{column}
+\end{columns}
+\end{footnotesize}
 }
-    \only<2->{\begin{column}{0.52\textwidth}
+\only<2->{
         %\begin{figure}
       %   \hspace{0.025\linewidth} uncorrelated \hspace{0.225\linewidth} correlated \hspace{0.2\linewidth}
       % \includegraphics[width = \textwidth]{figure/example_repid_extrapol.pdf}
@@ -462,9 +408,8 @@ Overall reduction of ICE curve variance due to splits by $X_j$ (in \%).
       %          \item Model: Tuned feedforward NN
       %          \item Split: $X_3 \leq 0$ (blue), $X_3 > 0$ (orange)
       %      \end{itemize}
-      \centering
- \includegraphics[width = 0.675
- \textwidth]{figure/ale_pdplot.png}
+\centering
+\image[0.675]{figure/ale_pdplot.png}
      % \caption{
       %$X_1, X_2, X_3 \sim \mathbbm{U}(-1,1)$ and 
       %$Y = 3X_1\mathbbm{1}_{X_3>0} - 3X_1\mathbbm{1}_{X_3\leq 0} + X_3 + \epsilon$% with $\epsilon \sim \mathbb{N}(0,0.09)$. 
@@ -472,37 +417,32 @@ Overall reduction of ICE curve variance due to splits by $X_j$ (in \%).
       %$X_1 = X_3 + \delta$ and $\delta \sim \mathbb{N}(0, 0.0625)$. 
       %First split: $\xv_3 \leq 0$ (blue) and $\xv_3 > 0$ (orange).}
   %\end{figure}
-    \end{column}}
+}
+\spacer[0]
+}
+\end{framev}
 
-\end{columns}
-\bigskip
-\end{frame}
 
-
-\begin{frame}{Conclusion}
-
-\begin{columns}[T, totalwidth = \textwidth]
-    \begin{column}{0.58\textwidth}
-
- \textbf{Summary of Contributions (REPID)}:
- \begin{itemize}
-    \item Regional effects in interpretable regions
-    \item Additive decomp. of feature effect 
+\begin{framev}[align=top]{Conclusion}
+\splitVTT[0.56]{
+\textbf{Summary of Contributions (REPID)}:
+\begin{itemizeM}
+\item Regional effects in interpretable regions
+\item Additive decomp. of feature effect
     %\item Prove meaningfulness of objective - only feature interactions between $\xv_j$ and $\xv_{-j}$ minimized %(measures only feature interactions)
-    \item Quantify feature interactions 
-    \item Outperforms SOTA interaction indices
+\item Quantify feature interactions
+\item Outperforms SOTA interaction indices
     %H-Statistics, Greenwell's and Shapley
-\end{itemize}
-
- \textbf{Summary of Contributions (GADGET)}:
- \begin{itemize}
- \item Unique regions for multiple features
- \item Additive decomp. of prediction function%\\
- \item Extension to ALE and Shapley Dependence
+\end{itemizeM}
+\spacer[0.25]
+\textbf{Summary of Contributions (GADGET)}:
+\begin{itemizeM}
+\item Unique regions for multiple features
+\item Additive decomp. of prediction function%\\
+\item Extension to ALE and Shapley Dependence
 % $\Rightarrow$ TODO: Investigate usefulness as ``approximation'' when terminal regions contain interactions
- \item Test to identify significant interactions
-\end{itemize}
-
+\item Test to identify significant interactions
+\end{itemizeM}
         % \begin{itemize}
         %     \item $f(X) = 3X_1\mathbbm{1}_{X_3>0} - 3X_1\mathbbm{1}_{X_3\leq 0} + X_3 + \epsilon$
         %     \item Features uniformly distributed
@@ -510,51 +450,46 @@ Overall reduction of ICE curve variance due to splits by $X_j$ (in \%).
         %     \item Right: $X_1$ and $X_3$ highly correlated
         %     \item First split: $\xv_3 \leq 0$ (blue) and $\xv_3 > 0$ (orange)
         % \end{itemize}
-    \end{column}
-    \begin{column}{0.45\textwidth}
-    \centering
-    \includegraphics[width=0.95\textwidth]{figure/sim1}
-    \vspace{-8pt}
-        \begin{columns}[T, totalwidth = \linewidth]
-     \footnotesize
-            \begin{column}{0.125\linewidth}
-            \centering
-             $\hat{f}_2^{PD}(X_2)$ %, X_1 > 0 \land X_3 = 0\)\\
-         \end{column}
-         \begin{column}{0.175\linewidth}
-         \centering
-             $\approx 8X_2$ %, X_1 > 0 \land X_3 = 0\)\\
-         \end{column}
-        \begin{column}{0.225\linewidth}
+}{
+\spacer[0]
 \centering
-            $\approx 16X_2$ %, X_1 \leq 0 \land X_3 = 0\)
-         \end{column}
-        \begin{column}{0.225\linewidth}
-        \centering
-            $ \approx -8X_2$ %, X_1 \leq 0 \land X_3 \neq 0\)
-         \end{column}        
-         \begin{column}{0.225\linewidth}
-         \centering
-             $\approx 0$%, X_1 > 0 \land X_3 \neq 0\)\\
-         \end{column}
-        \begin{column}{0.025\linewidth}
-
-         \end{column}
-     \end{columns}
-    \end{column}
-
+\image[1]{figure/sim1}
+\\
+\spacer[-0.5]
+\begin{footnotesize}
+\begin{columns}[T,totalwidth=\linewidth]
+\begin{column}{0.16\linewidth}
+\centering
+$\hat{f}_2^{PD}(X_2)$ %, X_1 > 0 \land X_3 = 0\)\\
+\end{column}
+\begin{column}{0.19\linewidth}
+\centering
+$\approx 8X_2$ %, X_1 > 0 \land X_3 = 0\)\\
+\end{column}
+\begin{column}{0.21\linewidth}
+\centering
+$\approx 16X_2$ %, X_1 \leq 0 \land X_3 = 0\)
+\end{column}
+\begin{column}{0.21\linewidth}
+\centering
+$ \approx -8X_2$ %, X_1 \leq 0 \land X_3 \neq 0\)
+\end{column}
+\begin{column}{0.21\linewidth}
+\centering
+$\approx 0$%, X_1 > 0 \land X_3 \neq 0\)\\
+\end{column}
+\begin{column}{0.02\linewidth}
+\end{column}
 \end{columns}
-
-\medskip
-\textbf{Further Directions}: 
-
+\end{footnotesize}
+\spacer[0]
+}
+\spacer[0.25] \\
+\textbf{Further Directions}:\\
+\spacer[0.25]
 Pruning, GADGET as a predictor, comparing regions across models, efficient implementation, more efficient testing and splitting approach, $\dots$
-\bigskip
-\end{frame}
-
-
+\end{framev}
 
 
 \endlecture
 \end{document}
-


### PR DESCRIPTION
## Summary

- Clean up regional effects slide sources for the feature effects lecture
- Refactor `slides01-fe-regional-main.tex` and `slides02-fe-regional-intImp.tex` to use shared slide/layout helpers such as `framev`, `splitVTT`, `splitVThreeT`, `image`, and `itemizeM`
- Normalize LaTeX formatting, spacing, TikZ setup, and nested itemization while preserving the slide content
