### PR TITLE
remove redundant LIME comments

### DIFF
--- a/slides/local-explanations-lime/slides01-le-intro.tex
+++ b/slides/local-explanations-lime/slides01-le-intro.tex
@@ -36,8 +36,6 @@ figure/lime.png
 % ------------------------------------------------------------------------------
 
 \begin{framei}[align=top]{Methodological Motivation}
-% Marius: We cannot write such stuff if we want to stay flexible how to combine chunks
-%Except for Shapley values and ICE curves, we focused so far mostly on global explanation methods that explain global model behavior (e.g. PDP, PFI, etc.). However, there are also many methods that explain the \textbf{local} behavior of a model.
 \item Purpose of local explanations:
 \begin{itemizeS}
 \item Insight into the driving factors for a \textbf{particular prediction/decision}
@@ -56,7 +54,6 @@ figure/lime.png
 
 
 \begin{framei}[align=top]{Social Motivation}
-%All these questions can indeed be relevant for the ML modeler. However, unlike in global methods that require expert ML understanding or even domain knowledge, many local methods aim to provide explanations also for laypersons. 
 \item Explanations for laypersons should be tailored to the \textbf{explainee}\\ % (who receives the explanation)\\ %(i.e., the person receiving the explanation)
 $\leadsto$ \textbf{case specific}, \textbf{human-intelligible}, \textbf{faithful} to explained mechanism
 \pause
