### PR TITLE
iterate im

### DIFF
--- a/slides/interpretable-models/slides01-im-motivation.tex
+++ b/slides/interpretable-models/slides01-im-motivation.tex
@@ -22,12 +22,10 @@ figure/whitebox
 }
 
 \begin{framev}[align=top]{Motivation}
-%Achieving interpretability by using interpretable models is the most straightforward approach
 %\bigskip
 \splitVTT[0.58]{
 \spacer[0.6]
 \begin{itemizeM}
-%\item Obtaining interpretations by using interpretable models is the easiest and least error-prone approach
 \item Achieving interpretability by using interpretable models is the most straightforward approach
 \item Classes of models deemed interpretable:
 \begin{itemizeS}[small]
@@ -60,12 +58,9 @@ $\leadsto$ LM provides straightforward interpretation
 \spacer[0.6]
 \begin{itemizeM}
 \item<+-> Interpretable models are transparent by design, making many model-agnostic explanation methods unnecessary\\
-%For inherently interpretable models some additional model-agnostic interpretation methods not required \\
 $\leadsto$ Eliminates an extra source of estimation error
 \item<+-> They often have few hyperparameters and are structurally simple (e.g., linear, additive, sparse, monotonic)\\
 $\leadsto$ Easy to train, fast to tune, straightforward to explain
-% \item Interpretable models often simple \\
-% $\leadsto$ training time is fairly small
 % \item Some interpretable models estimate monotonic effects \\
 % %the monotonicity constraint \\
 % $\leadsto$ Simple to explain as larger feature values always lead to higher (or smaller) outcomes (e.g., GLMs)
@@ -130,19 +125,12 @@ $\leadsto$ If assumptions are wrong, models may perform bad
 \spacer[0.25]
 \begin{itemizeM}
 \item<3->
-%No automatic modeling of complex relationships due to limited model flexibility
 Often do not automatically model complex relationships due to limited flexibility % didn't find a way to fig the hanging word
 \\
 e.g., high-order main or interaction effects need to be specified manually in LM
 %\pause
 \item<4-> Inherently interpretable models do not address all explanation needs\\
 $\leadsto$ Complementary model-agnostic methods (e.g., counterfactuals) remain valuable for specific tasks
-% Inherently interpretable models do not provide all types of explanations
-% %% one might be interested
-% \\
-% $\leadsto$ Methods providing other types of explanations still useful  (e.g., counterfactual explanations)
-%Methods providing other types of explanations still useful  (e.g., counterfactual explanations)
-%Still requires application of model-agnostic interpretation techniques if certain types of explanations are of interest (e.g., counterfactual explanations)
 \end{itemizeM}
 \end{framev}
 
@@ -154,8 +142,6 @@ $\leadsto$ Complementary model-agnostic methods (e.g., counterfactuals) remain v
 \begin{itemizeS}
 \item Built-in interpretation\\
 $\leadsto$ fewer risks from misleading post-hoc explanations
-%\item \ldots instead of explaining uninterpretable models post-hoc
-% \item Can sometimes work out by spending enough time and energy on data pre-processing or manual feature engineering
 \item Good performance possible with effort on preprocessing and/or feature engineering
 \item But interpretability depends on meaning of created features\\
 $\leadsto$ E.g., PCA keeps models linear, but yields hard-to-interpret components
@@ -164,10 +150,6 @@ $\leadsto$ E.g., PCA keeps models linear, but yields hard-to-interpret component
 %\pause
 %\footnote[frame]{Rudin, C. Stop explaining black box machine learning models for high stakes decisions and use interpretable models instead. Nat Mach Intell 1, 206–215 (2019).}
 % {https://www.nature.com/articles/s42256-019-0048-x}
-%\item Interpretable models also have the potential for a high predictive performance, but require more knowledge and time spent on data preprocessing
-% \item<2->[$\leadsto$] Drawback: Hard to achieve for data for which end-to-end learning is crucial\\
-% $\leadsto$ e.g., hard to extract good features for image / text data\\
-% $\leadsto$ information loss can lead to bad performance
 \item<2-> Limitation: Less suited for complex data requiring end-to-end learning
 \begin{itemizeS}
 \item Applies to image, text, or sensor data where features must be learned from raw input
@@ -177,23 +159,11 @@ $\Rightarrow$ Information loss and lower performance
 %(e.g., for image / text data extraction of good features is hard $\leadsto$ information loss = bad performance)
 %(e.g., image and text data would require good feature extraction steps $\leadsto$ information loss)
 %\pause
-%\item One can assume a trade-off between interpretability and model performance which generally (but not always) holds
-%\item<3-> Often there is a trade-off between interpretability and model performance
-%(but not always)
 \end{itemizeM}
-%\smallskip
-%\only<3>{\centering\includegraphics[width=0.65\textwidth]{figure/performance_vs_interpretability.pdf}}
-% Quelle: https://docs.google.com/presentation/d/12ZPrTjBKEUT-7drdyUJCQGK0oHVDtYIVd2_6byE62f0/edit?usp=sharing
 \end{framev}
 
 
 \begin{framev}[align=top]{Recommendation}
-% \begin{itemize}
-%     \item Start with most simple model that makes sense for application at hand
-%     \item Gradually increase complexity if performance is insufficient\\
-%     $\leadsto$ will usually lower interpretability and require additional interpretation methods
-%     \item Choose the most simple, sufficient model (Occam's razor)
-% \end{itemize}
 \begin{itemizeM}
 \item Begin with the simplest model appropriate for the task
 \item Increase complexity only if necessary to meet performance requirements\\

--- a/slides/interpretable-models/slides02-im-lm-simple.tex
+++ b/slides/interpretable-models/slides02-im-lm-simple.tex
@@ -37,8 +37,6 @@ figure/lm_example
 % https://towardsdatascience.com/assumptions-of-linear-regression-fdb71ebeaa8b
 % https://www.statology.org/linear-regression-assumptions/
 % https://link.springer.com/book/10.1007/978-3-642-34333-9
-%\textbf{Model formula}
-%$$\mathbb{E}_Y(Y \vert X) = \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \ldots + \theta_p x_p + \epsilon = X^T\mathbf{\theta} + \epsilon$$
 \splitVTT[0.58]{
 \spacer[0]
 $$y = \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \dots + \theta_p x_p + \epsilon = \xv^\top \thetav + \epsilon$$
@@ -50,11 +48,6 @@ $$y = \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \dots + \theta_p x_p + \epsilon =
 $\leadsto$ model consists of $p+1$ weights
 % \item Model equation is additive and identical across entire input space
 % \pause
-% \item Polynomial regression extends equation above by
-% \begin{itemize}
-% \item \textbf{higher order main effects} which have their own weights (e.g., quadratic: $\theta_{x_j^2} \cdot x_j^2$)
-% \item \textbf{interaction effects} (e.g., 2-way interaction: $\theta_{x_i, x_j} \cdot x_i \cdot x_j$)
-% \end{itemize}
 \end{itemizeM}
 }{
 \spacer[0]
@@ -66,8 +59,6 @@ $\leadsto$ model consists of $p+1$ weights
 \textbf{Properties and assumptions} \furtherreading{FARAWAY2002} % \furtherreading{CheckingAssumptions}
 \begin{itemizeM}
 \item<+-> \textbf{Linear} relationship between features and target
-%Predictions are \textbf{linear} combination of features $\leadsto$
-%Model equation is additive and linear w.r.t. features% and identical across entire input space
 \item<+-> $\epsilon$ and $y \vert \xv$ are \textbf{normally} distributed with \textbf{constant variance} (homoscedastic)\\
 $\leadsto$ $\epsilon \sim N(0, \sigma^2) \; \Rightarrow \; (y \vert \xv) \sim N(\xv^\top \theta, \sigma^2)$\\
 $\leadsto$ if violated, inference-based metrics (e.g., p-values) are invalid
@@ -157,7 +148,6 @@ $$|t_{\hat\theta_j}| = \left| \frac{\hat\theta_j}{SE(\hat\theta_j)} \right|$$
 \spacer[0.6]
 \begin{itemizeM}
 \item \textbf{p-value}: probability of obtaining a more extreme test statistic assuming $H_0$ is correct (here: $\theta_j = 0$, i.e., feat. $j$ not significant)\\
-%probability of obtaining a test statistic that is more extreme (values that speak against $H_0$) as the test statistic computed from the sample, assuming $H_0$ (here: $\theta_j =0)$ is correct.
 $\leadsto$ High $|t|$ $\Rightarrow$ small p-val. (speak against $H_0$)
 %\item The smaller the p-value, the less likely it is to obtain a more extreme test statistic
 \end{itemizeM}
@@ -174,11 +164,6 @@ $\leadsto$ High $|t|$ $\Rightarrow$ small p-val. (speak against $H_0$)
 \textbf{Bike data}: predict no. of rented bikes using 4 numeric, 1 cat. feat. (season)
 \\
 \spacer[0.25]
-% \begin{footnotesize}
-% $$
-% \hat y = \hat \theta_0 + \hat \theta_1 \mathds{1}_{(seas = SPRING)} + \hat \theta_2 \mathds{1}_{(seas = SUMMER)} + \hat \theta_3 \mathds{1}_{(seas = FALL)} + \hat \theta_4 temp + \hat \theta_5 hum + \hat \theta_6 windspeed + \hat \theta_7 days\_since\_2011
-% $$
-% \end{footnotesize}
 \splitVTT[0.43]{
 \spacer[0]
 \begin{align*}
@@ -246,7 +231,6 @@ days\_since\_2011 & 4.9 & 0.2 & 26.9 & 0.00 \\
 \item<+-> \textbf{Intercept}: If all feature values are 0 (and season is \code{WINTER} $\hat =$ reference cat.), the expected number of bike rentals is $\hat\theta_0 = 3229.3$
 \item<+-> \textbf{Categ.}: Rentals in \code{SPRING} are by $\hat\theta_1 = 862$ higher than in \code{WINTER}, c.p.
 \item<+-> \textbf{Numerical}: Rentals increase by $\hat\theta_4 = 120.5$ if \code{temp} increases by 1 $^\circ$C, c.p.
-%If the temperature increases by 1 order Celsius, the number of bike rentals increases by 120.5 c.p.
 \end{itemizeM}
 %\end{column}
 %\end{columns}

--- a/slides/interpretable-models/slides03-im-lm-extensions.tex
+++ b/slides/interpretable-models/slides03-im-lm-extensions.tex
@@ -76,36 +76,7 @@ $\leadsto$ Other ML models often learn them automatically
 \item Marginal effect of a feat. cannot be interpreted by single weights anymore\\
 $\leadsto$ Feature $x_j$ occurs multiple times (with different weights) in equation
 \end{itemizeM}
-%Weights cannot be interpreted in isolation as before
-% $$y = \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \dots + \theta_p x_p + \epsilon$$
-
-% \begin{itemize}
-% \item Results in polynomial regression 
-% \item Weights cannot be interpreted in isolation as before
-% \end{itemize}
 \end{framev}
-
-% \begin{frame}{Linear and Polynomial Regression}
-
-% \begin{align*}
-% \mathbb{E}_Y(Y \vert X) &= \theta_0 + \theta_1 x_1 + \dots + \theta_p x_p + \epsilon \\
-%  &= X^T\theta + \mathcal{E}
-% \end{align*}
-
-% \begin{itemize}
-% \itemsep1em
-% \item Model equation is identical across the entire feature space.
-% %\item The predictive power of LMs is determined by specifying the correct model structure.
-% \item Polynomial regression extends the LM by non-linear effects.
-% %A polynomial regression model is an extension of the LM that includes higher order terms or interactions.
-% %This enables us to model non-linear data while making use of the entire arsenal of LM functionality.
-% \item We can exactly determine feature effects (e.g., beta coefficients, effect plots) and importance scores (e.g., p-values, t-statistics).
-% %By knowing the model equation, we can exactly determine feature effects (e.g., beta coefficients, effect plots) and importance scores (e.g., p-values, t-statistics).
-% \item For higher order effects or interactions, beta coefficients cannot be interpreted in isolation.
-% \item Note: For inference-based metrics (p-values, confidence intervals) to be valid, error term needs to be normally distributed with zero mean, i.e., $\epsilon \sim N(0, \sigma^2) \; \Rightarrow \; (y \vert x) \sim N(x^T \theta, \sigma^2)$.\\
-% $\leadsto$ Restricts use of LMs in practice as distribution of error is a prior assumption about data.
-% \end{itemize}
-% \end{frame}
 
 \begin{framev}[align=top]{Example: Interaction Effect}
 \textbf{Ex.}: Interaction between \code{temp} and \code{season} will affect marginal effect of \code{temp}% with (right) and without (left) interaction.
@@ -187,8 +158,6 @@ $\leadsto$ \code{SPRING}:\\
 $({\color{winter}39.1} {\color{spring}+407.4}) \cdot x_{temp} + ({\color{winter}8.6} {\color{spring} - 18.7}) \cdot x_{temp}^2$ \\
 $\leadsto$ \code{SUMMER}:\\ $({\color{winter}39.1} {\color{summer}+801.1}) \cdot x_{temp} + ({\color{winter}8.6} {\color{summer} - 27.2}) \cdot x_{temp}^2$ \\
 $\leadsto$ \code{FALL}: \\$({\color{winter}39.1} {\color{fall}+217.4}) \cdot x_{temp} + ({\color{winter}8.6} {\color{fall} - 11.3}) \cdot x_{temp}^2$
-% \item<2>[$\leadsto$] High-order and interaction effects make the model more flexible but also less interpretable (more weights)
-% \item<2>[$\leadsto$] High-order and interaction effects need to be specified manually (inconvenient) - ML models do this automatically
 \end{itemizeS}
 }{
 \spacer[0]
@@ -258,13 +227,6 @@ days\_since\_2011 & 4.8 \\
 
 
 \begin{framev}[align=top]{Regularization via LASSO \furtherreading{TIBSHIRANI1996}}
-% \begin{itemize}
-%     \item LASSO adds an $L_1$-norm penalization term ($\lambda||\theta||_1$) to the least squares optimization problem%\\
-%     % $\leadsto$ Shrinks some feature weights to zero (feature selection)\\
-%     % $\leadsto$ Sparser models (with fewer features) are more interpretable
-%     % %Aim: Feature selection (sparsity) and regularization of feature weights
-%     % \item Penalization parameter $\lambda$ must be chosen (e.g., by CV) %or depending on the number of features to keep
-% \end{itemize}
 \splitVTT[0.6]{
 \spacer[0.6]
 \begin{itemizeM}
@@ -298,12 +260,9 @@ $$
 \splitVTT[0.65]{
 \spacer[0.6]
 \begin{itemizeM}
-%\item LASSO with main effects and interaction \code{temp} with \code{season}
 \item $\lambda$ is chosen $\leadsto$ 6 selected features ($\neq 0$)
 \item LASSO shrinks weights of single categories separately (due to dummy encoding)\\
-%only weights of single categories are set to zero (due to dummy encoding) not the whole feature\\
 $\leadsto$ No feature selection of whole categorical features (only w.r.t. category levels)\\
-%May be problematic for categorical features as only weights of single categories are set to zero (due to dummy encoding) instead of the whole categorical feature\\ %, polynomials and interactions
 $\leadsto$ Solution: group LASSO \furtherreading{YUANLIN2006}
 \end{itemizeM}
 \spacer[0.25]

--- a/slides/interpretable-models/slides04-im-glm.tex
+++ b/slides/interpretable-models/slides04-im-glm.tex
@@ -47,13 +47,6 @@ $\leadsto$ Gamma distribution
 }
 \pause
 \textbf{Solution}: GLMs extend LMs by allowing other distrib.-s from exp. family\\
-%$$g(\E (y \mid \xv)) = \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \ldots + \theta_p x_p$$
-% \begin{align*}
-% &g(\E (y \mid \xv)) = 
-% %\theta_0 + \theta_1 x_1 + \theta_2 x_2 + \ldots + \theta_p x_p = 
-% \xv^\top \theta\\
-% \Leftrightarrow \; & \E (y \mid \xv) = g^{-1}(\xv^\top \theta)
-% \end{align*}
 \spacer[0.25]
 \centerline{$g(\E(y \mid \xv)) = \xv^\top \thetav \; \Leftrightarrow \; \E(y \mid \xv) = g^{-1}(\xv^\top \thetav)$}
 \spacer[0.25]
@@ -64,62 +57,19 @@ $\leadsto$ LM is special case: Gaussian distrib. for $y \mid \xv$ with $g$ as id
 \item High-order and interaction effects can be manually added as in LMs
 \item Note: Interpretation of weights depend on link function and distribution
 \end{itemizeM}
- %   \medskip
- %   Non-Gaussian outputs via Generalized Linear Models (GLMs):
-  %  \begin{itemize}
-   %     \item link function $g$ -- can be freely chosen
-    %    \item exponential family defining $\E_Y$ -- can be freely chosen
-     %   \item weighted sum $X^\top W$
-    %\end{itemize}
-    %\medskip 
-    %\pause
- %Interaction effects via feature engineering:
- %\begin{itemize}
- %    \item E.g., feature expansion: $\theta_{x_i,x_j} x_i \cdot x_j$
- %\end{itemize}
 \end{framev}
 
 
 \begin{framev}[align=top]{GLM - Logistic Regression}
-%\begin{columns}[T, totalwidth=\textwidth]
-%\begin{column}{0.45\textwidth}
 \begin{itemizeM}
 \item Logistic regression $\hat{=}$ GLM with Bernoulli distribution and logit link function:
-%\begin{align*}
-%    g(x) &= \log\left(\frac{x}{1 - x}\right)  
-%    \Rightarrow \; g^{-1}(x) &= \frac{1}{1+\exp(-x)}
-%\end{align*}
 $$
 g(x) = \log\left(\frac{x}{1 - x}\right)
 \Rightarrow \; g^{-1}(x) = \frac{1}{1 + \exp(-x)}
 $$
-%\end{column}
-%\begin{column}{0.55\textwidth}
-% \begin{columns}[c, totalwidth=\textwidth]
-% \begin{column}{0.005\linewidth}
-% \scriptsize
-% \rotatebox[origin=c]{90}{\hspace{10pt}$P(y = 1)$}
-% \end{column}
-% \begin{column}{0.995\linewidth}
-%\includegraphics[width = \textwidth]{figure/reg_class_log_6.pdf}
-% \scriptsize\centerline{$\xv^\top \theta$}
-% \end{column}
-% \end{columns}
-%\end{column}
-%\end{columns}
-% \begin{columns}[T, totalwidth=\textwidth]
-% \begin{column}{0.65\textwidth}
-% \begin{itemize}
 \item Models probabilities for binary classification by
 $$\pi(\xv) = \E(y \mid \xv) = P(y = 1) = g^{-1}(\xv^\top \thetav) = \frac{1}{1 + \exp(-\xv^\top \thetav)}$$
-%\item Logistic regression models $\E(y \mid \xv) = P(y = 1)$, i.e., probabilities for binary classification
-%\item Logistic regression formula:
-%$$P(y = 1) =\frac{1}{1 + \exp(-( \theta_0 + \theta_1 x_1 + \theta_2 x_2 + \ldots + \theta_p x_p ))} $$
 \end{itemizeM}
-% \end{column}
-% \begin{column}{0.35\textwidth}
-% \end{column}
-% \end{columns}
 \centering
 \image[0.3]{figure/logreg-2vars-surface.png}
 \qquad
@@ -140,32 +90,6 @@ $$\pi(\xv) = \E(y \mid \xv) = P(y = 1) = g^{-1}(\xv^\top \thetav) = \frac{1}{1 +
 \end{framev}
 
 
-% \begin{frame}{Generalized Linear Models (GLMs)}
-
-% \begin{align*}
-% g\left(\mathbb{E}_Y(Y \vert X)\right) &= X^T\theta \\
-% \mathbb{E}_Y \left(Y \vert X\right) &= g^{-1}(X^T\theta)
-% \end{align*}
-% \begin{itemize}[<+->]
-% %\setlength\itemsep{1em}
-% %\item GLMs are a framework for target distributions of  exponential families (e.g., Gaussian, Binomial, Poisson, Gamma). Gaussian target distribution $+$ identity link $\hat =$ linear / polynomial model.
-% \item GLM framework assumes distribution of $Y$ is a member of exponential families, e.g.: % (e.g., Gaussian, Binomial, Poisson)
-% \begin{itemize}[<.->]
-%     \item Gaussian target distribution $+$ identity link $\hat =$ linear / polynomial model.
-%     \item Binomial target distribution $+$ logit link $log\left(\frac{\mathbb{E}_Y(Y \vert X)}{1 - \mathbb{E}_Y(Y \vert X)}\right)$ $\hat =$ logistic regression.
-% \end{itemize}
-% %\item GLMs keeps linear predictor $X^T\theta$ (explains $\mathbb{E}_Y(Y \vert X)$ through a more flexible link function $g$).
-% \item Link function $g$ describes how $X^T\theta$ relates to the expected, conditional target $\mathbb{E}_Y(Y \vert X)$.
-% \begin{itemize}[<.->]
-%     \item Interpretations as for linear / polynomial models but w.r.t. transformed target via $g$.
-%     \item Linear terms become non-linear through the link function (except for identity link)!
-% \end{itemize}
-% %\item If the target is distributed binomially, a natural link function is the logit link $log\left(\frac{\mathbb{E}_Y(Y \vert X)}{1 - \mathbb{E}_Y(Y \vert X)}\right)$ (logistic regression).
-% \item We need to specify the correct model equation, target distribution, and link function to receive a good model fit.
-% %\item %As the model equation is still known, interpretations are possible the same way as for polynomial regression models.
-% %However, even linear terms become non-linear through the link function (if the identity link is not used)!
-% \end{itemize}
-% \end{frame}
 %------------------------------------------------------------------
 %------------------------------------------------------------------
 
@@ -174,10 +98,8 @@ $$\pi(\xv) = \E(y \mid \xv) = P(y = 1) = g^{-1}(\xv^\top \thetav) = \frac{1}{1 +
 \item \textbf{Recall:} Odds is ratio of two probabilities, odds ratio is ratio of two odds
 \item Weights $\theta_j$ are interpreted linear as in LM (but w.r.t. log-odds)\\
 $\leadsto$ difficult to comprehend
-%relate to log-odds %$\leadsto$ Effects are linear as in LM (but w.r.t. log-odds)
 $$log\text{-}odds = \log\left(\frac{\pi(\xv)}{1 - \pi(\xv)}\right) = \log\left(\frac{P(y = 1)}{P(y = 0)}\right) = \theta_0 + \theta_1 x_1 + \ldots + \theta_p x_p$$
 \textbf{Interpretation}: Changing $x_j$ by one unit changes log-odds of class 1 compared to class 0 by $\theta_j$
-%\leadsto$ Effects are interpreted linear as in LM (but w.r.t. log-odds) $\leadsto$ difficult to comprehend
 \pause
 \item Odds for cls 1 vs. cls 0: %Odds can be caulculated by:
 % deliberate choice to use in line with \displaystyle given full slide
@@ -186,7 +108,6 @@ $odds = \displaystyle\frac{\pi(\xv)}{1 - \pi(\xv)}= \exp(\theta_0 + \theta_1 x_1
 $$\frac{odds_{x_j+1}}{odds} = \frac{\exp(\theta_0 + \theta_1 x_1 + \ldots + \theta_j(x_j + 1) + \ldots + \theta_p x_p)}{\exp(\theta_0 + \theta_1 x_1 + \ldots + \theta_j x_j + \ldots + \theta_p x_p)} = \exp(\theta_j)$$
 \textbf{Interpretation}: Changing $x_j$ by one unit changes the \textbf{odds ratio} for class 1 (compared to class 0) by the \textbf{factor} $\exp(\theta_j)$
 %\pause
-%\item Interpretation for different feature types is the same as for linear regression (however, linear interpretation only possible w.r.t. log odds $\leadsto$ difficult to comprehend)
 \end{itemizeM}
 \end{framev}
 

--- a/slides/interpretable-models/slides05-im-rule-based.tex
+++ b/slides/interpretable-models/slides05-im-rule-based.tex
@@ -31,15 +31,8 @@ figure/tree_surface2.png
 }
 
 \begin{framev}[align=top]{Decision Trees \furtherreading{BREIMANETAL1984}}
-%\textbf{Problem}: Can we model non-linear effects and interactions automatically (without manual specification as in GLMs or GAMs)?\\
-%Relationship between features and target are non-linear or interactions are present\\
-%\medskip
-%\pause
-
 \textbf{Idea}:
-%Split data in different subsets based on cut-off values in features 
 Partition data into axis-aligned regions via greedy search for feature cut points (minimizing a split criterion), then predict a constant mean $c_m$ in each leaf region $\mathcal{R}_m$:
-%Partition data into subsets based on cut-off values in features (found by minimizing a split criterion via greedy search) and predict constant mean $c_m$ in leaf node $\mathcal{R}_m$:
 \splitVTT[0.65]{
 \spacer[0]
 $$
@@ -93,16 +86,6 @@ $$
 }
 \end{framev}
 
-
-% \begin{frame}{Interpretation}
-% \begin{itemize}
-%     \item Directly by following the tree structure (i.e., sequence of decision rules)
-%     \item Importance of $x_j$: Aggregate ``improvement in split criterion'' over all splits where $x_j$ was involved\\
-%     \item[] $\leadsto$ e.g., variance for regression or Gini index for classification
-%     %Feature importance: How much did split criterion improve compared to parent node% by (scaled) score of how much splitting criterion (e.g. variance) is reduced compared to a parent node
-% \end{itemize}
-
-% \end{frame}
 
 \begin{framev}[align=top]{Interpretation of Tree-Based Models}
 \begin{itemizeM}
@@ -164,36 +147,6 @@ $$
 \end{itemizeS}
 \end{itemizeM}
 }
-% \vspace{0.4cm}
-% \begin{center}
-% \begin{tikzpicture}[scale=0.7, every node/.style={font=\small}]
-%   % Nodes
-%   \node[draw, circle] (root) at (0,0) {$x_j < 5$};
-%   \node[draw, circle] (left) at (-3,-2.5) {$x_k < 3$};
-%   \node[draw, rectangle] (L1) at (-4.2,-5) {$c_1$};
-%   \node[draw, rectangle] (L2) at (-1.8,-5) {$c_2$};
-
-%   \node[draw, circle] (right) at (3,-2.5) {$x_k < 7$};
-%   \node[draw, rectangle] (R1) at (2,-5) {$c_3$};
-%   \node[draw, rectangle] (R2) at (4,-5) {$c_4$};
-
-%   % Edges with labels
-%   \draw[->] (root) -- node[above left] {\scriptsize yes} node[midway, left=3pt] {\scriptsize  $\Delta\text{Var} = 0.18$} (left);
-%   \draw[->] (root) -- node[above right] {\scriptsize no} node[midway, right=3pt] {\scriptsize $\Delta\text{Var} = 0.10$} (right);
-
-%   \draw[->] (left) -- node[left] {\scriptsize $\Delta\text{Var} = 0.07$} (L1);
-%   \draw[->] (left) -- (L2);
-
-%   \draw[->] (right) -- (R1);
-%   \draw[->] (right) -- (R2);
-% \end{tikzpicture}
-% \end{center}
-
-% \vspace{0.2cm}
-% \begin{itemize}
-%     \item[] $\Rightarrow$ Feature importance($x_j$) += 0.18
-%     \item[] $\Rightarrow$ Feature importance($x_k$) += 0.07 + 0.10 = 0.17
-% \end{itemize}
 \end{framev}
 
 
@@ -249,177 +202,6 @@ hum & 2.92 \\
 %$\leadsto$ many different ways to learn a set of rules (incl. a default rule if none of the rules are met)
 
 %\end{frame}
-
-
-
-
-
-
-% %------------------------------------------------------------------
-% %------------------------------------------------------------------
-
-
-% \begin{frame}{Model-based Boosting \citebutton{Bühlmann and Yu 2003}{https://doi.org/10.1198/016214503000125}}
-
-% \begin{itemize}%[<+->]
-% %\setlength\itemsep{2em}
-% \item<1-> Recall: Boosting iteratively combines weak base learners (BL) %to create a powerful ensemble model
-% \item<1->
-% Idea: Use simple linear BL to ensure interpretability \\
-% %$\leadsto$ e.g., linear BL with single features in each iteration
-% %Boosting with gradient descent using interpretable base learners (e.g., use base learners with single features in each iteration $\leadsto$ coordinate gradient descent)
-% %The resulting ensemble is also interpretable.
-% %\pause
-% \item<2->
-% Possible to combine linear BL of same type (with distinct parameters $\theta$ and $\theta^{\star}$):
-% %Two linear base learners $b_j(x, \theta)$ and $b_j(x, \theta^{\star})$ of the same type, but distinct parameter vectors $\theta$ and $\theta^{\star}$ can be combined in a base learner of the same type:
-% $$b_j(x, \theta) + b_j(x, \theta^{\star}) = b_j(x, \theta + \theta^{\star})$$
-% %\pause
-% \item<3-> %In each iteration, a set of BLs is fitted on pseudo residuals. The one with the best fit is added to the previously computed model (using step-size $\nu$), e.g.,
-% In each iteration, fit a set of BLs and add the best BL to previous model (using step-size $\nu$):
-% %\medskip
-% \begin{align*}
-% \widehat{f}^{[1]}(x) &= \hat{f}_0 + \nu \textcolor{blue}{b_3(x_3, \theta^{[1]})} \\
-% \visible<4->{\widehat{f}^{[2]}(x) &= \widehat{f}^{[1]}(x) + \nu \textcolor{blue}{b_3(x_3, \theta^{[2]})} 
-% %= \hat{f}_0 + \nu \textcolor{blue}{b_3(x_3, \theta^{[1]})} + \nu \textcolor{blue}{b_3(x_3, \theta^{[2]})}
-% \\
-% \visible<5->{
-% \widehat{f}^{[3]}(x) &= \widehat{f}^{[2]}(x) + \nu \textcolor{orange}{b_1(x_1, \theta^{[3]})} 
-% %= \hat{f}_0 + \nu \textcolor{blue}{b_3(x_3, \theta^{[1]})} + \nu \textcolor{blue}{b_3(x_3, \theta^{[2]})} + \nu \textcolor{orange}{b_1(x_1, \theta^{[3]})} 
-% \\
-% &= \hat{f}_0 + \nu \left(\textcolor{blue}{b_3(x_3, \theta^{[1]} + \theta^{[2]})} + \textcolor{orange}{b_1(x_1, \theta^{[3]})}\right) 
-% \\
-% &= \hat{f}_0 + \textcolor{blue}{\hat{f}_3(x_3)} + \textcolor{orange}{\hat{f}_1(x_1)}
-% }
-% }
-% \end{align*}
-% \item<6-> Final model is additive (as GAMs), where each component function is interpretable
-
-% \end{itemize}
-% \end{frame}
-
-
-% \begin{frame}{Model-based Boosting - Example}
-
-% Simple case: Use linear model with single feature (including intercept) as BL
-% $$
-% b_j(x_j, \theta) = x_j\theta + \theta_0 \hspace*{0.2cm}\text{ for } j = 1,\ldots p \hspace*{0.3cm} \leadsto \text{ordinary linear regression}
-% $$
-
-% \begin{itemize}
-% \item<1-> Here: Interpretation of weights as in LM
-% \item<1-> After many iterations, it converges to same solution as least square estimate of LMs
-% \item<2-> Early stopping allows feature selection and might prevent overfitting (regularization)
-% %\item Specifying loss and link function according to exponential family leads a (regularized) GLM
-% \end{itemize}
-% \begin{columns}[T, totalwidth=\textwidth]
-% \begin{column}{0.49\textwidth}
-% \scriptsize
-% \begin{table}[ht]
-% \centering
-% \begin{tabular}{r|r|l}
-%   %\hline
-% \textbf{1000 iter. with $\nu = 0.1$} & Intercept & Weights \\ 
-%   \hline  \hline
-% days\_since\_2011 & -1791.06 & 4.9 \\ 
-%   \hline
-%   hum & 1953.05 & -31.1 \\ 
-%     \hline
-%   season & 0 &  \begin{tabular}[c]{@{}l@{}}
-%   WINTER: -323.4\\
-%   SPRING: 539.5\\
-%   SUMMER: -280.2\\
-%   FALL: 67.2
-%   \end{tabular}\\
-%     \hline
-%   %season &  & WINTER: -323.4, SPRING: 539.5, SUMMER: -280.2, FALL: 67.2 \\ 
-%   temp & -1839.85 & 120.4 \\ 
-%     \hline
-%   windspeed & 725.70 & -56.9 \\ 
-%     \hline
-%   offset & 4504.35 &  \\ 
-%    %\hline
-% \end{tabular}
-% \end{table}
-% \centering
-% $\Rightarrow$ Converges to solution of LM
-% \end{column}
-% \begin{column}{0.49\textwidth}
-
-% \only<1>{\scriptsize
-% Relative frequency of selected BLs across iterations
-% \includegraphics[width = .95 \textwidth]{figure/compboost_base_linear.pdf}}
-
-% \pause
-% \scriptsize
-% \only<2>{
-% \begin{table}[ht]
-% \centering
-% \begin{tabular}{r|r|l}
-%   %\hline
-%  \textbf{20 iter. with $\nu = 0.1$} & Intercept & Weights \\ 
-%   \hline  \hline
-%   days\_since\_2011 & -1210.27 & 3.3 \\ 
-%     \hline
-%    season & 0 & 
-%    \begin{tabular}[c]{@{}l@{}}
-%   WINTER: -276.9\\
-%   SPRING: 137.6\\
-%   SUMMER: 112.8\\
-%   FALL: 20.3
-%    \end{tabular}\\
-%      \hline
-%   temp & -1118.94 & 73.2 \\ 
-%     \hline
-%   offset & 4504.35 &  \\ 
-%    %\hline
-% \end{tabular}
-% \end{table}
-% \centering
-% $\Rightarrow$ 3 BLs selected after 20 iter. (feature selection)
-% }
-% \end{column}
-% \end{columns}
-% % \begin{itemize}
-% %     \item Linear base learners for numeric features and categorical base learner for season
-% %     \item 3 base learners selected after 100 iterations
-% % \end{itemize}
-% \end{frame}
-
-% \begin{frame}{Model-based Boosting - Interpretation}
-
-% \begin{itemize}
-%     \item Fit model on bike data with different BL types \citebutton{Daniel Schalk et al. 2018}{https://doi.org/10.21105/joss.00967}
-%     \item BLs: linear and centered splines for numeric features, categorical for season
-%     %and categorical base learner for season
-% \end{itemize}
-% \begin{columns}[T, totalwidth=\textwidth]
-% \visible<2->{
-% \begin{column}{0.5\textwidth}
-% \hspace{45pt}{\scriptsize{Feature importance}}
-%  \includegraphics[width = \textwidth]{figure/compboost_pfi.pdf}
-% %Feature importance (risk reduction over iter.)\\
-% %$\leadsto$ \code{days\_since\_2011} most important
-% %\scriptsize
-% %\verbatiminput{figure/mboost_output.txt}
-% \end{column}
-% }
-% \visible<3->{
-% \begin{column}{0.5\textwidth}  %%<--- here
-% \hspace{23pt}{\scriptsize{Feature effect}}
-%   \includegraphics[width = \textwidth]{figure/compboost_pfe.pdf}
-% %Partial feature effect for \code{days\_since\_2011}\\
-% %$\leadsto$ Total effect: Combination of partial effects of linear BL and centered spline BL
-% \end{column}
-% }
-% \end{columns}
-% \begin{itemize}
-%     \item<2->  Feature importance (risk reduction over iter.) $\leadsto$ \code{days\_since\_2011} most important
-%      \item<3-> Total effect for \code{days\_since\_2011}\\
-% $\leadsto$ Combination of partial effects of linear BL and centered spline BL
-% \end{itemize}
-% \end{frame}
-
 
 \begin{framev}[align=top]{Unbiased Recursive Partitioning}
 \furtherreading{HOTHORNETAL2006}

--- a/slides/interpretable-models/slides06-im-gam-boosting.tex
+++ b/slides/interpretable-models/slides06-im-gam-boosting.tex
@@ -146,13 +146,9 @@ $\leadsto$ represents degree of smoothness/complexity
 \item Boosting iteratively combines weak base learners to create powerful ensemble 
 \item
 Idea: Use simple BLs (e.g. univar., with splines) to ensure interpretability
-%$\leadsto$ e.g., linear BL with single features in each iteration
-%Boosting with gradient descent using interpretable base learners (e.g., use base learners with single features in each iteration $\leadsto$ coordinate gradient descent)
-%The resulting ensemble is also interpretable.
 %\pause
 \item
 Possible to combine BL of same type (with distinct parameters $\thetav$ and $\ts$):
-%Two linear base learners $b_j(x, \theta)$ and $b_j(x, \theta^{\star})$ of the same type, but distinct parameter vectors $\theta$ and $\theta^{\star}$ can be combined in a base learner of the same type:
 $$\bljt + \bljts = \bl[j](\xv, \thetav + \ts) $$
 \pause
 \item %In each iteration, a set of BLs is fitted on pseudo residuals. The one with the best fit is added to the previously computed model (using step-size $\nu$), e.g.,
@@ -267,10 +263,6 @@ $\Rightarrow$ 3 BLs selected after 20 iter. (feature selection)
 }
 }
 }
-% \begin{itemize}
-%     \item Linear base learners for numeric features and categorical base learner for season
-%     \item 3 base learners selected after 100 iterations
-% \end{itemize}
 \end{framev}
 
 
@@ -327,17 +319,11 @@ Difference in OOB risk: 259,326.0\\
 {\scriptsize Feature importance}\\
 \image{figure/compboost_pfi.pdf}
 \spacer[0]
-%Feature importance (risk reduction over iter.)\\
-%$\leadsto$ \code{days\_since\_2011} most important
-%\scriptsize
-%\verbatiminput{figure/mboost_output.txt}
 }{
 \centering
 {\scriptsize Feature effect}\\
 \image{figure/compboost_pfe.pdf}
 \spacer[0]
-%Partial feature effect for \code{days\_since\_2011}\\
-%$\leadsto$ Total effect: Combination of partial effects of linear BL and centered spline BL
 }
 }
 \only<2->{
@@ -357,180 +343,6 @@ $\leadsto$ Combination of partial effects of linear BL and centered spline BL
 
 %------------------------------------------------------------------
 %------------------------------------------------------------------
-
-
-% \begin{frame}{Decision Trees}
-
-% \begin{columns}[totalwidth=\textwidth]
-
-% \begin{column}{0.3\textwidth}
-
-%   \begin{tikzpicture}
-%   \usetikzlibrary{arrows}
-%     \usetikzlibrary{shapes}
-%      \tikzset{treenode/.style={draw, circle, font=\small}}
-%      \tikzset{line/.style={draw, thick}}
-%      \node [treenode, draw=red] (a0) {$a_0$};
-%      \node [treenode, below=0.75cm of a0, xshift=-1cm]  (a1) {$a_1$};
-%      \node [treenode, draw=red, below=0.75cm of a0, xshift=1cm]  (a2) {$a_2$};
-
-%      \node [treenode, draw=red, below=0.75cm of a2, xshift=-1cm] (a3) {$a_3$};
-%      \node [treenode, below=0.75cm of a2, xshift=1cm]  (a4) {$a_4$};
-
-%      \node [treenode, below=0.75cm of a3, xshift=-1cm] (a5) {$a_5$};
-%      \node [treenode, below=0.75cm of a3, xshift=1cm]  (a6) {$a_6$};
-
-%      \path [line] (a0.south) -- + (0,-0.4cm) -| (a1.north) node [midway, above] {$x_1<0.3$};
-%      \path [line] (a0.south) -- +(0,-0.4cm) -|  (a2.north) node [midway, above] {$x_1\geq0.3$};
-
-%      \path [line] (a2.south) -- + (0,-0.4cm) -| (a3.north) node [midway, above] {$x_1<0.6$};;
-%      \path [line] (a2.south) -- +(0,-0.4cm) -|  (a4.north) node [midway, above] {$x_1\geq0.6$};
-
-
-%      \path [line] (a3.south) -- + (0,-0.4cm) -| (a5.north) node [midway, above] {$x_2<0.2$};;
-%      \path [line] (a3.south) -- +(0,-0.4cm) -|  (a6.north) node [midway, above] {$x_2\geq0.2$};
-
-%   \end{tikzpicture}
-
-% \end{column}
-
-% \begin{column}{0.7\textwidth}
-
-% Properties:
-% \begin{itemize}
-%     \item able to model non-linear effects
-%     \item terminal nodes (aka leaf nodes) can have several observations and predicts the mean outcome over these
-%     \item Applicable to regression and classification
-% \end{itemize}
-
-% Interpretation:
-% \begin{itemize}
-%     \item directly by following the tree (i.e., sequence of rules)
-%     \item Feature importance by (scaled) score of much the splitting criterion was reduced compared to the parent
-% \end{itemize}
-
-% \end{column}
-
-% \end{columns}
-
-% \end{frame}
-
-% \begin{frame}{Decision Trees % OLD
-%\citebutton{Breiman et al. (1984)}{https://doi.org/10.1201/9781315139470}
-% new
-% \furtherreading{BREIMANETAL1984}}
-
-% %\textbf{Problem}: Can we model non-linear effects and interactions automatically (without manual specification as in GLMs or GAMs)?\\
-% %Relationship between features and target are non-linear or interactions are present\\
-% %\medskip
-% %\pause
-
-% \begin{columns}[T, totalwidth=\textwidth]
-
-% \begin{column}{0.7\textwidth}
-% \textbf{Idea of decision trees}: 
-% %Split data in different subsets based on cut-off values in features 
-% Partition data into subsets based on cut-off values in features (found by minimizing a split criterion via greedy search) and predict constant mean $c_m$ in leaf node $\mathcal{R}_m$:
-
-% $$
-% \hat f(x) = \sum_{m=1}^M c_m \mathds{1}_{\{x \in \mathcal{R}_m\}}
-% $$
-
-% % \begin{itemize}
-% % \item where $c_m$ is a constant and 
-% % \item $\mathcal{R}_m$ the $m$-th leaf node of the tree
-% % \end{itemize}
-% \pause
-% \begin{itemize}
-%     %\item Finding best split point (CART): Greedy search for the point that minimizes the variance of $y$ (regression) or the Gini index (classification)
-%     \item Applicable to regression and classification
-%     \item Able to model interactions and non-linear effects
-%     \item Able to handle mixed feature spaces and missing values
-% \end{itemize}
-
-% \end{column}
-% \begin{column}{0.3\textwidth}
-
-% \begin{tikzpicture}[scale=0.75, transform shape]
-%    \usetikzlibrary{arrows}
-%     \usetikzlibrary{shapes}
-%      \tikzset{treenode/.style={draw, circle, font=\small}}
-%      \tikzset{line/.style={draw, thick}}
-%      \node [treenode, draw=red] (a0) {};
-%      \node [treenode, below=0.75cm of a0, xshift=-1.5cm]  (a1) {};
-%      \node [treenode, below=0.75cm of a0, xshift=1.5cm]  (a2) {};
-
-%      \node [treenode, below=0.75cm of a2, xshift=-0.75cm] (a3) {$c_1$};
-%      \node [treenode, below=0.75cm of a2, xshift=0.75cm]  (a4) {$c_2$};
-
-%     \node [treenode, below=0.75cm of a1, xshift=-0.75cm] (a5) {$c_3$};
-%     \node [treenode, below=0.75cm of a1, xshift=0.75cm]  (a6) {$c_4$};
-
-%      \path [line] (a0.south) -- + (0,-0.4cm) -| (a1.north) node [midway, above] {$x_1<3$};
-%      \path [line] (a0.south) -- +(0,-0.4cm) -|  (a2.north) node [midway, above] {$x_1\geq3$};
-
-%      \path [line] (a2.south) -- + (0,-0.4cm) -| (a3.north) node [midway, above] {$x_2<6$};;
-%      \path [line] (a2.south) -- +(0,-0.4cm) -|  (a4.north) node [midway, above] {$x_2\geq6$};
-
-%     \path [line] (a1.south) -- + (0,-0.4cm) -| (a5.north) node [midway, above] {$x_3<2$};;
-%     \path [line] (a1.south) -- +(0,-0.4cm) -|  (a6.north) node [midway, above] {$x_3\geq2$};
-
-%     %\path (a5.south) -- +(0,0) -|  (a5.south) node [midway, below] {$f_{1,3}(x_1,x_3)$};
-%     %\path (a6.south) -- +(0,0) -|  (a6.south) node [midway, below] {$f_{1,3}(x_1,x_3)$};
-
-%     %\path (a3.south) -- +(0,0) -|  (a3.south) node [midway, below] {$f_{1,2}(x_1,x_2)$};
-%     %\path (a3.south) -- +(0,0) -|  (a4.south) node [midway, below] {$f_{1,2}(x_1,x_2)$};
-%     % \path (a3) edge [bend right, draw=white] node [below] {$f_{1,2}(x_1,x_2)$} (a4);
-%     % \path (a5) edge [bend right, draw=white] node [below] {$f_{1,3}(x_1,x_3)$} (a6);
-%    \end{tikzpicture}
-   
-% \end{column}
-% \end{columns}
-
-% \medskip
-% \pause
-% \textbf{Interpretation}
-% \begin{itemize}
-%     \item Directly by following the tree structure (i.e., sequence of decision rules)
-%     \item Importance of $x_j$: Aggregate ``improvement in split criterion'' over all splits where $x_j$ was involved\\
-%     (e.g., variance for regression or Gini index for classification)
-%     %Feature importance: How much did split criterion improve compared to parent node% by (scaled) score of how much splitting criterion (e.g. variance) is reduced compared to a parent node
-% \end{itemize}
-
-
-
-% \end{frame}
-
-% \begin{frame}{Decision Trees - Example}
-% \begin{itemize}
-%     \item Fit decision tree with tree depth of 3 on bike data
-%     \item E.g., mean prediction for the first 105 days since 2011 is 1798 (applies to $\hat = 15\%$ of the data)
-%     \item \code{days\_since\_2011} shows highest feature importance (explains most of variance)
-% \end{itemize}
-% \begin{columns}[T, totalwidth=\textwidth]
-% \begin{column}{0.4\textwidth}
-% \vspace{1.5cm}
-% \begin{table}[ht]
-% \centering
-% \begin{tabular}{lr}
-%   \hline
-%  Feature & Importance \\
-%   \hline
-% days\_since\_2011 & 79.53 \\ 
-%   temp & 17.55 \\ 
-%   hum & 2.92 \\ 
-%    \hline
-% \end{tabular}
-% \end{table}
-% \end{column}
-% \begin{column}{0.6\textwidth}
-%   \includegraphics[width = \textwidth]{figure/tree.pdf} 
-% \end{column}
-% \end{columns}
- 
-% \end{frame}
-% %------------------------------------------------------------------
-% %------------------------------------------------------------------
 
 % %\begin{frame}[c]{Decision Rules}
 

--- a/slides/interpretable-models/slides07-im-ebm.tex
+++ b/slides/interpretable-models/slides07-im-ebm.tex
@@ -159,22 +159,6 @@ $\displaystyle\text{RSS}_L + \text{RSS}_R$};
 \end{tikzpicture}
 \end{framev}
 
-% % --- Slide 3: Optimized Split via Prefix Sums ---
-% \begin{frame}{Efficient Split Selection: Prefix-Sum Trick}
-%   \begin{itemize}
-%     \item \textbf{Cumulative sums:} For sorted $y^{(1)} \leq \dots \leq y^{(n)}$:
-%     \[ S_k = \sum_{i=1}^k y^{(i)}, \quad SS_k = \sum_{i=1}^k (y^{(i)})^2 \]
-%     \item \textbf{RSS via prefix sums:}
-%     \[ \text{RSS}_{1..k} = SS_k - \frac{(S_k)^2}{k} \]
-%     \[ \text{RSS}_{k+1..n} = SS_N - SS_k - \frac{(S_N - S_k)^2}{n-k} \]
-%     \item \textbf{Key identity:} \[ \text{RSS} = SS - \frac{S^2}{n} \quad \text{(algebraic variance expansion)} \]
-%     \item \textbf{Total RSS:} Compute in $O(1)$ per split using prefix sums
-%     \item \textbf{Total complexity:} $O(n)$ per feature (after sorting and $O(n)$ precomputation)
-%   \end{itemize}
-% \end{frame}
-
-
-
 \begin{framev}[align=top]{Efficient Split Selection}
 \begin{itemizeM}
 \item \textbf{Setup:} For feature $X_j$, sort the data $(x_j^{(i)}, y^{(i)})_{i=1}^n$ by increasing $x_j^{(i)}$
@@ -227,154 +211,6 @@ $O(n\log n)$ (sorting) + $O(n)$ (cumulative sums and scan)
 
 
 
-
-% % --- Slide 4: Illustration of Prefix-Sum Computation ---
-% \begin{frame}{Prefix-Sum Trick: Visual Example}
-%   \centering
-%   $$\scriptsize
-% \boxed{y^{(1)} = 1.2,\; y^{(2)} = 2.0,\; y^{(3)} = 1.5,\; y^{(4)} = 3.2,\; y^{(5)} = 2.8,\; y^{(6)} = 4.1} \; \text{(sorted wrt feature)}
-% $$
-% % --- TikZ figure: prefix-sum trick (spacing optimised, no overlaps) ---------------
-% \begin{tikzpicture}[>=latex,
-%                     x=1.75cm,   % <-- wider columns
-%                     y=0.8cm,   % <-- more vertical room
-%                     font=\tiny]
-
-%   % ------------------------------------------------------------------
-%   % (1) sorted target values y^{(i)}
-%   \foreach \x/\i in {0/1, 1/2, 2/3, 3/4, 4/5, 5/6}{
-%     \node[circle, draw, fill=blue!12, inner sep=2pt] (y\i) at (\x,0) {$y^{(\i)}$};
-%   }
-
-%   % ------------------------------------------------------------------
-%   % (2) prefix sums S_k  = sum y^{(i)}  ---- wider boxes
-%   \foreach \x/\val/\i in {0/1.2/1, 1/3.2/2, 2/4.7/3, 3/7.9/4, 4/10.7/5, 5/14.8/6}{
-%     \node[draw, minimum width=1.4cm, minimum height=0.52cm,
-%           fill=green!12, align=center] (S\i) at (\x,-1.1) {$S_{\i}=\,\val$};
-%   }
-%   \node[anchor=east] at (-0.4,-1.1) {Prefix $S_k$};
-
-%   % ------------------------------------------------------------------
-%   % (3) prefix sums SS_k = sum y^{(i)}^2
-%   \foreach \x/\val/\i in {0/1.44/1, 1/5.44/2, 2/7.69/3, 3/17.93/4,
-%                           4/25.77/5, 5/42.58/6}{
-%     \node[draw, minimum width=1.4cm, minimum height=0.52cm,
-%           fill=orange!12, align=center] (SS\i) at (\x,-2.3) {$SS_{\i}=\,\val$};
-%   }
-%   \node[anchor=east] at (-0.4,-2.3) {Prefix $SS_k$};
-
-%   % ------------------------------------------------------------------
-%   % (4) candidate split between y4 and y5  (k = 4)
-%   \draw[dashed] (3.5,0.55) -- (3.5,-2.9);
-%   \node[anchor=south] at (3.5,0.7) {$k=4$};
-
-%   % braces indicating left / right partitions  (y-shifted to avoid boxes)
-%   \draw[decorate, decoration={brace,mirror,amplitude=4pt}]
-%         (-0.25,-2.75) -- (3.5,-2.75)
-%         node[midway,below=4pt] {left: $N_L=k=4$};
-
-%   \draw[decorate, decoration={brace,mirror,amplitude=4pt}]
-%         (3.5,-2.75) -- (5.25,-2.75)
-%         node[midway,below=4pt] {right: $N_R=n-k=2$};
-
-%   % ------------------------------------------------------------------
-%   % (5) computation box  (placed lower to clear everything)
-%   \node[draw, rounded corners, align=left, anchor=north,
-%         minimum width=7.3cm] (comp) at (2.5,-4.0) {
-%       \strut$\displaystyle
-%          \text{RSS}_{1..k}=SS_{k}-\frac{S_{k}^{2}}{k}
-%          \qquad\text{\color{purple}{\scriptsize($\mathcal{O}(1)$)}}$\\[4pt]
-%       $\displaystyle
-%          \text{RSS}_{k+1..n}=SS_N-SS_{k}-\frac{(S_N-S_{k})^{2}}{n-k}$};
-
-%   \draw[->,>=latex] (3,-2.5) -- ++(0,-0.3) -- (comp.north);
-
-%   % complexity foot-note
-%   \node[anchor=west,font=\tiny] at (1.5,-6.5)
-%         {\color{gray}$\mathcal{O}(1)$ per split \ $\Rightarrow$ \ $\mathcal{O}(n)$ per feature};
-% \end{tikzpicture}
-
-% \end{frame}
-
-% --- Slide 4: Worked Example --------------------------------------
-% \begin{frame}{Prefix-Sum Trick: Worked Example (RSS)}
-% \centering
-% {\scriptsize
-% \[
-%   \boxed{y^{(1)}\!=\!1.2,\;
-%          y^{(2)}\!=\!2.0,\;
-%          y^{(3)}\!=\!1.5,\;
-%          y^{(4)}\!=\!3.2,\;
-%          y^{(5)}\!=\!2.8,\;
-%          y^{(6)}\!=\!4.1}
-%   \quad\text{s.t.\ }x_{j}^{(1)}\le\dots\le x_{j}^{(6)}
-% \]
-% }
-
-% \begin{tikzpicture}[>=latex,
-%                     x=1.75cm,
-%                     y=0.75cm,
-%                     font=\tiny]
-
-% % (1) sorted targets
-% \foreach \x/\i in {0/1,1/2,2/3,3/4,4/5,5/6}{
-%   \node[circle, draw, fill=blue!12, inner sep=2pt] (y\i) at (\x,0)
-%         {$y^{(\i)}$};
-% }
-
-% % (2) prefix sums S_k
-% \foreach \x/\val/\i in {0/1.2/1,1/3.2/2,2/4.7/3,3/7.9/4,4/10.7/5,5/14.8/6}{
-%   \node[draw, minimum width=1.4cm, minimum height=0.5cm,
-%         fill=green!12, align=center] (S\i) at (\x,-1.0)
-%         {$S_{\i}=\val$};
-% }
-% \node[anchor=east] at (-0.4,-1.0) {Prefix $S_k$};
-
-% % dashed split after k = 4
-% \draw[dashed] (3.5,0.55) -- (3.5,-1.6);
-% \node[anchor=south] at (3.5,0.7) {$k=4$};
-
-% % braces
-% \draw[decorate,decoration={brace,mirror,amplitude=4pt}]
-%       (-0.25,-1.45) -- (3.5,-1.45)
-%       node[midway,below=4pt] {left $N_L=4$};
-% \draw[decorate,decoration={brace,mirror,amplitude=4pt}]
-%       (3.5,-1.45) -- (5.25,-1.45)
-%       node[midway,below=4pt] {right $N_R=2$};
-
-% % (3) computation box
-% \node[draw, rounded corners, align=left, anchor=north,
-%       minimum width=7.2cm] (comp) at (2.5,-2.8) {
-%   \strut$\displaystyle
-%     \Delta\text{RSS}(k{=}4)
-%     = \frac{S_4^{2}}{4}
-%       +\frac{(S_6-S_4)^{2}}{2}
-%       -\frac{S_6^{2}}{6}$\\[2pt]
-%   $\displaystyle
-%     =\frac{7.9^{2}}{4}
-%       +\frac{(14.8-7.9)^{2}}{2}
-%       -\frac{14.8^{2}}{6}
-%       \;\approx\;2.08$
-% };
-
-% \draw[->] (3.0,-1.25) -- (comp.north);
-
-% % complexity foot-note
-% \node[anchor=west,font=\tiny,gray] at (1.5,-3.7)
-%       {\(\mathcal{O}(1)\) per split \(\;\Longrightarrow\;\) \(\mathcal{O}(n)\) per feature};
-% \end{tikzpicture}
-% \end{frame}
-
-% % --- Slide 5: Complexity Comparison ---
-% \begin{frame}{Naive vs. Cumulative-Sum Split}
-%   \begin{itemize}
-%     \item \textbf{Naive:} $O(n^2)$ per feature (explicit recomputation of RSS)
-%     \item \textbf{Prefix sum:} $O(n)$ per feature (after $O(n \log n)$ sorting)
-%     \item \textbf{Speedup:} For $n = 10^4$: $\sim10^8$ vs. $10^4$ operations per feature
-%     \item \textbf{Same optimal split:} Numerically identical result, algorithmically faster
-%     \item \textbf{Constraint:} Only valid if both partitions are non-empty: split between distinct $x_i$
-%   \end{itemize}
-% \end{frame}
 
 % ------------------------------------------------------------
 % --- Slide : Prefix-Sum Trick - Worked Example  -------------
@@ -559,66 +395,6 @@ Cycle through each feature $j = 2,\dots,p$:
 
 
 
-
-
-
-
-
-
-
-
-
-% \begin{frame}{Intelligible GAM - Algorithm Sketch - Part I}
-
-% \begin{figure}
-%     \centering
-%     \includegraphics[width=1\linewidth]{figure/EBM_Step1.png}
-%     \label{fig:Intelligible EBM_Step1}
-% \end{figure}
-% \begin{itemize}
-%     \item Set all shape functions $f_j^{[0]}$ to zero, $j=1,\cdots,p$
-%     \item Calculate the initial pseudo-residual (i.e. the negative gradient of the loss function w.r.t. the current model prediction), e.g.\\
-%     1. for squared error loss: $\tilde{r}^{[0]}=-\frac{\partial L}{\partial \hat{y}}=y-\hat{y}^{[0]}=y-\sum_jf_j^{(0)}(x_{ij})$\\
-%     2. for log loss: $\tilde{r}^{[0]}=-\frac{\partial L}{\partial \hat{y}}=y-\sigma(\hat{y}^{[0]})$ with $\sigma(\cdot)$ being the sigmoid function
-%     \item Fit a shallow bagging tree with 2-4 leaves $T_1^{[1]}: x_{i1}\to \tilde{r}$ \textbf{only using the first feature} to predict the pseudo-residuals, with $\{x_{i1},\tilde{r}\}_1^n$ as training dataset
-%     \item Update $f_1$: $f_1^{[1]}(x_{i1})=f_1^{[0]}+\eta\cdot T_1^{[1]}(x_{i1})$
-%     \item Update $\hat{y}$: $\hat{y}^{[1]}=\sum_jf_j^{[1]}(x_{ij})$
-%     \item Update the residual w.r.t. the original target, e.g. $\tilde{r}^{[1]}=y-\hat{y}^{[1]}$
-%     \item Go to the second feature
-% \end{itemize}
-% \end{frame}
-
-% \begin{frame}{Intelligible GAM - Algorithm Sketch - Part II}
-% \begin{figure}
-%     \centering
-%     \includegraphics[width=1\linewidth]{figure/EBM_Step2.png}
-%     \label{fig:Intelligible EBM_Step2}
-% \end{figure}
-% \begin{itemize}
-%     \item Fit a shallow bagging tree $T_2^{[1]}$ \textbf{only using the second feature} to predict the updated residuals
-%     \item Update $f_2$ with $f_2^{[1]}(x_{i2})=f_2^{(0)}+\eta\cdot T_2^{[1]}(x_{i2})$ and then update $\hat{y}^{[1]}$
-%     \item Update the residual: this residual takes into account both what was learned on the first tree and second tree for the first two features
-%     \item Go to $\text{feat}_3$
-% \end{itemize}
-
-% \end{frame}
-
-% \begin{frame}{Intelligible GAM - Algorithm Sketch - Part III}
-% \begin{figure}
-%     \centering
-%     \includegraphics[width=1\linewidth]{figure/EBM_Step3.png}
-%     \label{fig:Intelligible EBM_Step3}
-% \end{figure}
-% \begin{itemize}
-%     \item Go through every feature and keep updating the residual
-%     \item Grow a small tree on each feature but just one at a time in each iteration
-%     \item Do $M$ iterations through these features until convergence (e.g. $M=10000$) \\
-%     $\leadsto$ keep the learning rate $\eta$ so small that feature ordering does not matter
-% \end{itemize}
-
-% \end{frame}
-
-
 \begin{framev}[align=top]{Univariate EBM - Prediction \& Interpretability}
 \begin{itemizeM}
 \item Final model consists of $M$ shallow trees per feature:
@@ -636,23 +412,6 @@ $$
 \image{figure/ebm_prediction.png}
 \end{framev}
 
-
-% \begin{frame}{Intelligible GAM - Prediction}
-% \begin{itemize}
-%     \item Output: $M$ trees which were only trained on $\text{feat}_1$ \\
-%     \qquad\;\; + $M$ trees which were only trained on $\text{feat}_2$ \\
-%     \qquad\;\; $\cdots$ \\
-%     \qquad\;\; + $M$ trees which were only trained on $\text{feat}_p$
-%     \item Summarize the weighted predictions of $M$ trees for each unique value of $\text{feat}_1$ $\hat{f}_1(x_1)=\sum_{m=1}^{M}\eta\cdot T_1^{[m]}(x_1)$, and plot $\hat{f}_1(x_1)$ vs. $x_1$ as a 2D graph
-%     \item Generate a 2D graph for every feature in the same way
-% \end{itemize}
-% \quad $\leadsto$ Intelligible GAM: A series of 2D graphs as a perfect summary of predictions
-% \begin{figure}
-%     \centering
-%     \includegraphics[width=\textwidth]{figure/ebm_prediction.png}
-%     \label{fig:Intelligible ebm_prediction}
-% \end{figure}
-% \end{frame}
 
 % \begin{frame}{Intelligible GAM - Novelty and Extension}
 % \begin{itemize}
@@ -672,33 +431,6 @@ $$
 %         \item Replace the 2-4 regions of small tree
 %         \item By a dynamic programming algorithm called FAST
 %     \end{itemize}
-% \end{itemize}
-% \end{frame}
-
-% \begin{frame}{Accurate GAM plus Pairwise Interactions}
-% \textbf{Generalized Additive Models plus Interactions}: $$g(\E (y \mid \xv)) = \theta_0 + \sum f(x) + \sum f_{ij}(x,x_j)\quad for\quad i,j=1,\cdots,p,\quad i\neq j$$
-% \begin{itemize}
-%     \item $O(p^2)$: a large number of pairwise interactions if $p$ is big\\
-%     $\leadsto$ Select only a small number of the most important interactions
-%     \item Intuitively, significant reduction in RSS $\to$ Strong pair interaction
-%     \item \textbf{FAST} algorithm does quick ranking without fully building every interaction function
-% \end{itemize}
-% \end{frame}
-
-
-% \begin{frame}{GA2M - EBM \& Pairwise Interactions}
-% \textbf{Generalized Additive Models plus Interactions (GA2M):}
-% $$
-% g\big(\mathbb{E}[y \mid \xv]\big) = \theta_0 + \sum_{j=1}^p f_j(x_j) + \sum_{i<j} f_{ij}(x_i, x_j)
-% $$
-
-% \begin{itemize}
-%     \item \textbf{Extends EBM}: Adds selected bivariate functions $f_{ij}(x_i, x_j)$ to improve accuracy
-%     \item \textbf{Interpretability preserved}: Each $f_{ij}$ is visualized as a 2D heatmap
-%     \item Naively $O(p^2)$ possible pairs $\leadsto$ select only most relevant interactions
-%     \item \textbf{FAST algorithm}: Ranks all feature pairs without exhaustively fitting them\\
-%     $\leadsto$ Measures on how much a pair reduces residual sum of squares (RSS)
-%     \item Top-ranked interactions added via a second-stage boosting step
 % \end{itemize}
 % \end{frame}
 
@@ -1402,64 +1134,6 @@ $$
 % \end{itemize}
 % \end{frame}
 
-% \begin{frame}{GA2M - Two-stage Construction}
-% \begin{enumerate}
-%     \item Fit main effects
-%     \begin{itemize}
-%         \item Fit model only using univariate terms
-%         \item Fix the main effects model
-%     \end{itemize}
-%     \item Fit pairwise residual of main effects model to original targets
-%     \begin{itemize}
-%         \item Use FAST to sort through $O(p^2)$ pairs
-%         \item User selects number $K$ of pairs to be added
-%         \item Run boosting algorithm to fit $K$ pairs
-%         \item Final model = $p$ mains + $K$ pairs
-%     \end{itemize}
-% \end{enumerate}
-% \end{frame}
-
-% \begin{frame}{Accurate GAM - 2. Stage Algorithm Sketch}
-% \begin{figure}
-%     \centering
-%     \includegraphics[width=1\linewidth]{figure/GA2M_Step1.png}
-%     \label{fig:GA2M_Step1}
-% \end{figure}
-% \begin{columns}[T, totalwidth=\textwidth]
-%     \begin{column}{0.4\textwidth} 
-%         \begin{figure}
-%             \vspace{-1.35cm} 
-%             \hspace{-0.8cm} 
-%             \includegraphics[width=0.8\linewidth]{figure/GA2M_Step0.png}
-%             \label{fig:GA2M_predictor}
-%         \end{figure}
-%     \end{column}
-%     \hfill
-%     \begin{column}{0.7\textwidth}
-%     \begin{itemize}
-%       \setlength{\leftskip}{-0.7cm}
-%       \vspace{-0.8cm}
-%     \item Model each selected pairwise interaction $f_{ij}(x_i, x_j)$ using boosting over residuals
-%     \item Replace shallow trees with a tree-like 2D predictor (similar to FAST) but use 3 cuts: 2 axis-aligned ($c_i$, $c_j$) and 1 additional refinement
-%     \item Reuse precomputed lookup tables from FAST (sum of targets and counts per region)
-%     \item Apply greedy search over cut positions to minimize RSS per boosting step
-% \end{itemize}
-
-%         % \begin{itemize}
-%         %     \setlength{\leftskip}{-0.7cm}
-%         %     \vspace{-0.8cm}
-%         %     \item To model the pairwise interactions effectively and efficiently\\
-%         %     $\leadsto$Replace the shallow tree ensembles used in Intelligible GAM with a tree-like predictor (similar to FAST)
-%         %     \item 3 cuts instead of 2 cuts
-%         %     \item Re-use the stored values in the lookup tables for sum of targets and sum of counts from FAST
-%         %     \item Greedy search for the best combination of cuts (lowest RSS)
-%         % \end{itemize}
-%     \end{column}
-% \end{columns}
-
-% \end{frame}
-
-
 \begin{framev}[align=top]{EBM - Boosting Pairwise Interactions}
 %\vspace{-0.2cm}
 %\begin{figure}
@@ -1523,38 +1197,6 @@ $$
 \end{framev}
 
 
-% \begin{frame}{Accurate GAM - Prediction}
-% \begin{itemize}
-%     \item Output: $M$ predictors which were only trained on $\text{Pair}_1$ \\
-%     \qquad\;\; + $M$ predictors which were only trained on $\text{Pair}_2$ \\
-%     \qquad\;\; $\cdots$ \\
-%     \qquad\;\; + $M$ predictors which were only trained on $\text{Pair}_K$
-%     \item Summarize the weighted predictions of $M$ models in a 3D heatmap
-%     \item The dimension of color represents the contribution of pairwise feature values to the prediction
-%     \item Generate a 3D heatmap for each pair of features
-% \end{itemize}
-
-% \begin{figure}    
-%     \includegraphics[width=0.4\linewidth]
-%     {figure/3D Heatmap.png}
-%     \label{fig:3D Heatmap}
-% \end{figure}
-
-% \end{frame}
-
-% \begin{frame}{GA2M - Prediction with Pairwise Interactions}
-% \begin{itemize}
-%     \item Output: $M$ predictors for each of the $K$ selected pairwise interactions $f_{ij}(x_i, x_j)$
-%     \item Each $f_{ij}$ is visualized as a 2D heatmap over feature pairs
-%     \item Color encodes the contribution of feature value combinations to the final prediction
-%     \item Summarize the ensemble of $M$ predictors per pair into a single interpretable surface
-% \end{itemize}
-
-% \vspace{0.3cm}
-% \centering
-% \includegraphics[width=0.42\linewidth]{figure/3D Heatmap.png}
-% \end{frame}
-
 \begin{framev}[align=top]{EBM - Prediction with Pairwise Interactions}
 \begin{itemizeM}
 \item Each selected pair $(x_i, x_j)$ is modeled by $M$ boosted predictors trained on their residual interaction
@@ -1585,52 +1227,6 @@ $$
 
 
 
-% % ---------- SLIDE 1: headline comparison ---------------------------
-% \begin{frame}{EBM \textit{vs.} Model-based Boosting}
-% \small
-% \setlength{\tabcolsep}{5pt}
-% \begin{tabular}{@{}p{2.5cm}p{4.5cm}p{4.5cm}@{}}
-% \toprule
-% \textbf{Aspect} &
-% \textbf{EBM \phantom{XXXXXXXXX} % OLD
-%\citebutton{Lou et al. 2012}{https://www.cs.cornell.edu/~yinlou/papers/lou-kdd12.pdf}
-% new
-% \furtherreading{LOU2012} % OLD
-%\citebutton{Lou et al. 2013}{https://www.cs.cornell.edu/~yinlou/papers/lou-kdd13.pdf}
-% new
-% \furtherreading{LOU2013}} &
-% \textbf{Model-based Boosting \phantom{XXXX} 
-% % OLD
-%\citebutton{Buhlmann, 2003}{https://doi.org/10.1198/016214503000125}
-% new
-% \furtherreading{Buhlmann_2003} % OLD
-%\citebutton{Buhlmann, 2008}{https://arxiv.org/abs/0804.2752}
-% new
-% \furtherreading{Buhlmann_2008}} \\
-% \midrule
-% \emph{Base learner} &
-% Bagged trees (2-4 leaves), one feature at a time; piece-wise constant shape functions &
-% Custom learner per component (linear, spline, tree) \\
-% \addlinespace[2pt]\pause
-% \emph{Iteration policy} &
-% Round-robin cycle over \emph{all} features at every boosting iteration &
-% Greedy: update \emph{single} component that most reduces risk \\
-% \addlinespace[2pt]\pause
-% \emph{Regularisation} &
-% $\eta\!\approx\!0.01$;\; high $M$ (5-10k) + early stopping via internal CV on OOB samples;\; bagging lowers variance &
-% Shrinkage $\nu\!\in\!(0,1]$;\; early stopping;\; intrinsic variable selection \\
-% \addlinespace[2pt]\pause
-% \emph{Interactions} &
-% FAST ranks and selects top-$K$ interaction pairs, fitted as bivariate trees (GA2M) &
-% Only included if user provides explicit interaction terms; no automatic pairwise search\\
-% \addlinespace[2pt]\pause
-% \emph{Interpretability} &
-% 1-D step plots ($f_j$) + selected 2-D heat-maps ($f_{ij}$) &
-% Depends on base learner: coefficients, smooth splines, random-effect curves, etc.\\
-% \bottomrule
-% \end{tabular}
-% \end{frame}
-%------------- SLIDE 1 -------------------------------------------------
 \begin{framei}[align=top]{EBM \textit{vs.} Model-based Boosting}
 %-- BASE LEARNER -----------------------------------------------------
 \item \textbf{Base learner}

--- a/slides/interpretable-models/slides08-im-rpf.tex
+++ b/slides/interpretable-models/slides08-im-rpf.tex
@@ -166,19 +166,6 @@ Define \textit{Planted Trees}: decision trees where each inner node can be a \te
 \end{itemizeM}
 \end{framev}
 
-% \begin{frame}{RPF: Example}
-
-%     \begin{figure}[h]
-%         \centering
-%         % \vspace{-10pt} % Note that this is only to ensure a normal, not to big margin around the figure
-%         \includegraphics[width=1.1\linewidth]{figure/2023_paper_skizze_Planted_Tree.jpg}
-%         % \vspace{-10pt}
-%         \caption{Example of a single fully grown planted tree}
-%         \label{fig:Planted_Tree_example_paper}
-%     \end{figure}
-
-% \end{frame}
-
 \begin{framev}[align=top]{RPF: Example}
 \begin{center}
 \begin{figure}[h]


### PR DESCRIPTION
# Commented-Out Content Removal Report

Edited files:

- `slides/interpretable-models/slides01-im-motivation.tex`
- `slides/interpretable-models/slides02-im-lm-simple.tex`
- `slides/interpretable-models/slides03-im-lm-extensions.tex`
- `slides/interpretable-models/slides04-im-glm.tex`
- `slides/interpretable-models/slides05-im-rule-based.tex`
- `slides/interpretable-models/slides06-im-gam-boosting.tex`
- `slides/interpretable-models/slides07-im-ebm.tex`
- `slides/interpretable-models/slides08-im-rpf.tex`

## Summary

- Removed commented-out units: **45**
- Kept candidate units: **16**
- Restored or moved provenance/reference comment blocks: **0**
- Evidence scope: current file **yes**, sibling `.tex` files **yes**

## Provenance / attribution audit

- No provenance/reference blocks needed to be moved.
- Deleted provenance in the old trade-off figure reprise in `slides01-im-motivation.tex` was already preserved near the active figure source comment in the Motivation frame.
- Removed boosting and tree legacy blocks only where citation/reference material was already preserved in active sibling slides, especially `slides06-im-gam-boosting.tex` and `slides05-im-rule-based.tex`.
- Removed EBM comparison and GA2M legacy blocks only where Lou/Buhlmann references were already preserved in the active EBM comparison and interaction slides.
- No deleted provenance lines were left without preservation.

<details>
<summary><strong>slides/interpretable-models/slides01-im-motivation.tex</strong>: 7 removed, 4 kept</summary>

Evidence scope: current file **yes**, sibling `.tex` files **no**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | `L25`; `L30` | Alternative Motivation phrasings saying interpretable models are the straightforward or easiest path. | Same file, frame `Motivation`. | Same takeaway is already stated in the active first bullet. | None. |
| 2 | `L63`; `L67-L68` | Old Advantages wording on avoiding model-agnostic methods and low training effort. | Same file, frame `Advantages`. | Same advantages are already covered by the first two active bullets. | None. |
| 3 | `L133`; `L140-L145` | Alternative Disadvantages wording on limited flexibility and still needing model-agnostic explanations. | Same file, frame `Disadvantages & Limitations`. | Same limitations are already active with clearer wording. | None. |
| 4 | `L157-L158` | Old Further Comments subpoints on preferring interpretable models and recovering performance via preprocessing/feature engineering. | Same file, frame `Further Comments`. | Same pedagogical point is already covered in the active Rudin-related subitems. | Nearby Rudin reference already preserved. |
| 5 | `L167-L170` | Older end-to-end-learning drawback wording for image/text data. | Same file, frame `Further Comments`. | Same limitation is already active in the second item and its subitems. | None. |
| 6 | `L180-L186` | Trade-off reminder plus repeated figure/source reprise. | Same file, frame `Motivation`. | Same trade-off claim and same figure are already active earlier in the file. | Source was already preserved near the active figure. |
| 7 | `L191-L196` | Old Recommendation bullet list. | Same file, frame `Recommendation`. | Active bullets restate the same three recommendations. | None. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `L19` | Learning-goal question about characteristics of interpretable models. | Not explicitly covered by active content in this file or its siblings. |
| 2 | `L69-L75` | Monotonic-effects and deployment/implementation remarks in `Advantages`. | Only partially reflected by the active slide; still more specific. |
| 3 | `L116-L117` | High-dimensional feature-specification limitation. | More specific than the active limited-flexibility wording. |
| 4 | `L205-L238` | Old two-dataset comparison tables. | Adds a Boston Housing comparison not preserved by the active Bike-only table. |

</details>

<details>
<summary><strong>slides/interpretable-models/slides02-im-lm-simple.tex</strong>: 6 removed, 3 kept</summary>

Evidence scope: current file **yes**, sibling `.tex` files **yes**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | `L40-L41` | Old `Model formula` heading plus expectation-form equation. | Same file, frame `Linear Regression`. | The active main equation already covers the same formula. | None. |
| 2 | `L53-L57` | Commented polynomial-extension block. | Sibling file `slides03-im-lm-extensions.tex`, frame `Interaction and High-order Effects`. | The same teaching point was moved into the dedicated extensions slide. | None. |
| 3 | `L69-L70` | Linear-combination/additive phrasing for the assumptions section. | Same file, frame `Linear Regression`. | Same point is already conveyed by the active equation and first assumptions bullet. | None. |
| 4 | `L160` | Verbose p-value paraphrase. | Same file, frame `Linear Regression - Interpretation` (feature importance). | Same definition is already stated actively in shorter form. | None. |
| 5 | `L177-L181` | Footnotesize one-line bike-model equation. | Same file, frame `Example: Lin. Regression - Main Effects`. | The active aligned equation already serves the same role. | None. |
| 6 | `L249` | Duplicate temperature interpretation sentence. | Same file, frame `Example: Lin. Regression - Main Effects`. | Same numerical interpretation is already an active bullet. | None. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `L79-L80` | Inference-validity warning plus practical-use caveat. | More specific than the active assumptions wording. |
| 2 | `L117-L122` | Dummy-encoding elaboration plus higher-order caveat. | Only partially preserved here and in the sibling extensions slide. |
| 3 | `L232-L241` | Boxplot-based contribution visualization block. | No active slide in this directory preserves that visual explanation. |

</details>

<details>
<summary><strong>slides/interpretable-models/slides03-im-lm-extensions.tex</strong>: 5 removed, 2 kept</summary>

Evidence scope: current file **yes**, sibling `.tex` files **yes**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | `L79-L85` | Mini-block saying weights cannot be interpreted in isolation. | Same file, frame `Interaction and High-order Effects`. | Same takeaway is already active in the implications bullets. | None. |
| 2 | `L88-L108` | Full legacy `Linear and Polynomial Regression` frame. | Same file, frame `Interaction and High-order Effects`; sibling `slides02-im-lm-simple.tex`, frame `Linear Regression`. | Its concepts are already split across the active LM basics and extensions slides. | None. |
| 3 | `L190-L191` | Repeated bullets on flexibility loss and manual specification. | Same file, frame `Interaction and High-order Effects`. | Same consequences are already active earlier in the file. | None. |
| 4 | `L261-L267` | Old LASSO intro block. | Same file, first frame `Regularization via LASSO`. | The active LASSO frame already states the same ideas. | None. |
| 5 | `L301`; `L304`; `L306` | Repeated LASSO example notes on interaction setup and dummy-encoding limitation. | Same file, second frame `Regularization via LASSO`. | Same notes are already active in the example bullets. | None. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `L160-L163` | Extrapolation warning about season-specific temperature ranges. | Not preserved by active content. |
| 2 | `L334-L351` | Alternative LASSO coefficient table using a polynomial example. | Distinct example detail not preserved by the active interaction-based table. |

</details>

<details>
<summary><strong>slides/interpretable-models/slides04-im-glm.tex</strong>: 5 removed, 3 kept</summary>

Evidence scope: current file **yes**, sibling `.tex` files **no**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | `L50-L56` | Old aligned GLM equation block. | Same file, frame `GLM`. | Same equation is already active in compact form. | None. |
| 2 | `L68-L79` | Old non-Gaussian-output and manual-interaction summary block. | Same file, frame `GLM`. | Same ideas are already covered by the active bullet list. | None. |
| 3 | `L84-L122` | Old columns-based `GLM - Logistic Regression` layout and duplicate formulas. | Same file, frame `GLM - Logistic Regression`. | Same logistic-link and probability formulas are already active. | None. |
| 4 | `L143-L168` | Full legacy `Generalized Linear Models (GLMs)` frame. | Same file, frame `GLM`. | The same concepts are already covered actively with updated wording. | None. |
| 5 | `L177`; `L180`; `L189` | Alternative log-odds interpretation notes. | Same file, frame `GLM - Log. Regression - Interpretation`. | Same interpretation is already active with clearer wording. | None. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `L206-L220` | Full logistic-regression coefficient table with `z` values. | Adds detail beyond the active simplified table. |
| 2 | `L251` | Season odds-ratio interpretation example. | Not preserved actively. |
| 3 | `L260-L347` | Marginal-effects derivation sequence. | Unique derivation block with no active duplicate in this directory. |

</details>

<details>
<summary><strong>slides/interpretable-models/slides05-im-rule-based.tex</strong>: 6 removed, 1 kept</summary>

Evidence scope: current file **yes**, sibling `.tex` files **yes**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | `L34-L42` | Early alternative Decision Trees intro wording. | Same file, frame `Decision Trees`. | Same concept is already active with cleaner wording. | None. |
| 2 | `L97-L105` | Old `Interpretation` frame. | Same file, frame `Interpretation of Tree-Based Models`. | Same interpretation points are already active. | None. |
| 3 | `L168-L196` | Old delta-variance visualization and manual feature-importance accumulation block. | Same file, frame `Interpretation of Tree-Based Models`. | Same example is already active in a newer diagram and bullet list. | None. |
| 4 | `L262-L299` | Old `Model-based Boosting` overview frame. | Sibling file `slides06-im-gam-boosting.tex`, frame `Model-based Boosting`. | The topic was moved to the dedicated boosting slide file. | Boosting reference already preserved in the active sibling slide. |
| 5 | `L302-L387` | Old `Model-based Boosting - Example` frame. | Sibling file `slides06-im-gam-boosting.tex`, frame `Model-based Boosting - Linear Example`. | Same example role now lives in the dedicated boosting file. | No separate provenance issue. |
| 6 | `L389-L418` | Old `Model-based Boosting - Interpretation` frame. | Sibling file `slides06-im-gam-boosting.tex`, frames `Linear Example: Interpretation` and `Non-linear Example: Interpretation`. | Same interpretation content is already active in the sibling boosting slides. | Schalk reference already preserved in the active sibling file. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `L227-L251` | `Decision Rules` frame with support/accuracy trade-off and default-rule note. | Distinct teaching point not preserved by active content elsewhere in this file. |

</details>

<details>
<summary><strong>slides/interpretable-models/slides06-im-gam-boosting.tex</strong>: 6 removed, 1 kept</summary>

Evidence scope: current file **yes**, sibling `.tex` files **yes**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | `L149-L155` | Old inline explanations about interpretable base learners and combining same-type learners. | Same file, frame `Model-based Boosting`. | Same explanation is already active in the surrounding bullets and formula. | None. |
| 2 | `L270-L273` | Old summary on selected base learners. | Same file, frame `Model-based Boosting - Linear Example`. | Same takeaway is already visible in the active example and tables. | None. |
| 3 | `L330-L340` | Old feature-importance and feature-effect caption notes. | Same file, frame `Non-linear Example: Interpretation`. | Same captions and interpretations are already active. | None. |
| 4 | `L362-L416` | Very old `Decision Trees` frame. | Sibling file `slides05-im-rule-based.tex`, frame `Decision Trees`. | Same tree introduction now lives in the dedicated rule-based slide file. | No separate provenance issue. |
| 5 | `L418-L502` | Revised old `Decision Trees` overview frame. | Sibling file `slides05-im-rule-based.tex`, frames `Decision Trees` and `Interpretation of Tree-Based Models`. | Same tree overview and interpretation are already active in the sibling file. | Breiman reference already preserved in the active sibling file. |
| 6 | `L504-L529` | Old `Decision Trees - Example` frame. | Sibling file `slides05-im-rule-based.tex`, frame `Decision Trees - Example`. | Same example is already active in the sibling file. | None. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `L98-L106` | Extended GAM table with `Ref.df` and `F` columns. | Adds statistical detail beyond the active simplified table. |

</details>

<details>
<summary><strong>slides/interpretable-models/slides07-im-ebm.tex</strong>: 9 removed, 2 kept</summary>

Evidence scope: current file **yes**, sibling `.tex` files **no**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | `L163-L174` | Old `Efficient Split Selection: Prefix-Sum Trick` frame. | Same file, frame `Efficient Split Selection`. | Same split-selection idea is already active in updated form. | None. |
| 2 | `L232-L366` | Old prefix-sum visual and worked-example frames. | Same file, frame `Efficient Split Selection - Example`. | Same pedagogical example is already active in the newer example slide. | None. |
| 3 | `L369-L377` | Old `Naive vs. Cumulative-Sum Split` comparison frame. | Same file, frames `Naive Split Selection: Explicit Comput.` and `Efficient Split Selection`. | Same comparison is already distributed across active slides. | None. |
| 4 | `L571-L620` | Old `Intelligible GAM - Algorithm Sketch` Parts I-III. | Same file, active univariate EBM sequence and active prediction/interpretability slides. | Same algorithm flow is already covered actively with the newer EBM structure. | None. |
| 5 | `L640-L654` | Old `Intelligible GAM - Prediction` frame. | Same file, frame `Univariate EBM - Prediction & Interpretability`. | Same prediction summary is already active. | None. |
| 6 | `L678-L703` | Old GA2M overview frames. | Same file, frame `EBM with Pairwise Interactions`. | Same interaction overview is already active with cleaner framing. | Lou references already preserved in active interaction/comparison slides. |
| 7 | `L1405-L1459` | Old GA2M two-stage construction and second-stage algorithm frames. | Same file, frames `EBM - Two-Stage Model Construction` and `EBM - Boosting Pairwise Interactions`. | Same construction story is already active. | None beyond already preserved active references. |
| 8 | `L1526-L1556` | Old pairwise-prediction frames. | Same file, frames `EBM - Prediction with Pairwise Interactions` and `EBM - Final Model Structure`. | Same prediction summary is already active. | None. |
| 9 | `L1588-L1628` | Old comparison-table frame for EBM vs. model-based boosting. | Same file, active `EBM vs. Model-based Boosting` comparison slides. | Same comparison now exists as active slide content. | Lou/Buhlmann references already preserved in active comparison slides. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `L657-L676` | `Intelligible GAM - Novelty and Extension`. | Adds discrete-shape-function and bagging-vs-spline rationale not fully preserved by the active intro. |
| 2 | `L731-L1392` | FAST derivation cluster. | Keeps lower-level cumulative-histogram and lookup-table mechanics not fully spelled out by the active FAST walkthrough. |

</details>

<details>
<summary><strong>slides/interpretable-models/slides08-im-rpf.tex</strong>: 1 removed, 0 kept</summary>

Evidence scope: current file **yes**, sibling `.tex` files **no**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | `L169-L180` | Old figure-only `RPF: Example` frame. | Same file, active frame `RPF: Example`. | The same example role is already served by the active slide. | None. |

### Kept

No notable kept slide-content candidates. Remaining comments are metadata, TODOs, or diagram-maintenance notes.

</details>