@@ -73,21 +70,16 @@ $\leadsto$ \textbf{case specific}, \textbf{human-intelligible}, \textbf{faithful
 
 \begin{framev}[align=top]{GDPR \& AI Act: The Right to Explanation}
 ``The data subject should have the right not to be subject to a decision
-    %, which may include a measure, evaluating personal aspects relating to him or her which is 
     [...] based solely on automated processing [...],
-    %and which produces legal effects concerning him or her or similarly significantly affects him or her, 
 such as automatic refusal of an online credit application or e-recruiting practices without any human intervention.
 \\
 $[\ldots]$\\
 In any case, such processing should be subject to suitable safeguards, which should include [...]
-%specific information to the data subject and 
 the \textbf{right to obtain} [...]
-%human intervention, to express his or her point of view, to obtain 
 \textbf{an explanation of the decision reached after such assessment and to challenge the decision}.''
 \hfill \furtherreading{GDPR2016}
 \spacer[0.25]\\
 ``Any affected person [...]
-%subject to a decision which is taken by the deployer on the basis of the output from a high-risk AI system listed in Annex III, with the exception of systems listed under point 2 thereof, and which produces legal effects or similarly significantly affects that person in a way that they consider to have an adverse impact on their health, safety or fundamental rights 
 shall have the right to obtain from the deployer clear and meaningful explanations of the role of the AI system in the decision-making procedure and the main elements of the decision taken.''
 \hfill \furtherreading{ACT2021}
 \end{framev}
@@ -131,7 +123,6 @@ $\leadsto$ our predictor is actually a snow detector
 \spacer[0.6]
 \begin{itemizeM}
 \item<1-> Imagine: You apply for a loan at an online bank and are immediately rejected without reasons
-%Imagine: You are applying at a bank's online portal for a loan and your application gets immediately rejected without reasons
 \item<2-> Bank could e.g. provide a counterfactual explanation using local explanation methods:
 \begin{itemizeS}
 \item[] ``If you were older than 21, your loan application would have been accepted."
@@ -166,13 +157,12 @@ $\leadsto$ our predictor is actually a snow detector
 \item<2-> \textbf{Applicable model classes:}
 \begin{itemizeS}
 \item Model-agnostic (by design)
-\item Model-specific variants (exploit internal structure for speed/accuracy)%variants for efficiency or more accurate estimation (by exploiting model structure)
+\item Model-specific variants (exploit internal structure for speed/accuracy)
 \end{itemizeS}
 %\\
 %$\leadsto$ very popular also for deep learning models
 \item<3-> \textbf{Audience:} ML engineers, laypersons, and domain experts
 \item<4-> \textbf{Supported data types:} Broad applicability across modalities (tabular, image, text, audio), but method-specific adaptations often required
-%\textbf{Data types:} Often agnostic, including tabular, image, text, and audio data
 \item<5-> \textbf{Main method families}
 \begin{itemizeS}
 \item Single ICE curves
@@ -181,7 +171,6 @@ $\leadsto$ our predictor is actually a snow detector
 \item Counterfactual explanations
 \item Adversarial examples
 \end{itemizeS}
-%\textbf{Methods:} Many, most prominent are counterfactual explanations, shapley values, local interpretable model-agnostic explanations (LIME), adversarial examples, single ICE curve%, anchors
 %\footnote{For Shapley values and ICE curves see other lectures}
 % \item<6-> \textbf{Special:} Due to audience, strong interactions with social sciences and strong connections to cognitive science and neurosciences due to data types
 \end{framei}

--- a/slides/local-explanations-lime/slides04-le-lime.tex
+++ b/slides/local-explanations-lime/slides04-le-lime.tex
@@ -39,47 +39,17 @@ figure/lime5
 % Prerequisite: le-intro
 
 % ------------------------------------------------------------------------------
-% \begin{frame}{LIME}
-% \begin{itemize}
-% 		% \item LIME assumption: Even if an ML model is very complex, local predictions may be explained by a simpler, interpretable model
-% 		% \smallskip\pause
-% 		\item LIME explains \textbf{individual} predictions of \textbf{any} black-box model by approximating the model \textbf{locally} with an interpretable model (local surrogate model)\\
-%         $\leadsto$ \textbf{Assumption:} Complex models behave simply in small input neighborhoods
-% 		\smallskip\pause
-% 		\item Called local surrogate models $\leadsto$ often inherently interpretable models such as linear models or classification/regression trees are chosen\\
-% 		\smallskip\pause
-% 		\item LIME should answer why a ML model predicted $\hat y$ for input $\xv$
-% 		\smallskip\pause
-% 		\item LIME is model-agnostic and can handle tabular, image and text data 
-% \end{itemize}
-% \end{frame}
-
-% Improved slide: LIME – Local Surrogate Explanations
 \begin{framei}[align=top]{LIME}
-%\item \textbf{Key idea:} Approximate any black‑box model $\fh$ around a single input $\xv$ with an \emph{interpretable} surrogate $\gh$
 \item \textbf{Locality assumption:}\\
 $\fh$ behaves similarly simple in a small neighborhood of $\xv$\\
 $\leadsto$ Approximate $\fh$ near $\xv$ using an interpretable surrogate model $\gh$
 \item \textbf{Interpretation strategy:}\\
 Use $\gh$'s simple internal structure to explain $\fh(\xv)$ locally\\
 $\leadsto$ \textbf{Common surrogates:} sparse linear models, shallow decision trees
-%\item \textbf{Algorithm:} Perturb $\xv$, obtain $\fh(\tilde{\xv})$, weight by proximity, fit $\gh$ to weighted data, interpret $\gh$’s parameters
-%\item \textbf{Typical uses:} Debug single predictions, detect spurious features, provide actionable recourse
 \item \textbf{Applicability:} Model‑agnostic; supports tabular, image, and text data %via modality‑specific perturbations
 \item \textbf{In practice:}
 Generate samples near $\xv$, predict with $\fh$, and fit $\gh$ to these samples using $\fh$'s outputs as targets, weighting samples by their proximity to $\xv$
 \end{framei}
-
-
-% \begin{frame}{LIME}
-%   \begin{itemize}
-%     \item<1-> \textbf{Core idea:} Complex models may be approximated locally by simpler, interpretable models\\
-%     $\leadsto$ Explain individual predictions of any model via local surrogate models
-%     \item<3-> \textbf{Surrogates:} Typically simple models (e.g., linear, decision tree) fitted to perturbed samples near the input $\xv$
-%     \item<4-> \textbf{Goal:} Provide human-interpretable justification for why the model predicted $\hat{y}$ for input $\xv$
-%     \item<5-> \textbf{Properties:} Model-agnostic; applicable to tabular, image, and text data (with modality-specific perturbations)
-%   \end{itemize}
-% \end{frame}
 
 
 \begin{framev}[align=top]{LIME: Characteristics}
@@ -90,7 +60,6 @@ Surrogate model $\gh$ should satisfy two characteristics:
 \begin{enumerate}
 \item \textbf{Interpretable}: Provide human-understandable insights into the relationship between input features and prediction, e.g. via coefficients or model structure
 \item \textbf{Local fidelity / faithfulness}: $\gh$ closely approximates $\fh$ in the vicinity of the input $\xv$ being explained
-%similar behavior as $\fh$ in the vicinity of the obs. being predicted
 \end{enumerate}
 \textbf{Goal:} Find $\gh$ with \textbf{minimal complexity and maximal local fidelity}
 \end{framev}
@@ -116,28 +85,6 @@ Let $\Gspace = \{g: \Xspace \to \R ~|~ g(\xv) = \sum_{m=1}^M c_m \mathds{1}_{\{\
 \end{itemizeM}
 \end{framev}
  
-% \begin{frame}{Local model fidelity}
-%  	\begin{itemize}
-%  		\item $\gh$ is locally faithful to $\fh$ w.r.t. $\xv$ 
-%  		if for $\zv \in \Zspace \subseteq \R^p$ close to $\xv$, predictions of $\gh(\zv)$ are close to $\fh(\zv)$ 
-%  		\item In an optimization task: the closer $\zv$ is to $\xv$, the closer $\gh(\zv)$ should be to $\fh(\zv)$  
-%  		\pause
-%  		\item Two required measures:
-%  		\begin{enumerate}
-%  			\item A proximity (similarity) measure $\neigh(\zv)$ between $\zv$ and $\xv$, e.g. the exponential kernel:
-%  			$$\neigh(\zv) = exp(-d(\xv, \zv)^2/\sigma^2)$$ 
-%  			with $\sigma$ as the kernel width and $d$ as the Euclidean distance (numeric features) or the Gower distance (mixed features) 
-%  			\pause
-%  			\item A distance measure or loss function $L(\fh(\zv), \gh(\zv))$, e.g. the L$_2$ loss/squared error
-%  			$$L(\fh(\zv), \gh(\zv)) = (\gh(\zv) - \fh(\zv))^2$$ 
-%  		\end{enumerate}
-%  		\pause
-%  		\item Given points $\zv$, we can measure local fidelity of $\gh$ with respect to $\fh$ in terms of a weighted loss
-%  		$$ L(\fh, g, \neigh) = \sum_{\zv \in \Zspace} \neigh(\zv) L(\fh(\zv), \gh(\zv)) $$
-%  		%\item Note that identifying \textbf{locally} faithful explanations that are interpretable is less of a challenge than identifying \textbf{globally} faithful explanations. Yet, global fidelity implies local fidelity but not vice versa.
-%  	\end{itemize}
-% \end{frame}
-
 \begin{framev}[align=top]{Local Fidelity of Surrogate Models}
 \begin{itemizeM}
 \item Surrogate $\gh$ is \textbf{locally faithful} to a black-box model $\fh$ around an input $\xv$ if\\
@@ -169,6 +116,7 @@ $$
 $$
 L(\fh, \gh, \neigh) = \sum_{\zv \in \Zspace} \neigh(\zv) \cdot L(\fh(\zv), \gh(\zv))
 $$
+%\item Note that identifying \textbf{locally} faithful explanations that are interpretable is less of a challenge than identifying \textbf{globally} faithful explanations. Yet, global fidelity implies local fidelity but not vice versa.
 \end{itemizeM}
 \end{framev}
 
@@ -187,7 +135,6 @@ $$
 \begin{itemizeS}
 \item[$\leadsto$] Optimize $L(\fh, \gh, \neigh)$ without making assumptions on the form of $\fh$
 \item[$\leadsto$] Surrogate $\gh$ approximates $\fh$ locally through sampling and fitting
-%learn $\gh$ only approximately
 \end{itemizeS}
 \end{framei}
 
@@ -208,7 +155,6 @@ $$
 \item Train interpretable surrogate model $\gh$ on data $\zv \in \Zspace$ using weights $\neigh(\zv)$\\
 $\leadsto$ Predictions $\fh(\zv)$ are used as the target of this model
 \item Return $\gh$ as the local explanation for $\fh(\xv)$
-%the interpretable model $\gh$ as the explainer
 \end{enumerate}
 \end{framev}
 

--- a/slides/local-explanations-lime/slides05-le-lime-examples.tex
+++ b/slides/local-explanations-lime/slides05-le-lime-examples.tex
@@ -67,7 +67,6 @@ $\gh(\xv) = 0.640$ vs. $\fh_{bad}(\xv) = 0.658$
 }{
 \spacer[0]
 \image{figure/lime_credit.pdf}
-%{\scriptsize Local surrogate model: \( \gh(\xv) = \thetah^\top \xv \)}
 \spacer[0]
 }
 \textbf{Interpretation:} Prediction is mainly driven by loan duration, with small positive effect from sex and credit.amount, and negative contributions from housing and purpose.

--- a/slides/local-explanations-lime/slides06-le-lime-pitfalls.tex
+++ b/slides/local-explanations-lime/slides06-le-lime-pitfalls.tex
@@ -53,21 +53,11 @@ $\leadsto$ But several papers highlight important (practical) limitations
 \item \textbf{Robustness} -- explanations vary for similar points
 \item \textbf{Superpixels (images)} -- instability due to segmentation method
 \end{itemizeS}
-% \begin{itemize}
-%     \item Sampling procedure (extrapolation)
-%     \item Definition of locality (sensitivity)
-%     \item Scope of feature effects (local vs. global)
-%     \item Faithfulness (trade-off with sparsity)
-%     \item Surrogate model (hiding biases, robustness)
-%     \item Definition of superpixels in case of image data (sensitivity)
-% \end{itemize}
-%\item These are discussed in more detail in the following
 \end{framei}
 
 
 \begin{framei}[align=top]{Pitfall: Sampling}
 \item \textbf{Pitfall}: Common sampling strategies for $\zv \in \Zspace$ ignore feat dependencies
-% \item \textbf{Implication}:  Unlikely data points might be used to learn local explanation models
 \item \textbf{Implication:} Surrogate model may be trained on unrealistic points\\
 $\leadsto$ Undermines the fidelity and validity of the explanation
 \pause
@@ -81,20 +71,9 @@ $\leadsto$ Requires enough training data points near $\xv$
 \begin{framev}[align=top]{LIME Pitfall: Locality}
 \begin{itemizeM}
 \item \textbf{Pitfall}: Difficult to define locality (= how samples are weighted locally) %\\
-% \begin{itemize}
-%    \item[$\leadsto$]
-%$\leadsto$ Strongly affects local model, but there is no automatic procedure for choosing neighborhood
-% \end{itemize}
 \item \textbf{Implication:} Local model and explanation quality depend heavily on this weighting, but no principled way exists to choose it
 \item \textbf{Default:} Use exponential kernel as proximity measure between $\xv$ and $\zv$:\\
 $\neigh(\zv) = exp(-d(\xv, \zv)^2/\sigma^2)$ with distance measure $d$ and kernel width $\sigma$
-% \begin{center}
-%     \includegraphics[width=0.6\textwidth]{figure/lime_locality}
-%     \vspace{-0.5cm}
-%
-%     \scriptsize{Linear surrogate models for two observations based on the same model with one target and one feature. Each line displays one linear surrogate model with different kernel width. In the right figure, larger kernel sizes are more severe.}
-%
-% \end{center}
 \end{itemizeM}
 \pause
 \textbf{Example:} For 2 obs. (green points), fit local surr. models (lines) using only $x_1$
@@ -110,22 +89,6 @@ $\neigh(\zv) = exp(-d(\xv, \zv)^2/\sigma^2)$ with distance measure $d$ and kerne
 
 
 \begin{framei}[align=top]{LIME Pitfall: Locality \furtherreading{KOPPER2019}}
-%     \begin{itemize}
-%          \item \textbf{Solution I}: Kernel width strongly interacts with locality:
-%          \begin{itemize}
-%              \item Large kernel width leads to interaction with points further away (unwanted)
-%              \item Small kernel width leads to small neighborhood\\
-%              $\leadsto$ risk of few data points\\
-%              $\leadsto$ potentially fitting more noise
-%          \end{itemize}
-%          \pause
-%         \item \textbf{Solution II}: Use Gower distance where no kernel width needs to be specified
-%         \begin{itemize}
-%             \item \textbf{Problem}: data points far away receive weight $ > 0$\\
-%             $\leadsto$ resulting explanations are rather global than local surrogates
-%         \end{itemize}
-%     \end{itemize}
-% \vspace{0.3cm}
 \item \textbf{Pitfall:} Choice of kernel width ($\sigma$) critically influences locality
 \pause
 \item \textbf{Implication of edge cases:}
@@ -151,40 +114,24 @@ $\leadsto$ Used in practical LIME implementations \furtherreading{LIMEPAC}
 \item \emph{Local features} affect predictions only in small subregions of $\Xspace$
 \end{itemizeS}
 \item<2-> \textbf{Implication:} LIME’s surrogate may over-weight global features, producing explanations that miss critical local signals.
-% \item<2-> \textbf{Implication}:
-% \begin{itemize}
-%     \item \emph{Global features:} influence predictions broadly across $\Xspace$
-%     \item \emph{Local features:} affect predictions only in small subregions
-%     % \item Some features influence the \textbf{global} shape of the black-box model
-%     % \item Other \textbf{local} features impact predictions only in smaller regions of $\Xspace$ %for a small area of $\Xspace$
-% \end{itemize}
 \item<3-> \textbf{Example:} Decision trees
 \begin{itemizeS}
 \item Features near the root impact many instances $\rightarrow$ global
 \item Features in lower nodes act locally
-% \item Features used in early splits affect many predictions (global)
-% \item Features used in later splits have localized effects
 \end{itemizeS}
-%Split features close to root have a more global influence than the ones close to leaves
 \end{framei}
 
 
 \begin{framev}[align=top]{Pitfall: Local vs. Global Features \furtherreading{LAUGEL2018}}
-%\begin{columns}[T, totalwidth=\textwidth]
-%   \begin{column}{0.6\textwidth}
-%\vspace{-.5cm}
 \begin{itemizeM}
 \item \textbf{Problem:} Sampling around observation to be explained $\xv$ may miss decision boundary
 \item \textbf{Solution (LS: Local Surrogate Method):}
 \begin{enumerate}
-% \item Red point: Obs. $\xv$ to be explained
 \item Find closest point to $\xv$ (red dot) from opposite class (black cross)
 \item Sample around that point to better capture boundary
 \item Train local surrogate using those samples\\
 $\leadsto$ better approximates the local direction of the decision boundary
 \end{enumerate}
-%       \textbf{Solution}:
-% Find closest point to $\xv$ from other class and sample new points $\zv$ around it for higher local accuracy
 \image{figure/laugel_method}
 \begin{center}
 \begin{small}
@@ -192,38 +139,10 @@ $\leadsto$ better approximates the local direction of the decision boundary
 \end{small}
 \end{center}
 \end{itemizeM}
-%{Local surrogate (LS) method by \furtherreading{LAUGEL2018}}
-%Sample new instances $\zv$ around the decision boundary closest from point $\xv$ for higher local accuracy
-% \pause
-% \item Red dot (right figure): Closest point from other class
-
-% \item Red line: Local surrogate (LS) method \furtherreading{LAUGEL2018}\\
-% $\leadsto$ better approximates the local direction of the decision boundary
 \begin{itemizeM}
 \item LIME: What does the model do around this point?
 \item LS: How does the model change when crossing boundary near this point?
 \end{itemizeM}
-
-%   \begin{center}
-%       \includegraphics[width=1\textwidth]{figure/laugel_method}
-%       {Local surrogate (LS) method by \furtherreading{LAUGEL2018}}
-%       \vspace{-0.3cm}
-%       \end{center}
-% \end{column}
-% \begin{column}{0.39\textwidth}
-% %\vspace{0.3cm}
-
-%   \begin{center}
-%   \includegraphics[width=1\textwidth]{figure/lime-globallocal2}
-%
-%   {Half-moons dataset}
-%
-% \end{center}
-
-%   \end{column}
-
-% \end{columns}
-%\footnote[frame]{Laugel et al. (2018). Defining Locality for Surrogates in Post-hoc Interpretability. \url{https://arxiv.org/pdf/1806.07498.pdf}.}
 \end{framev}
 
 
@@ -248,9 +167,6 @@ class flips only near boundary when moving up/down\\
 \textbf{Observation:} LIME decision boundaries (blue/green) fail to match the steep local bound captured by LS (red)
 }
 
-% \begin{center}
-%LIME decision boundaries with different kernels (blue and green lines) do not match the direction of the local decision boundary (which appears steeper)
-%\footnote[frame]{Laugel et al. (2018). Defining Locality for Surrogates in Post-hoc Interpretability. \url{https://arxiv.org/pdf/1806.07498.pdf}.}
 \end{framev}
 
 
@@ -289,8 +205,6 @@ $$\gh_{gam}(\xv) = \thetah_0 + f_1(x_{age}) + f_2(x_{checking.account}) + f_3(x_
 
 \begin{framev}[align=top]{Pitfall: Hiding biases \furtherreading{SLACK2020}}
 \begin{itemizeM}
-% \item \textbf{Problem}: Developer could manipulate their model to hide biases
-% \item \textbf{Observation}: LIME can sample out-of-distribution points (extrapolation)
 \item \textbf{Problem:} LIME samples out-of-distribution (OOD) points, making it exploitable
 \item \textbf{Risk:} Developers can adversarially hide bias in the original model
 \pause
@@ -298,36 +212,12 @@ $$\gh_{gam}(\xv) = \thetah_0 + f_1(x_{age}) + f_2(x_{checking.account}) + f_3(x_
 \end{itemizeM}
 \begin{enumerate}
 \item Train a detector to distinguish in-distribution vs. OOD points
-%classifier to discriminate between in-distribution and out-of-distribution data points
-%\item for in-distribution points, use the original (biased) model
 \item Use \textbf{biased model} for in-distribution inputs (i.e., true predictions)
-%\item for out-of-distribution points produced for local explanation, use an unbiased model
 \item Use \textbf{unbiased model} for OOD samples to get LIME explanations
 \item[$\leadsto$] LIME explanations rely on unbiased model\\
 $\Rightarrow$ hides bias in original model
-% \item[$\leadsto$] LIME samples out-of-distribution points and uses the unbiased model for local explanation\\
-% \item[$\leadsto$] this hides the bias of the true model
 \end{enumerate}
-%   \begin{columns}[T, totalwidth=\textwidth]
-%       \begin{column}{0.5\textwidth}
 \imageC[0.8][SIKONJA2021]{figure/attack_biased_unbiased.jpg}
-%       \end{column}
-%\pause
-%     \begin{column}{0.5\textwidth}
-%     \textbf{Example}: Not using `gender` to approve a loan % Credit dataset %
-%     \begin{itemize}
-%         \item biased model trained on features correlated with `gender` (e.g. duration of parental leave)\\
-%         $\leadsto$ used
-%         %for in-distribution points (realistic values)
-%         to make biased / unfair predictions
-%         \item unbiased model trained on features uncorrelated with `gender`\\
-%         $\leadsto$ used to produce explanations based on unbiased predictions to hide bias
-%         %$\leadsto$ used for (extrapolated) LIME samples\\
-%         %$\Rightarrow$ produced local explanations seem fair as they are based on unbiased model
-%         %could be trained on features uncorrelated with `gender`
-%     \end{itemize}
-%     \end{column}
-% \end{columns}
 \end{framev}
 
 
@@ -352,7 +242,6 @@ $\Rightarrow$ explanation appears fair, but original predictions are biased
 \item \textbf{Observation}: Explanations of two very close points could vary greatly
 \begin{itemizeS}
 \item[$\leadsto$] Variability driven by the stochastic sampling of $\zv$ for each explanation
-%can happen because of other sampled data points $\zv$
 \end{itemizeS}
 \item \textbf{Example:}
 \end{itemizeM}
@@ -383,7 +272,6 @@ LIME returns different coefficients for similar points.
 \spacer[0.6]
 \begin{itemizeM}
 \item \textbf{Problem}: LIME relies on superpixels (but their definition differ) for image data
-%Instability because of specification of superpixels for image data
 \item \textbf{Observation}: Definition of superpixel differ, influencing their size, shape, and alignment
 \pause
 \item \textbf{Implication}: Specification of superpixel has a large influence on LIME explanations

--- a/slides/local-explanations-lime/slides06-le-lime-pitfalls.tex
+++ b/slides/local-explanations-lime/slides06-le-lime-pitfalls.tex
@@ -271,8 +271,8 @@ LIME returns different coefficients for similar points.
 \splitVTT[0.64]{
 \spacer[0.6]
 \begin{itemizeM}
-\item \textbf{Problem}: LIME relies on superpixels (but their definition differ) for image data
-\item \textbf{Observation}: Definition of superpixel differ, influencing their size, shape, and alignment
+\item \textbf{Problem}: LIME relies on superpixels, but their definition differ for image data
+\item \textbf{Observation}: Definition of superpixel influences their size, shape, and alignment
 \pause
 \item \textbf{Implication}: Specification of superpixel has a large influence on LIME explanations
 \item \textbf{Attack}: Change superpixels as part of an adversarial attack $\leadsto$ changed explanation


### PR DESCRIPTION
# Commented-Out Content Removal Report

Edited files:

- `slides/local-explanations-lime/slides01-le-intro.tex`
- `slides/local-explanations-lime/slides04-le-lime.tex`
- `slides/local-explanations-lime/slides05-le-lime-examples.tex`
- `slides/local-explanations-lime/slides06-le-lime-pitfalls.tex`

## Summary

- Removed commented-out units: **21**
- Kept candidate units: **9**
- Additional manual comment cleanups after review: **5**
- Kept comments relocated after review: **1**
- Restored or moved provenance/reference comment blocks: **0**
- Evidence scope: current file **yes**, sibling `.tex` files **yes**

## Manual follow-up adjustments

- `slides01-le-intro.tex`: removed the Marius flexibility note above `Methodological Motivation`.
- `slides01-le-intro.tex`: removed the inline alternative wording after `Model-specific variants`.
- `slides04-le-lime.tex`: removed three small residual inline/commented duplicates: the alternate local-fidelity wording, the approximate-learning note, and the explainer-return wording.
- `slides04-le-lime.tex`: moved the local/global-fidelity caveat into the `Local Fidelity of Surrogate Models` itemize block as a commented optional bullet.

## Provenance / attribution audit

- No deleted provenance required relocation; active `\furtherreading{...}` or image-source arguments already preserve the relevant attribution near the corresponding slides.
- Laugel URL footnotes removed from old duplicate layout comments were already represented by active `\furtherreading{LAUGEL2018}` anchors in the same local/global-feature slides.
- The LIME image API URL in `slides05-le-lime-examples.tex` was kept because it is a source/reference note, not redundant slide content.
- The local/global-fidelity caveat in `slides04-le-lime.tex` was kept as a commented optional bullet inside the active local-fidelity slide because active content does not cover that distinction.

<details>
<summary><strong>slides/local-explanations-lime/slides01-le-intro.tex</strong>: 5 removed, 5 kept</summary>

Evidence scope: current file **yes**, sibling files **no**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | `slides01-le-intro.tex:40` | Old global-to-local motivation sentence. | `slides01-le-intro.tex:40-52`; active bullets define prediction-specific and neighborhood-local purposes. | Same motivation is now expressed as active local-explanation goals and questions. | No separate provenance issue. |
| 2 | `slides01-le-intro.tex:59` | Old layperson-audience motivation. | `slides01-le-intro.tex:57-67`; active social-motivation bullets cover explainees, laypersons, trust, bias, and rights. | Same social motivation is active with more concrete framing. | No separate provenance issue. |
| 3 | `slides01-le-intro.tex:76,78,83,85,90` | Commented legal quote fragments omitted from GDPR/AI Act excerpts. | `slides01-le-intro.tex:72-85`; active quote uses ellipses and preserves the right-to-explanation excerpts. | The omitted fragments are not needed for the active teaching point. | Citations remain active at `slides01-le-intro.tex:81,85`. |
| 4 | `slides01-le-intro.tex:134` | Alternative loan-application phrasing. | `slides01-le-intro.tex:119-131`; active example uses the same rejection-without-reasons scenario and recourse point. | Pure wording duplicate. | No separate provenance issue. |
| 5 | `slides01-le-intro.tex:175,184` | Alternative data-type and method-family wording. | `slides01-le-intro.tex:156-174`; active characteristics list covers modalities and method families. | Same taxonomy appears in active bullets. | Reference footnote at original line 185 was kept. |

### Manual Follow-Up

| # | Location | Adjustment | Rationale |
|---|---|---|---|
| 1 | `slides01-le-intro.tex:39` | Removed Marius flexibility note. | Source/process comment no longer needed near cleaned slide content. |
| 2 | `slides01-le-intro.tex:161` | Removed inline alternative wording for model-specific variants. | Active wording already states the same efficiency/structure point. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `slides01-le-intro.tex:163-164` | Deep-learning popularity note. | Active content does not explicitly state popularity for deep learning models. |
| 2 | `slides01-le-intro.tex:175` | Footnote pointing to other Shapley/ICE lectures. | Reference/navigation note, not redundant slide content. |
| 3 | `slides01-le-intro.tex:176` | Social-science, cognitive-science, and neuroscience connection. | Distinct teaching point not covered by active bullets. |
| 4 | `slides01-le-intro.tex:179-193` | Recap frame for ICE curves. | Contains ICE-specific definition and warning not actively repeated in this directory. |
| 5 | `slides01-le-intro.tex:195-204` | Recap frame for Shapley values. | Contains Shapley-specific origin and contribution explanation not actively repeated here. |

</details>

<details>
<summary><strong>slides/local-explanations-lime/slides04-le-lime.tex</strong>: 3 removed, 2 kept</summary>

Evidence scope: current file **yes**, sibling files **yes**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | `slides04-le-lime.tex:42-67` | Old LIME introduction frame plus inline key-idea, algorithm, and use-case alternatives. | `slides04-le-lime.tex:42-51`; use cases also appear in `slides01-le-intro.tex:47-52,110-131`. | Active LIME slide covers locality, surrogate interpretation, model-agnostic applicability, and practical sampling/fitting. | No separate provenance issue. |
| 2 | `slides04-le-lime.tex:74-82` | Second alternative LIME overview frame. | `slides04-le-lime.tex:42-51,55-65`; active slides cover the same core idea, surrogates, goal, and properties. | Fully superseded by active LIME and characteristics slides. | No separate provenance issue. |
| 3 | `slides04-le-lime.tex:119-139` | Old local-fidelity frame, except the unique local/global-fidelity caveat. | `slides04-le-lime.tex:90-119`; active local-fidelity slide defines faithfulness, proximity, loss, and weighted objective. | Same math and optimization principle are active. | No separate provenance issue; unique caveat kept at `slides04-le-lime.tex:89`. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `slides04-le-lime.tex:119` | Caveat that global fidelity implies local fidelity but not vice versa. | Distinction is not actively covered; kept as a commented optional bullet inside the active local-fidelity slide. |
| 2 | `slides04-le-lime.tex:207-214` | Gower-proximity alternative with MARIUS note. | Maintainer note says it does not belong in the example, and the exact derivation is not active here. |

### Manual Follow-Up

| # | Location | Adjustment | Rationale |
|---|---|---|---|
| 1 | `slides04-le-lime.tex:63` | Removed alternate wording for local fidelity. | Active item already states the same vicinity/fidelity point. |
| 2 | `slides04-le-lime.tex:139` | Removed `learn \gh only approximately`. | Active bullet already says the surrogate approximates through sampling and fitting. |
| 3 | `slides04-le-lime.tex:160` | Removed `the interpretable model \gh as the explainer`. | Active algorithm step already says to return `\gh` as the local explanation. |
| 4 | `slides04-le-lime.tex:119` | Relocated local/global-fidelity caveat into the active frame. | Keeps the distinct caveat attached to the relevant objective slide. |

</details>

<details>
<summary><strong>slides/local-explanations-lime/slides05-le-lime-examples.tex</strong>: 1 removed, 2 kept</summary>

Evidence scope: current file **yes**, sibling files **no**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | `slides05-le-lime-examples.tex:70` | Commented caption formula for the local surrogate. | `slides05-le-lime-examples.tex:54,61-65,91-94`; active bullets already identify the surrogate and its prediction/approximation role. | Caption repeats the active credit-example explanation. | No separate provenance issue. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `slides05-le-lime-examples.tex:98-112` | Bike-sharing example frame. | Specific bike example and effects are not active elsewhere in this directory. |
| 2 | `slides05-le-lime-examples.tex:182` | LIME image API URL. | Source/reference note, not redundant slide content. |

</details>

<details>
<summary><strong>slides/local-explanations-lime/slides06-le-lime-pitfalls.tex</strong>: 12 removed, 1 kept</summary>

Evidence scope: current file **yes**, sibling files **no**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | `slides06-le-lime-pitfalls.tex:56-64` | Old pitfall overview list. | `slides06-le-lime-pitfalls.tex:42-55`; active list covers the same pitfall categories. | Same taxonomy is active. | No separate provenance issue. |
| 2 | `slides06-le-lime-pitfalls.tex:70` | Old sampling implication wording. | `slides06-le-lime-pitfalls.tex:59-67`; active slide states unrealistic samples and fidelity/validity risk. | Same implication with clearer wording. | No separate provenance issue. |
| 3 | `slides06-le-lime-pitfalls.tex:84-87` | Old locality implication wording. | `slides06-le-lime-pitfalls.tex:71-76`; active slide states weighting affects explanation quality and lacks a principled choice. | Same locality-warning point. | No separate provenance issue. |
| 4 | `slides06-le-lime-pitfalls.tex:91-97` | Old locality figure and caption block. | `slides06-le-lime-pitfalls.tex:79-87`; active example, figure, and line-color explanation cover the same visual. | Same figure role and kernel-width explanation. | No separate provenance issue. |
| 5 | `slides06-le-lime-pitfalls.tex:113-128` | Old kernel-width and Gower-similarity solution block. | `slides06-le-lime-pitfalls.tex:91-105`; active slide covers large/small sigma, Gower weights, globalizing far points, and s-LIME. | Same solution and edge-case structure is active. | `\furtherreading{KOPPER2019}`, `\furtherreading{LIMEPAC}`, and `\furtherreading{GAUDEL2022}` remain active nearby. |
| 6 | `slides06-le-lime-pitfalls.tex:154-168` | Old global/local feature definitions and decision-tree examples. | `slides06-le-lime-pitfalls.tex:109-121`; active slide defines global/local features and root/lower-node tree behavior. | Same conceptual distinction and example. | `\furtherreading{LAUGEL2018}` remains active in frame title. |
| 7 | `slides06-le-lime-pitfalls.tex:173-226` | Old LS layout, solution wording, figures, and Laugel footnote. | `slides06-le-lime-pitfalls.tex:125-156`; active slides cover nearest opposite-class point, boundary sampling, LS contrast, and figure labels. | Same LS method explanation and visual material are active. | Laugel attribution remains active at `slides06-le-lime-pitfalls.tex:125,156`. |
| 8 | `slides06-le-lime-pitfalls.tex:251-253` | Old local/global example observation and Laugel footnote. | `slides06-le-lime-pitfalls.tex:149-167`; active example states the LIME boundaries fail to match the local boundary. | Same example takeaway is active. | Laugel attribution remains active at `slides06-le-lime-pitfalls.tex:156`. |
| 9 | `slides06-le-lime-pitfalls.tex:292-293` | Old hiding-bias problem and OOD observation. | `slides06-le-lime-pitfalls.tex:206-209`; active slide states OOD exploitability and hidden bias risk. | Same threat model is active. | `\furtherreading{SLACK2020}` remains active in frame title. |
| 10 | `slides06-le-lime-pitfalls.tex:301-330` | Old adversarial-model steps, image layout, and credit example. | `slides06-le-lime-pitfalls.tex:213-234`; active slides cover detector, biased/unbiased models, OOD triggering, and credit example. | Same attack mechanics and example are active. | Image attribution `SIKONJA2021` remains active at `slides06-le-lime-pitfalls.tex:220`. |
| 11 | `slides06-le-lime-pitfalls.tex:355` | Old robustness sampling explanation. | `slides06-le-lime-pitfalls.tex:239-245`; active slide states variability is driven by stochastic sampling. | Same robustness cause is active. | `\furtherreading{JAAKKOLA2018}` remains active in frame title. |
| 12 | `slides06-le-lime-pitfalls.tex:386` | Old superpixel-instability wording. | `slides06-le-lime-pitfalls.tex:270-278`; active slide covers differing superpixel definitions and adversarial changes. | Same instability point is active. | `\furtherreading{ACHANTA2012}` remains active in frame title. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `slides06-le-lime-pitfalls.tex:192-200` | Detailed expanded GAM equation. | More detailed than the active shortened equation, so it may still be pedagogically useful. |

</details>
