### PR TITLE
refactor(slides): remove redundant comments on feature importance slides

### DIFF
--- a/slides/feature-importance/slides01-fi-intro.tex
+++ b/slides/feature-importance/slides01-fi-intro.tex
@@ -49,14 +49,10 @@ figure_man/feature-importance.png
 \begin{itemizeS}
 \item condenses information into one number per feature
 \item typically compares prediction errors (involves $y$) with/without feature
-    % \item condensed to one number per feature
-    % \item provides insight into the relationship with $y$
 \end{itemizeS}
 \item<3> \textbf{Clarification:} By \emph{feature importance}, we mean \emph{loss-based} methods that assess a feature's impact via changes in \emph{prediction error}. \\
 $\leadsto$
 Other notions exist (e.g., variance-based methods; see \furtherreading{GREENWELL2020}).
-  %\textbf{N.B.}: 
-  %Here, we use the term feature importance to describe loss-based feature importance methods. In the literature, you may find other notions of ``feature importance'' (e.g., variance-based methods derived from feature effect methods, see also \furtherreading{GREENWELL2020})
 \end{framei}
 
 
@@ -77,25 +73,7 @@ w.r.t. performance \\
 \spacer[0]
 \imageC{figure_man/bike_pdp+ice}
 }
-% \begin{center}
-%   \begin{figure}
-%   \includegraphics[width=0.55\linewidth]{figure_man/bike_pdp+ice} \hfill \includegraphics[width=0.35\linewidth]{figure_man/bike_pfi}
-% \end{figure}
-% \end{center}
 \end{framev}
-
-% \begin{frame}{Feature Importance Scheme}
-% Loss-based feature importance methods are often based on two concepts
-% \lz
-% \begin{enumerate}
-%   \item \textbf{Perturbation/Removal:}\\
-%   Generate predictions for which the feature of interest has been perturbed or removed
-%   \item \textbf{Performance Comparison:} \\
-%   Compare performance under perturbation/removal with the original model performance
-% \end{enumerate}
-% \lz
-% Depending on the type of perturbation/removal, feature importance methods provide insight into different aspects of model and data.
-% \end{frame}
 
 
 \begin{framev}[align=top]{Feature Importance - Differences \furtherreading{EWALD2024}}
@@ -114,19 +92,11 @@ Many loss-based feature importance methods exist, which mainly differ in \\
 \item \textbf{Compare ``reduced model'' without FOI vs. full model}: \\
 Measure drop in performance when FOI is ``removed'' \\
 $\leadsto$ Similar idea as backward feature elimination  % (LOCO, PFI, CFI)
-     %(backward feature elimination)%\\
-     %$\leadsto$ Leave-one-covariate out (LOCO)
 \item \textbf{Compare ``empty model'' (no features) vs. model with only FOI}: \\
 Measure gain in performance when only FOI is used \\
 $\leadsto$ Similar idea as forward feature selection %(LOCI)%\\
-     %$\leadsto$ Leave-one-covariate in (LOCI)
 \item \textbf{Compare models with/without FOI across different feature sets}: \\
 Measure average contrib. when FOI joins any feat. set (Shapley-based) %(cSAGE, mSAGE)%\\
-     %$\leadsto$ Shapley Additive Global Importance (SAGE)
-  % \item \emph{Reduced vs. full model:} performance drop when $X_j$ is removed %(LOCO, PFI, CFI)
-  % \item \emph{FOI only vs. empty model:} performance gain when only the feature is used %(LOCI)
-  % \item \emph{Across all coalitions:} average contribution over every subset 
-  % %(mSAGE, cSAGE)
 \end{itemizeM}
 \pause
 \spacer[0.25]
@@ -141,19 +111,6 @@ Interpretation goals often differ and typically address non-overlapping question
 For example, one may be interested in getting insight into whether the ...
 \begin{enumerate}
 \item[(1)] feature $x_j$ is causal for the prediction?
-    % \only<2>{\begin{itemize}
-    %   \item Changing feature value $x_j$ has an effect on prediction $\yh = \fh(x)$
-    %   \item In LM: non-zero coefficient, in ML: present feature effect
-    %   \item \textbf{Note:} If $x_j$ is causal for prediction $\yh$ $\nRightarrow$ causal for the ground truth $y$, e.g.:
-    %   %A feature being causal for prediction $\yh$ does not imply that the underlying variable is causal for the ground truth $y$, e.g.:
-    %   \begin{itemize}
-    %       \item A symptom may help predict a disease ($\leadsto$ causal for $\hat{y}$) %A disease symptom may be used in a model to predict disease status \\
-    %       %$\leadsto$ causal for prediction $\yh$
-    %       \item Intervening on symptom may not affect disease ($\leadsto$ not causal for $y$)
-    %       %But intervening on disease symptom does not have an effect on the disease \\
-    %       %$\leadsto$ not causal for the ground truth $y$
-    %   \end{itemize}
-    % \end{itemize}}
 \item[(2)] feature $x_j$ contains prediction-relevant information about $y$?
 \item[(3)] model requires access to $x_j$ to achieve its prediction performance?
 \end{enumerate}
@@ -220,33 +177,6 @@ A feature may be causal for $\yh$ (1) without containing prediction-relevant inf
 \end{framev}
 
 
-% \begin{frame}{Potential Interpretation Goals}
-
-% For example, one may be interested in getting insight into whether the ...
-
-% \begin{enumerate}
-%     \item[(1)] feature $x_j$ is causal for the prediction?
-%           \begin{itemize}
-%           \item A symptom may help predict a disease ($\leadsto$ causal for $\hat{y}$) %A disease symptom may be used in a model to predict disease status \\
-%           %$\leadsto$ causal for prediction $\yh$
-%           \item Intervening on symptom may not affect disease ($\leadsto$ not causal for $y$)
-%           %But intervening on disease symptom does not have an effect on the disease \\
-%           %$\leadsto$ not causal for the ground truth $y$
-%       \end{itemize}
-%     \item[(2)] feature $x_j$ contains prediction-relevant information about $y$?
-%     \begin{itemize}
-%       \item $x_j$ helps predict $y$ (e.g., conditional expectation) w.r.t. performance 
-%       %, as measured by the difference in expected loss
-%       %%\item e.g. when $\E[y|x_j] \neq \E[y]$ for models that minimize MSE
-%       %\item feature selection terminology: \textit{weak relevance} \furtherreading{PELLET2008}
-%       \item If $x_j \indep y$, then $\E[y|x_j] = \E[y]$ and $x_j$ and $y$ have zero mutual information\\ %and therefore cannot contain 
-%       $\leadsto$ $x_j$ carries no prediction-relevant information
-%     \end{itemize}
-%     \item[(3)] model requires access to $x_j$ to achieve it's prediction performance?
-% \end{enumerate}
-% \end{frame}
-
-
 
 
 \begin{framev}[align=top]{Example: Prediction-relevant information (2)}
@@ -254,47 +184,6 @@ A feature may contain prediction-relevant information (2) without causing the pr
 \spacer[0.5]
 \splitVTT[0.49]{
 \spacer[0]
-%   \begin{figure}
-%   \begin{tikzpicture}[thick, scale=1.1, every node/.style={scale=1, line width=0.25mm, black, fill=white}]
-% 		%
-% 		\node[draw, ellipse, scale=0.7, fill=orange] (x7) at (0, 2) {contacts};
-% 		\node[draw, ellipse, scale=0.7, fill=orange] (x0) at (0, 1) {trust};
-% 		\node[draw, ellipse, scale=0.7, fill=orange] (x1) at (0, 0) {vaccinated};
-% 		\node[draw, ellipse, scale=0.7, fill=orange] (x4) at (0, -1) {test};
-% 		%\node[draw, ellipse, scale=0.7] (x5) at (0, -2) {compliance};
-% 		\node[draw, ellipse, scale=0.7] (y) at (-2,-.5) {$Y$: COVID risk};
-% 		\node[draw, ellipse, scale=0.7] (x6) at (0, -2) {noise};
-% 		\draw[dashed,gray] (-3.25,-2.5) -- (1,-2.5) -- (1,2.5) -- (-3.25,2.5) -- cycle;
-% 		\node[scale=0.7] (dots) at (-1,-2.75) {data level};
-% 		\draw[->] (x0) -- (x1);
-% 		\draw[->] (x1) -- (y);
-% 		\draw[->] (y) -- (x4);
-% 		%\draw[->] (x5) -- (x4);
-% 		\draw[->] (x7) -- (y);
-% 		%\draw[-] (xd) -- (y);
-		
-% 		\node[draw, ellipse, scale=0.7] (ux7) at (2, 2) {\texttt{cnt}};
-% 		\node[draw, ellipse, scale=0.7] (ux0) at (2, 1) {\texttt{trust}};
-% 		\node[draw, ellipse, scale=0.7] (ux1) at (2, 0) {\texttt{vac}};
-% 		\node[draw, ellipse, scale=0.7] (ux4) at (2, -1) {\texttt{test}};
-% 		%\node[draw, ellipse, scale=0.7] (ux5) at (2,-2) {\texttt{cmpl}};
-%         \node[draw, ellipse, scale=0.7] (ux6) at (2,-2) {\texttt{noise}};
-% 		\draw[dashed,gray] (1.25,-2.5) -- (3.5,-2.5) -- (3.5,2.5) -- (1.25,2.5) -- cycle;
-% 		\node[scale=0.7] (dots) at (2.5,-2.75) {model level};
-% 		\draw[->, dotted] (x1) -- (ux1);
-% 		\draw[->, dotted] (x4) -- (ux4);
-% 		\draw[->, dotted] (x0) -- (ux0);
-% 		%\draw[->, dotted] (x5) -- (ux5);
-% 		\draw[->, dotted] (x6) -- (ux6);
-% 		\draw[->, dotted] (x7) -- (ux7);
-		
-% 		\node[draw, circle, scale=0.7] (yhat) at (3.2, -.5) {$\hat{Y}$};
-% 		\draw[->] (ux1) -- (yhat);
-% 		\draw[->] (ux4) -- (yhat);
-% 		%\draw[->] (ux5) -- (yhat);
-% 		\draw[->] (ux6) -- (yhat);
-% \end{tikzpicture}
-% \end{figure} 
 \resizebox{\linewidth}{!}{%
 \begin{tikzpicture}[thick, scale=1.1, every node/.style={scale=1, line width=0.25mm, black, fill=white}]
 			%
@@ -393,47 +282,6 @@ A feature may contain prediction-relevant information (2), without the model req
 \draw[->] (ux6) -- (yhat);
 \end{tikzpicture}
 }
-%   \begin{figure}
-%   \begin{tikzpicture}[thick, scale=1.1, every node/.style={scale=1, line width=0.25mm, black, fill=white}]
-% 		%
-% 		\node[draw, ellipse, scale=0.7, fill=orange] (x7) at (0, 2) {contacts};
-% 		\node[draw, ellipse, scale=0.7] (x0) at (0, 1) {trust};
-% 		\node[draw, ellipse, scale=0.7, fill=orange] (x1) at (0, 0) {vaccinated};
-% 		\node[draw, ellipse, scale=0.7, fill=orange] (x4) at (0, -1) {test};
-% 		%\node[draw, ellipse, scale=0.7, fill=orange] (x5) at (0, -2) {compliance};
-% 		\node[draw, ellipse, scale=0.7] (y) at (-2,-.5) {$Y$: COVID risk};
-% 		\node[draw, ellipse, scale=0.7] (x6) at (0, -2) {noise};
-% 		\draw[dashed,gray] (-3.25,-2.5) -- (1,-2.5) -- (1,2.5) -- (-3.25,2.5) -- cycle;
-% 		\node[scale=0.7] (dots) at (-1,-2.75) {data level};
-% 		\draw[->] (x0) -- (x1);
-% 		\draw[->] (x1) -- (y);
-% 		\draw[->] (y) -- (x4);
-% 		%\draw[->] (x5) -- (x4);
-% 		\draw[->] (x7) -- (y);
-% 		%\draw[-] (xd) -- (y);
-		
-% 		\node[draw, ellipse, scale=0.7] (ux7) at (2, 2) {\texttt{cnt}};
-% 		\node[draw, ellipse, scale=0.7] (ux0) at (2, 1) {\texttt{trust}};
-% 		\node[draw, ellipse, scale=0.7] (ux1) at (2, 0) {\texttt{vac}};
-% 		\node[draw, ellipse, scale=0.7] (ux4) at (2, -1) {\texttt{test}};
-% 		%\node[draw, ellipse, scale=0.7] (ux5) at (2,-2) {\texttt{cmpl}};
-%         \node[draw, ellipse, scale=0.7] (ux6) at (2,-2) {\texttt{noise}};
-% 		\draw[dashed,gray] (1.25,-2.5) -- (3.5,-2.5) -- (3.5,2.5) -- (1.25,2.5) -- cycle;
-% 		\node[scale=0.7] (dots) at (2.5,-2.75) {model level};
-% 		\draw[->, dotted] (x1) -- (ux1);
-% 		\draw[->, dotted] (x4) -- (ux4);
-% 		\draw[->, dotted] (x0) -- (ux0);
-% 		%\draw[->, dotted] (x5) -- (ux5);
-% 		\draw[->, dotted] (x6) -- (ux6);
-% 		\draw[->, dotted] (x7) -- (ux7);
-		
-% 		\node[draw, circle, scale=0.7] (yhat) at (3.2, -.5) {$\hat{Y}$};
-% 		\draw[->] (ux1) -- (yhat);
-% 		\draw[->] (ux4) -- (yhat);
-% 		%\draw[->] (ux5) -- (yhat);
-% 		\draw[->] (ux6) -- (yhat);
-% \end{tikzpicture}
-% \end{figure} 
 }{
 \spacer[0.25]
   %\hspace{0.2cm}
@@ -481,116 +329,6 @@ $\leadsto$ $x_j$ does not contribute unique prediction-relevant information abou
 \end{itemizeS}
 \end{enumerate}
 \end{framev}
-
-
-% \begin{frame}{Potential Interpretation Goals}
-
-% Feature importance methods provide condensed insights, but can only highlight certain aspects of model and data. There are different interpretation goals one might be interested in whose question of interest do not necessarily coincide (except for special cases).
-% %Except for special cases, several questions of interest do not coincide.
-
-% \lz
-
-% For example, one may be interested in getting insight into whether the ...
-
-% \begin{enumerate}
-% %<1|only@1>
-%     \item[(1)]<1|only@1> feature $x_j$ is causal for the prediction?
-%     \begin{itemize}
-%       \item Changing feature value $x_j$ has an effect on prediction $\yh = \fh(x)$
-%       \item In LM: non-zero coefficient, in ML: present feature effect
-%       \item \textbf{Note:} 
-%       A feature being causal for prediction $\yh$ does not imply that the underlying variable is causal for the ground truth $y$, e.g.:
-%       \begin{itemize}
-%           \item A disease symptom may be used in a model to predict disease status \\
-%           $\leadsto$ causal for prediction $\yh$
-%           \item But intervening on disease symptom does not have an effect on the disease \\
-%           $\leadsto$ not causal for the ground truth $y$
-%       \end{itemize}
-%     \end{itemize}
-%     \item[(2)]<2|only@2> feature $x_j$ contains prediction-relevant information about $y$?
-%     \begin{itemize}
-%       \item Feature $x_j$ helps to predict the target $y$ (e.g., conditional expectation) w.r.t. performance 
-%       %, as measured by the difference in expected loss
-%       \item e.g. when $\E[y|x_j] \neq \E[y]$ for models that minimize MSE
-%       %\item feature selection terminology: \textit{weak relevance} \furtherreading{PELLET2008}
-%       \item If $x_j \indep y$ (independent) then $x_j$ and $y$ have zero mutual information (since $\E[y|x_j] = \E[y]$)\\ %and therefore cannot contain 
-%       $\leadsto$ $x_j$ has no prediction-relevant information
-%     \end{itemize}
-%     \item[(3)]<3-4|only@3-4> model requires access to $x_j$ to achieve it's prediction performance?
-%     \begin{itemize}
-%       \item Feature $x_{j}$ helps to predict the target $y$, compared to using only $x_{-j}$ w.r.t. performance %, as measured by the difference in expected loss
-%       \item e.g. when $\E[y|x_{-j}] \neq \E[y|x_j, x_{-j}]$ for models that minimize MSE
-%       %\item feature selection terminology: \textit{strong relevance} \furtherreading{PELLET2008}
-%       \item If $x_j \indep y | x_{-j}$ (independent) then $\E[y|x_{-j}] = \E[y|x_j, x_{-j}]$ \\
-%       $\leadsto$ $x_j$ does not contribute unique prediction-relevant information about $y$
-%       \item \textbf{Note:} A model may rely on features that can be replaced with others, e.g., a random forest fitted on data with $\E[y|x_1] \neq \E[y]$ and $\E[y|x_1] = \E[y|x_1, x_2]$ where $x_1$ was not used as split variable may rely on $x_2$ %was not sampled as potential split variable may rely on $x_2$.
-%     \end{itemize}
-% \end{enumerate}
-% \lz
-% \only<4>{The distinctness of the aforementioned aspects can be proven by example (sketch).}
-% \end{frame}
-
-% \begin{frame}{Potential Interpretation Goals}
-
-% The distinctness of the aforementioned aspects can be proven by example (sketch):
-
-% \begin{itemize}
-%   \item A feature may be causal for the prediction $\yh$ (1) without containing prediction-relevant information about $y$ (2)\\
-%   \textit{Example:} overfitting
-%   \item A feature may contain prediction-relevant information (2) without causing the prediction (1)\\ \textit{Examples:} underfitting, model multiplicity
-%   \item A feature may contain prediction-relevant information (2), without the model requiring access to the feature for (optimal) prediction performance (3)\\
-%   \textit{Note:} A model may rely on features that can be replaced with others, e.g., a random forest fitted on data with $\E[y|x_1] \neq \E[y]$ and $\E[y|x_1] = \E[y|x_1, x_2]$ where $x_1$ was not used as split variable may rely on $x_2$ %was not sampled as potential split variable may rely on $x_2$.
-%   \\
-%   \textit{Examples:} correlated features, confounding
-%   \end{itemize}
-% $\Rightarrow$ In general, an importance score cannot provide insight into all aspects at once.
-% \end{frame}
-
-
-
-% \begin{frame} {Causal for the prediction (1)}
-%   \begin{figure}
-%   \begin{tikzpicture}[thick, scale=1.1, every node/.style={scale=1, line width=0.25mm, black, fill=white}]
-% 		%
-% 		\node[draw, ellipse, scale=0.7] (x7) at (0, 2) {contacts};
-% 		\node[draw, ellipse, scale=0.7] (x0) at (0, 1) {trust};
-% 		\node[draw, ellipse, scale=0.7] (x1) at (0, 0) {vaccinated};
-% 		%\node[draw, ellipse, scale=0.7] (x4) at (0, -1) {test};
-% 		%\node[draw, ellipse, scale=0.7] (x5) at (0, -2) {compliance};
-% 		\node[draw, ellipse, scale=0.7] (y) at (-2,-.5) {$Y$: COVID risk};
-% 		\node[draw, ellipse, scale=0.7] (x6) at (0, -3) {noise};
-% 		\draw[dashed,gray] (-3.25,-3.5) -- (1,-3.5) -- (1,2.5) -- (-3.25,2.5) -- cycle;
-% 		\node[scale=0.7] (dots) at (-1,-3.75) {data level};
-% 		\draw[->] (x0) -- (x1);
-% 		\draw[->] (x1) -- (y);
-% 		%\draw[->] (y) -- (x4);
-% 		%\draw[->] (x5) -- (x4);
-% 		\draw[->] (x7) -- (y);
-% 		%\draw[-] (xd) -- (y);
-		
-% 		\node[draw, ellipse, scale=0.7] (ux7) at (2, 2) {\texttt{cnt}};
-% 		\node[draw, ellipse, scale=0.7] (ux0) at (2, 1) {\texttt{trust}};
-% 		\node[draw, ellipse, scale=0.7, fill=orange] (ux1) at (2, 0) {\texttt{vac}};
-% 		%\node[draw, ellipse, scale=0.7, fill=orange] (ux4) at (2, -1) {\texttt{test}};
-% 		%\node[draw, ellipse, scale=0.7, fill=orange] (ux5) at (2,-2) {\texttt{cmpl}};
-%         \node[draw, ellipse, scale=0.7, fill=orange] (ux6) at (2,-3) {\texttt{noise}};
-% 		\draw[dashed,gray] (1.25,-3.5) -- (3.5,-3.5) -- (3.5,2.5) -- (1.25,2.5) -- cycle;
-% 		\node[scale=0.7] (dots) at (2.5,-3.75) {model level};
-% 		\draw[->, dotted] (x1) -- (ux1);
-% 		%\draw[->, dotted] (x4) -- (ux4);
-% 		\draw[->, dotted] (x0) -- (ux0);
-% 		%\draw[->, dotted] (x5) -- (ux5);
-% 		\draw[->, dotted] (x6) -- (ux6);
-% 		\draw[->, dotted] (x7) -- (ux7);
-		
-% 		\node[draw, circle, scale=0.7] (yhat) at (3.2, -.5) {$\hat{Y}$};
-% 		\draw[->] (ux1) -- (yhat);
-% 		%\draw[->] (ux4) -- (yhat);
-% 		%\draw[->] (ux5) -- (yhat);
-% 		\draw[->] (ux6) -- (yhat);
-% \end{tikzpicture}
-% \end{figure} 
-% \end{frame}
 
 \endlecture
 \end{document}

--- a/slides/feature-importance/slides02-fi-pfi.tex
+++ b/slides/feature-importance/slides02-fi-pfi.tex
@@ -40,80 +40,29 @@ figure_man/feature-importance.png
 
 	% ------------------------------------------------------------------------------
 
-% \begin{frame}{Permutation Feature Importance Idea \furtherreading{BREIMAN2001}}
-
-% In general, feature importance methods share two components
-% \lz
-% \begin{enumerate}
-%   \item \textbf{Perturbation/Removal:} Generate predictions for which the feature of interest has been perturbed or removed.
-%   \item \textbf{Performance Comparison:} Compare performance under perturbation/removal with the original model performance.
-% \end{enumerate}
-% \lz
-% \textbf{Permutation Feature Importance Idea:} "Remove" the feature of interest $x_j$ by perturbing it such that it is uninformative. Therefore, resample the variable from its marginal distribution $\P(x_j)$, e.g. by randomly permuting observations in $x_j$.
-
-% %\footnote[frame]{\fullcite{Breiman2001rf}}
-
-% %\framebreak
-
-% %\begin{figure}
-% %  \includegraphics[width=0.75\textwidth]{figure_man/feature-importance.png}
-% %\end{figure}
-
-% %\vspace{-0.2cm}
-% %\tiny{Fisher et al. (2018). All models are wrong but many are useful: Variable importance for black-box, proprietary, or misspecified prediction models, using model class reliance. arXiv preprint arXiv:1801.01489 (2018).}
-
-% \end{frame}
-
-
+% Source note from removed legacy frame motivativing PFI idea:
+% Fisher et al. (2018). All models are wrong but many are useful: Variable importance for black-box, proprietary, or misspecified prediction models, using model class reliance. arXiv preprint arXiv:1801.01489.
 
 \begin{framei}[align=top]{Motivation for PFI}
 \item<1-> \textbf{Goal:} Assess how important feature(s) $X_S$ are for predictive performance of a \textbf{fixed trained model} $\fh$ on a given dataset $\D$
 \item<1-> \textbf{Idea:} Estimate performance change when $X_S$ is "made uninformative"
 \item<2-> \textbf{Question:} Can we make $X_S$ uninformative by removing it from model?\\
 $\leadsto$ No, $\fh$ was trained with $X_S$; retraining without $X_S$ gives a different model
-%$\fh$ is already trained using $X_S$, i.e., we cannot remove $X_S$ without retraining
-%\item \textbf{Solution:} \textbf{Perturb $X_S$} by replacing $x_S$ with a \textbf{random permutation} $\tilde{x}_S$\\
-%$\leadsto$ Breaks dependence with $y$, preserves marginal $\mathbb{P}(X_S)$
 \item<3->
 \textbf{Solution:} Simulate feature removal by replacing $X_S$ with a perturbed version $\tilde{X}_S$ that is independent of $(X_{-S}, Y)$ but preserves distrib. $\mathbb{P}(X_S)$\\
 $\leadsto$ Compare {\color{blue}baseline predictions $\fh(X)$} with {\color{red}perturbed predictions $\fh(\tilde{X}_S, X_{-S})$}
-%\textbf{Solution:} "Destroy" information of $X_S$ by replacing it with a perturbed $\Tilde{X}_{S}$ (i.i.d. copy of $X_S$ independent of $(X_{-S},Y)$)
-%Estimate the added predictive value of feature(s) $X_S$ for a given trained model $\fh$, test data $\D$, test data $\D$ where $X_S$ was replaced by $\Tilde{X}_{S}$ by:
-%and compare {\color{red}reduced model where $X_S$ is made uninformative $\fh(\Tilde{X}_{S}, X_{-S})$} vs. {\color{blue}full model $\fh(X)$}:
 $$
 \text{PFI}_S :=
 {\color{red}\underbrace{\mathbb{E}\Big[L\big(\fh(\tilde{X}_S, X_{-S}), Y\big)\Big]}_{\text{risk after "destroying" }X_S}}
 -
 {\color{blue}\underbrace{\mathbb{E}\Big[L\big(\fh(X), Y\big)\Big]}_{\text{baseline risk}}},
 $$
-%where $(X,Y)\sim\mathcal{P}$ and
-%$\tilde{X}_S$ is an i.i.d. copy of $X_S$ independent of $(X_{-S},Y)$\\
-%$\rightarrow$ breaks associations between $X_S$ and $Y$ while preserving the marginal $\mathbb{P}(X_S)$
 \item<3-> \textbf{How to perturb $X_S$?}
 \begin{itemizeS}
 \item Add random noise: distorts $\mathbb{P}(X_S)$ (not used)
 \item Permutation: preserves marginal $\mathbb{P}(X_S)$, breaks dependence with $Y$ (used)
 \end{itemizeS}
 \end{framei}
-
-
-% \begin{frame}{Permutation Feature Importance (PFI) \furtherreading{BREIMAN2001}}
-
-% \textbf{Idea:} "Destroy" information of $X_S$ in $\fh$ by replacing it with perturbed $\Tilde{X}_{S}$
-% %Estimate the added predictive value of feature(s) $X_S$ for a given trained model $\fh$, test data $\D$, test data $\D$ where $X_S$ was replaced by $\Tilde{X}_{S}$ by:
-% and compare {\color{red}reduced model where $X_S$ is made uninformative $\fh(\Tilde{X}_{S}, X_{-S})$} vs. {\color{blue}full model $\fh(X)$}:
-
-% \[
-% \text{PFI}_S :=
-%  {\color{red}\underbrace{\mathbb{E}\Big[L\big(\fh(\tilde{X}_S, X_{-S}), Y\big)\Big]}_{\text{risk after "destroying" }X_S}}
-%  -
-%  {\color{blue}\underbrace{\mathbb{E}\Big[L\big(\fh(X), Y\big)\Big]}_{\text{baseline risk}}},
-% \]
-
-% where $(X,Y)\sim\mathcal{P}$ and
-% $\tilde{X}_S$ is an i.i.d. copy of $X_S$ independent of $(X_{-S},Y)$\\
-% $\rightarrow$ breaks associations between $X_S$ and $Y$ while preserving the marginal $\mathbb{P}(X_S)$
-% \end{frame}
 
 \begin{framev}[align=top]{Permutation Feature Importance (PFI) \furtherreading{BREIMAN2001}}
 \textbf{Sample estimator (using independent test set $\D=\{(\xv^{(i)},y^{(i)})\}_{i=1}^{n}$)}
@@ -122,7 +71,6 @@ $$
 \item Repeat permutation (e.g., $m$ times) and average difference of both errors:
 $$
 \widehat{PFI}_S = \tfrac{1}{m}  \textstyle\sum\nolimits_{k = 1}^{m} \big[ \riske (\fh, {\color{red}\pert{\D}{S}{}_{(k)}}) - \riske (\fh, {\color{blue}\D}) \big]
-%, \quad \riske(\fh, \D) = \frac{1}{n} \sum\limits_{(x, y) \in \D}  L(\fh(x), y)
 $$
 \begin{itemizeS}
 \item $\D^{(k)}_{\,S}$: dataset with column(s) $x_S$ are \textbf{permuted} once (in repetition\ $k$)
@@ -136,100 +84,14 @@ $$
 \image[0.9]{figure_man/permuted-fv.pdf}\\
 \begin{scriptsize}
 Note: $S$ refers to a subset of features, here $|S|=1$ to measure impact of permuting $x_1$ on performance
-%$S$ refers to a subset of features (here: $|S|=1$). We assess the impact of permuting $x_S$ on model performance.
 \end{scriptsize}
 \par}
 \end{framev}
 
 
-% \begin{frame}{Permutation Feature Importance (PFI) \furtherreading{BREIMAN2001}}
-
-
-% % TODO: explain this idea better in one separate slide, e.g. we have a fixed model we want to analyze and a data set. Our aim is to understand the importance of features. We would like to remove a feature and measure its "added value" w.r.t. performance compared to not removing it. But we cannot remove it as the model is fixed and was already trained with that feature -> permuting is the next best thing we can do to "destroy" the information of the feature -> another possibility could be to add some noise to the feature to perturb it but this would change the marginal distribution
-
-% \textbf{Idea:} "Destroy" feat. of interest $x_j$ by perturbing it s.t. it becomes uninformative, e.g., randomly permute obs. in $x_j$ (marginal distribution $\P(x_j)$ stays the same).  %Therefore, resample the variable from its marginal distribution $\P(x_j)$, e.g. by randomly permuting observations in $x_j$.
-
-% PFI for features $x_S$ using test data $\D$:
-% \begin{itemize}
-%   \item Measure the error {\color{blue}\textbf{without permuting feat.}} and {\color{red}\textbf{with permuted feat. values}} $\pert{x}{}{}_S$
-%   \item Repeat permuting the feat. (e.g., $m$ times) and avg. the difference of both errors: 
-% \begin{align*}
-% &\widehat{PFI}_S = \tfrac{1}{m} \textstyle\sum\nolimits_{k = 1}^{m} \riske (\fh, {\color{red}\pert{\D}{S}{}_{(k)}}) - \riske (\fh, {\color{blue}\D}),\\&\text{ where }
-% \riske(\fh, \D) = \frac{1}{n} \sum\nolimits_{(x, y) \in \D}  L(\fh(x), y)
-% \end{align*}
-% \end{itemize}
-% \pause
-% The data $\D$ where $x_S$ is replaced with $\pert{x}{S}{}$ is denoted as $\pert{\D}{S}{}$.\\
-% Example of permuting feature $x_S$ with $S = \{1\}$ and $m=6$:
-
-% % TODO: update to new notation
-% %\begin{center}
-% \centerline{}
-% %\end{center}
-
-% %\vspace*{0.2cm}
-% {\scriptsize{Note: 
-% The $S$ in $x_S$ refers to a \textbf{S}ubset of features for which we are interested in their effect on the prediction.\\
-% Here: We calculate the feature importance for one feature at a time $|S| = 1$.}\par}
-
-% \end{frame}
-
-
-% \begin{columns, totalwidth=\textwidth}
-%   \begin{column}{0.5\textwidth}
-%     \only<1-3,5-7>{$\hspace{36pt}{\color{white}\riske(\fh, {\color{red}\pert{\D}{S}{}_{(k)}}) - \riske(\fh, {\color{blue}\D})}$}
-%   \only<4>{$\hspace{36pt}\riske(\fh, {\color{red}\pert{\D}{S}{}_{(k)}}) - \riske(\fh, {\color{blue}\D}),$ where 
-% $\riske(\fh, \D) =$ \scalebox{0.7}{$\frac{1}{n} \sum\nolimits_{(x, y) \in \D}$} $\scriptstyle L(\fh(x), y)$}
-% % $\scriptstyle\riske(\fh, \D) =$ \scalebox{0.7}{$\frac{1}{n} \sum\nolimits_{(x, y) \in \D}$} $\scriptstyle L(\fh(x), y)$}
-% %   \only<5-6>{$\hspace{36pt}{\color{white}\riske(\fh, {\color{red}\pert{\D}{S}{}_{(k)}}) - \riske(\fh, {\color{blue}\D})}$}
-  
-%   \begin{center}
-%   \only<1>{\includegraphics[page=2, trim=0pt 5pt 0 66pt, clip, width=\textwidth]{figure_man/pfi_demo2}}%
-%   \only<2>{\includegraphics[page=3, trim=0pt 5pt 0 66pt, clip, width=\textwidth]{figure_man/pfi_demo2}}%
-%   \only<3-4>{\includegraphics[page=4, trim=0pt 5pt 0 66pt, clip, width=\textwidth]{figure_man/pfi_demo2}}%
-%   \only<5>{\includegraphics[page=5, trim=0pt 5pt 0 66pt, clip, width=\textwidth]{figure_man/pfi_demo2}}%
-%   \only<6>{\includegraphics[page=6, trim=0pt 5pt 0 66pt, clip, width=\textwidth]{figure_man/pfi_demo2}}%
-%   \only<7>{\includegraphics[page=7, trim=0pt 5pt 0 66pt, clip, width=\textwidth]{figure_man/pfi_demo2}}%
-%   \end{center}
-%   \end{column}
-%   \begin{column}{0.5\textwidth}
-  
-%   \begin{itemize}
-%     \only<1-2>{\item[1.]\textbf{Perturbation:} Sample feature values from the distribution of $x_S$ ($P(X_S)$). \newline $\Rightarrow$ Randomly permute feature $x_S$. Replace the original feature with the permuted feature $\pert{x}{}{}_S$ and create data with permuted feature   $\pert{\D}{S}{}$.}
-%     \only<2>{\item[2.] \textbf{Prediction:} Make predictions for both data, i.e., $\D$ and $\pert{\D}{S}{}$.}
-%     \only<3-4>{\item[3.] \textbf{Aggregation:}
-%       \begin{itemize}
-%         \item Compute the loss for each observation in both data sets.
-%       \end{itemize}}
-%     \only<5>{\item[3.] \textbf{Aggregation:}
-%       \begin{itemize}
-%         \item Compute the loss for each observation in both data sets.
-%       \item Take the difference of both losses $\Delta L$ for each observation.
-%       \end{itemize}}
-%      \only<6>{\item[3.] \textbf{Aggregation:}
-%       \begin{itemize}
-%         \item Compute the loss for each observation in both data sets.
-%         \item Take the difference of both losses $\Delta L$ for each observation.
-%         \item Average this change in loss across all observations.
-%       \end{itemize}}
-%     \only<7>{\item[3.] \textbf{Aggregation:}
-%       \begin{itemize}
-%         \item Compute the loss for each observation in both data sets.
-%         \item Take the difference of both losses $\Delta L$ for each observation.
-%         \item Average this change in loss across all observations.
-%         \item Also, average over multiple repetitions, if available.
-%       \end{itemize}}
-%   \end{itemize}
-%   \end{column}
-% \end{columns}
-
-
-
 \begin{framev}[align=top]{Permutation Feature Importance}
 \only<1-4>{$\hspace{30pt}{\color{white}\riske(\fh, {\color{red}\pert{\D}{S}{}_{(k)}}) - \riske(\fh, {\color{blue}\D})}$}%
 \only<5-6>{$\hspace{30pt}\riske(\fh, {\color{red}\pert{\D}{S}{}_{(k)}}) - \riske(\fh, {\color{blue}\D})$}%
-% $\scriptstyle\riske(\fh, \D) =$ \scalebox{0.7}{$\frac{1}{n} \sum\nolimits_{(x, y) \in \D}$} $\scriptstyle L(\fh(x), y)$}
-%   \only<5-6>{$\hspace{36pt}{\color{white}\riske(\fh, {\color{red}\pert{\D}{S}{}_{(k)}}) - \riske(\fh, {\color{blue}\D})}$}
 
 \only<1>{\includegraphics[page=2, trim=0pt 5pt 0 66pt, clip, width=0.9\textwidth]{figure_man/pfi_demo2}}%
 \only<2>{\includegraphics[page=3, trim=0pt 5pt 0 66pt, clip, width=0.9\textwidth]{figure_man/pfi_demo2}}%
@@ -251,28 +113,6 @@ $\Rightarrow$ Replace $x_S$ with permuted feat. $\pert{x}{}{}_S$ and create data
 \only<5>{\\ Note: Same as computing $\riske$ on both data sets and \\taking difference}%
 \item<6-> Repeat perturbation and average over multiple repetitions%
 \end{itemizeS}
-% \only<3-4>{\item[3.] \textbf{Aggregation:}
-%   \begin{itemize}
-%     \item Compute the loss for each observation in both data sets.
-%   \end{itemize}}
-% \only<5>{\item[3.] \textbf{Aggregation:}
-%   \begin{itemize}
-%     \item Compute the loss for each observation in both data sets.
-%   \item Take the difference of both losses $\Delta L$ for each observation.
-%   \end{itemize}}
-%  \only<6>{\item[3.] \textbf{Aggregation:}
-%   \begin{itemize}
-%     \item Compute the loss for each observation in both data sets.
-%     \item Take the difference of both losses $\Delta L$ for each observation.
-%     \item Average this change in loss across all observations.
-%   \end{itemize}}
-% \only<7>{\item[3.] \textbf{Aggregation:}
-%   \begin{itemize}
-%     \item Compute the loss for each observation in both data sets.
-%     \item Take the difference of both losses $\Delta L$ for each observation.
-%     \item Average this change in loss across all observations.
-%     \item Also, average over multiple repetitions, if available.
-%   \end{itemize}}
 \end{itemizeM}
 \end{framev}
 
@@ -303,27 +143,6 @@ $\Rightarrow$ PFI score contains importance of all interactions with permuted fe
 
 %TODO: Simplify example
 \begin{framev}[align=top]{Comments on PFI - Extrapolation}
-% %\textbf{Example:} Let $y = x_3 + \epsilon_y$ with $\epsilon_y \sim N(0, 0.1)$ where $x_1$, $x_2 := x_1 + \epsilon_1$ are highly correlated ($x_1 \sim N(0,1), \epsilon_1 \sim N(0, 0.01)$). Let $x_3, x_4 \sim N(0,1)$ be noisy features are independent.
-%  \textbf{Example:} Let $y = x_3 + \epsilon_y$ with $\epsilon_y \sim N(0, 0.1)$ where $x_1 :=  \epsilon_1$, $x_2 := x_1 + \epsilon_2$ are highly correlated ($\epsilon_1 \sim N(0,1), \epsilon_2 \sim N(0, 0.01)$) and $x_3 := \epsilon_3$, $x_4 := \epsilon_4$,  with $\epsilon_3, \epsilon_4 \sim N(0,1)$. All noise terms are independent.
-%  Fitting a LM yields $\fh(\xv) \approx 0.3 x_1 - 0.3 x_2 + x_3$.
-% \pause
-
-% %\begin{figure}
-% % \hfill
-% %   \includegraphics[width=0.3\linewidth]{figure_man/pfi_hexbin_pre.pdf}\hfill
-% %   \includegraphics[width=0.3\linewidth]{figure_man/pfi_hexbin_post.pdf} \hfill
-% %   \includegraphics[width=0.39\linewidth]{figure_man/pfi_extrapolation.pdf} \hfill
-% \centerline{\includegraphics[width=0.9\linewidth]{figure_man/pfi_hexbin_extrapolation.pdf}}
-% Hexbin plot of $x_1, x_2$ before permuting $x_1$ (left), after permuting $x_1$ (center), and PFI scores (right)
-% \\
-% \pause
-% % \caption{Density plot for $x_1, x_2$ before permuting $x_1$ (left) and after permuting $x_1$ (center). Right: PFI including $.05$ to $.95$ quantiles.}
-% %\end{figure}
-% % 
-% $\Rightarrow$ $x_1$ and $x_2$ should be irrelevant for the prediction $\fh(\xv)$ %for $\{\xv: \P(\xv) > 0\}$ 
-% since $0.3 x_1 - 0.3 x_2 \approx 0$ \\
-% $\Rightarrow$ PFI evaluates model on unrealistic obs. outside $\P(\xv)$ $\leadsto$ $x_1$, $x_2$ are considered relevant (PFI $> 0$)
-% %$\Rightarrow$ Since PFI evaluates the model on unrealistic observations, the features $x_1$ and $x_2$ are nevertheless considered relevant
 \textbf{Example:} Let $y = x_3 + \epsilon_y$, with $\epsilon_y \sim \mathcal{N}(0, 0.1)$.
 \begin{itemizeS}
 \item $x_1 := \epsilon_1$, $x_2 := x_1 + \epsilon_2$; highly correlated ($\epsilon_1 \sim \mathcal{N}(0,1)$, $\epsilon_2 \sim \mathcal{N}(0, 0.01)$)
@@ -377,8 +196,6 @@ $\Rightarrow$ PFI does not fairly attribute the performance to the individual fe
 {\centering
 \image[0.9]{figure_man/pfi_test_vs_train.pdf}\\
 \par}
-%\caption{While PFI on test data considers all features to be irrelevant, PFI on train data exposes the features on which the model overfitted.}
-%\caption{PFI on test data detects no relevant features. \\PFI on training data highlights features the model overfitted to.}
 \textbf{Observation:}
 \begin{itemizeM}
 \item PFI on train data highlights features that the model overfitted to.
@@ -390,9 +207,6 @@ $\Rightarrow$ PFI does not fairly attribute the performance to the individual fe
 \textbf{Why?} $PFI \neq 0$ if permuting a feature breaks a dependency the model relies on.
 Model overfits due to spurious feature-target dependencies in train that vanish on test.\\
 $\Rightarrow$ To find features that help the model to generalize, compute PFI on test data.
-%\textbf{Why?} PFI can only be nonzero if the permutation breaks a dependence in the data. Spurious feature-target dependencies overfit train data but vanish on test data.%help the model perform well on train data but are not present in the test data.
-%\\
-%$\Rightarrow$ If you are interested in which features help the model to generalize, apply PFI on test data.
 \end{framev}
 
 
@@ -402,7 +216,6 @@ Can we get insight into whether the ...
 \item<1-> feature $x_j$ is causal for the prediction?
 \begin{itemizeS}
 \item $PFI_j \neq 0$ $\Rightarrow$ model relies on $x_j$
-%(contraposition does not hold, see training vs. test data example)
 \item As the train vs. test data example shows, the converse does not hold
 \end{itemizeS}
 \item<2-> feature $x_j$ contains prediction-relevant information?
@@ -417,85 +230,6 @@ Can we get insight into whether the ...
 \end{enumerate}
 \end{framev}
 
-
-% \begin{frame}{Testing Importance (PIMP) \furtherreading{ALTMANN2010}}
-
-% \begin{itemize}[<+->]
-%   \item PIMP was originally introduced for random forest's built-in permutation feature importance
-%   %\item It fixes the problem that the importance measure prefers features with many categories.
-%   \item PIMP investigates whether the PFI score \textbf{significantly} differs from 0\\
-%   $\Rightarrow$ Useful because PFI can be non-zero due to randomness/stochasticity
-%   \item PIMP tests the $H_0$-hypothesis: Feature is independent of the target $y$ (unimportant)
-%   %It computes the distribution of importances under the $H_0$-hypothesis that the feature is independent of the target $y$
-%   \item Sampling under $H_0$: Permute target $y$, retrain model, compute PFI scores (repeat)\\
-%   $\Rightarrow$ Permuting $y$ breaks relationship to all features\\
-%   $\Rightarrow$ By computing PFI scores again, we obtain distribution of PFI scores under $H_0$
-%   \item %We now rescale the importance to a 
-%   Compute p-value - the tail probability under $H_0$ - and use it as a new importance measure
-% \end{itemize}
-
-% %\footnote[frame]{\fullcite{altmann2010permutation}}
-% %{\tiny{Altmann, André, et al. "Permutation importance: a corrected feature importance measure." 
-% %Bioinformatics 26.10 (2010): 1340-134.}}
-
-% \end{frame}
-
-% \begin{frame}{Testing Importance (PIMP)}
-
-% PIMP algorithm:
-% \begin{enumerate}
-% 	\item<1-3> For $m \in \{1, \ldots, n_{repetitions}\}$:
-% 		\begin{itemize}
-% 			\item Permute response vector $y$
-% 			\item Retrain model with data $\Xmat$ and permuted $y$
-% 			\item Compute feature importance $PFI_j^m$ for each feature $j$ (under $H_0$)
-% 		\end{itemize}
-% 	\item<2-3> Train model with $\Xmat$ and unpermuted $y$
-% 	\item<3> For each feature $j \in \{1,\ldots,p\}$:
-% 		\begin{itemize}
-% 			\item Fit probability distribution of the feature importance values $PFI_j^m$, $m \in \{1, \ldots, n_{repetitions}\}$ (choice between Gaussian, lognormal, gamma or non-parametric)
-% 			\item Compute feature importance $PFI_j$ for the model without permutation of $y$ (under $H_1$)
-% 			\item Retrieve the p-value of $PFI_j$ based on the fitted distribution
-% 		\end{itemize}
-% \end{enumerate}
-% \end{frame}
-
-
-% %TODO: Simplify or better explain example
-% \begin{frame}{PIMP for extrapolation example}
-% \textbf{Recall:} 
-% $y = x_3 + \epsilon_y$ with $\epsilon_y \sim N(0, 0.1)$, 
-% $x_1$, $x_2$ highly correlated but independent of $y$, 
-% $x_4$ is independent of $y$ and all other variables.
-% Fitting a LM yields $\fh(\xv) \approx 0.3 x_1 - 0.3 x_2 + x_3$.
-% %Fitting a \texttt{lm} yields $\fh(x) \approx 0.3 x_1 - 0.3 x_2 + x_3$.
-% %
-% %\begin{figure}
-%   \includegraphics[width=\linewidth]{figure_man/pimp.pdf}
-%   %\caption{$H_0$ distribution (1000 samples) for each feature as histograms, the true PFI indicated in red. PIMP only considers $x_3$ relevant. Although PFI for $x_1$ and $x_2$ is nonzero, PIMP considers them irrelevant since they are not predictive of $y$. Even after permuting $y$, the model relies on them.}
-% %\end{figure}
-
-% \begin{itemize}
-%     \item Histograms: $H_0$ distribution of PFI scores after permuting $y$ (1000 repetitions)
-%     \item Red: PFI score estimated on unpermuted $y$ (under $H_1$) $\leadsto$ compare against $H_0$ distribution
-%     \item Results: Although PFI for $x_1$ and $x_2$ is nonzero (red), PIMP considers them not significantly relevant (p-value > 0.05) 
-%     %since they are not predictive of $y$
-% \end{itemize}
-% \end{frame}
-
-% \begin{frame}{Digression: Multiple testing problem \furtherreading{ROMANO2010}}
-% \begin{itemize}[<+->]
-%   \item When should we reject the $H_0$-hypothesis for a feature? 
-%   \item The larger the number of features, the more tests need to be performed by PIMP\\
-%   $\leadsto$ \textbf{Multiple testing problem}: If multiplicity of tests is not taken into account, the probability that some of the true $H_0$-hypothesis is rejected (type-I error) by chance may be large
-%   \item Accounting for multiplicity of individual tests can be achieved by controlling an appropriate error rate, e.g., the \textbf{family-wise error rate} (FWE: probability of at least one type-I error)
-%   \item One classical method to control the FWE is the \textbf{Bonferroni correction} which rejects a null hypothesis if its p-value is smaller than $\alpha/m$ with $m$ as the number of performed parallel tests
-%   %\item We refer to other lectures or the statistics literature for more details
-%   \end{itemize} 
-
-%   %\footnote[frame]{\fullcite{romano2010multiple}}
-%   %{\tiny{Romano, J. P., Shaikh, A. M., and Wolf, M. (2010). Multiple Testing. The New Palgrave Dictionary of Economys. \url{https://home.uchicago.edu/~amshaikh/webfiles/palgrave.pdf}}\par}
-% \end{frame}
 % % \begin{frame}
 % %   \printbibliography
 % % \end{frame}

--- a/slides/feature-importance/slides02-fi-pimp.tex
+++ b/slides/feature-importance/slides02-fi-pimp.tex
@@ -49,19 +49,13 @@ figure_man/pimp
   %\item It fixes the problem that the importance measure prefers features with many categories.
   \item PIMP idea: Test if an observed $\widehat{\text{PFI}}_j^{\text{obs}}$ score is \emph{significantly} greater than expected under the null hypothesis of $X_j$ being not important\\
   $\leadsto$ Accounts for spurious importance due to randomness
-  %Addresses random fluctuations that cause non-zero PFI scores
-  %Useful because PFI can be non-zero due to randomness/stochasticity
-  %It computes the distribution of importances under the $H_0$-hypothesis that the feature is independent of the target $y$
  \item Null hypothesis $H_0$: Feature $X_j$ is conditionally indep. of $y$ (unimportant)
   \item Approximate null distrib. of PFI scores under $H_0$ by repeated permuts:\\
   Permute $y$ $\rightarrow$ retrain $\rightarrow$ recompute $\widehat{\text{PFI}}_j$ scores for all $j$ $\rightarrow$ repeat $B$ times\\
   $\Rightarrow$ Permuting $y$ breaks relationship to all features (PFI scores reflect noise only)%\\
-  %$\Rightarrow$ By computing PFI scores again, we obtain distribution of PFI scores under $H_0$
-  \item %We now rescale the importance to a 
+  \item
   Assess the significance of PFI scores via tail probability under $H_0$\\
-  %Compute p-value via tail probability under $H_0$ over all $B$ repetitions
     $\Rightarrow$ Use this as a new feat. importance score, adjusting for random chance
-  %and use this as new importance measure
 \end{itemize}
 
 %\footnote[frame]{\fullcite{altmann2010permutation}}
@@ -82,10 +76,9 @@ figure_man/pimp
 	\item<2-3> Train model on original data  $(\Xmat, \yv)$ with unpermuted target
 	\item<3> For each feature $j \in \{1,\ldots,p\}$:
 		\begin{itemize}
-        		\item Compute $\widehat{\text{PFI}}_j^{\text{obs}}$ for the model without permutation of $y$ (under $H_1$)
+			\item Compute $\widehat{\text{PFI}}_j^{\text{obs}}$ for the model without permutation of $y$ (under $H_1$)
 			\item Fit probability distribution to all PFI scores $\{\widehat{\text{PFI}}_j^{(b)}\}_{b=1}^{B}$ (under $H_0$)\\
             e.g., by assuming Gaussian/lognormal/gamma distrib (parametric)%\\
-            %$\leadsto$ non-parametric by computing empirical tail probability
 			\item Compute p-value: Prob. that null importance exceeds observed: 
             \begin{itemize}
                 \item parametric by taking tail probability of assumed distribution $$\mathbb{P}(\widehat{\text{PFI}}_j^{(m)} \geq \widehat{\text{PFI}}_j^{\text{obs}})$$
@@ -111,12 +104,6 @@ figure_man/pimp
   \item Fitting a linear model yields $\hat{f}(\xv) \approx 0.3 x_1 - 0.3 x_2 + x_3$
 \end{itemize}
 
-% $y = x_3 + \epsilon_y$ with $\epsilon_y \sim N(0, 0.1)$, 
-% $x_1$, $x_2$ highly correlated but independent of $y$, 
-% $x_4$ is independent of $y$ and all other variables.
-% Fitting a LM yields $\fh(\xv) \approx 0.3 x_1 - 0.3 x_2 + x_3$.
-%Fitting a \texttt{lm} yields $\fh(x) \approx 0.3 x_1 - 0.3 x_2 + x_3$.
-%
 %\begin{figure}
   \includegraphics[width=\linewidth]{figure_man/pimp.pdf}
   %\caption{$H_0$ distribution (1000 samples) for each feature as histograms, the true PFI indicated in red. PIMP only considers $x_3$ relevant. Although PFI for $x_1$ and $x_2$ is nonzero, PIMP considers them irrelevant since they are not predictive of $y$. Even after permuting $y$, the model relies on them.}
@@ -128,25 +115,12 @@ figure_man/pimp
     \item Recall: PFI for $x_1$, $x_2$, $x_3$ is non-0 suggesting they are important (red lines)
     \item PIMP considers $x_1$, $x_2$ not significantly relevant (p-value > 0.05) 
 
-    %since they are not predictive of $y$
 \end{itemize}
 \end{frame}
 
-% \begin{frame}{Digression: Multiple testing problem \furtherreading{ROMANO2010}}
-% \begin{itemize}[<+->]
-%   \item When should we reject the $H_0$-hypothesis for a feature? 
-%   \item The larger the number of features, the more tests need to be performed by PIMP\\
-%   $\leadsto$ \textbf{Multiple testing problem}: If multiplicity of tests is not taken into account, the probability that some of the true $H_0$-hypothesis is rejected (type-I error) by chance may be large
-%   \item Accounting for multiplicity of individual tests can be achieved by controlling an appropriate error rate, e.g., the \textbf{family-wise error rate} (FWE: probability of at least one type-I error)
-%   \item One classical method to control the FWE is the \textbf{Bonferroni correction} which rejects a null hypothesis if its p-value is smaller than $\alpha/m$ with $m$ as the number of performed parallel tests
-%   %\item We refer to other lectures or the statistics literature for more details
-%   \end{itemize} 
-
-%   %\footnote[frame]{\fullcite{romano2010multiple}}
-%   %{\tiny{Romano, J. P., Shaikh, A. M., and Wolf, M. (2010). Multiple Testing. The New Palgrave Dictionary of Economys. \url{https://home.uchicago.edu/~amshaikh/webfiles/palgrave.pdf}}\par}
-% \end{frame}
-
 \begin{frame}{Digression: Multiple Testing \furtherreading{ROMANO2010}}
+% \footnote[frame]{\fullcite{romano2010multiple}}
+% {\tiny{Romano, J. P., Shaikh, A. M., and Wolf, M. (2010). Multiple Testing. The New Palgrave Dictionary of Economys. \url{https://home.uchicago.edu/~amshaikh/webfiles/palgrave.pdf}}\par}
 
 \begin{itemize}%[<+->]
   \item When should we reject $H_0$ for a given feature?

--- a/slides/feature-importance/slides03-fi-cfi.tex
+++ b/slides/feature-importance/slides03-fi-cfi.tex
@@ -53,7 +53,6 @@ figure_man/feature-importance.png
 \item \textbf{PFI Idea:} Replace feature(s) $X_S$ with perturbed $\tilde X_S$ to preserve marginal distr. $\P(X_S)$ so that $\tilde X_S \indep Y$ (indep.), e.g., by random permutations
 \item \textbf{Problem:} Breaks not only association between $X_S$ and $Y$ (what we want) but also between $X_S$, $X_{-S}$ $\Rightarrow$ $\P(X_S, X_{-S}) \neq \P(\tilde X_S, X_{-S})$ (extrapolation)
 \item \textbf{CFI Idea:} Replace feature(s) $X_S$ with perturbed $\tilde X_S$ to preserve joint distr. so that $\P(X_S, X_{-S}) = \P(\tilde X_S, X_{-S})$ (no extrapolation) while still $\tilde X_S \indep Y$
-%Sample $X_S$ from conditional dist. $\P(X_S|X_{-S})$ to preserve joint dist., i.e., $\P(X_S|X_{-S}) \P(X_{-S}) = \P(X_S, X_{-S})$
 \end{itemize}
 %\\
 %\lz
@@ -73,26 +72,12 @@ $X_1 \sim \mathcal{N}(0,1)$ (if $X_2 < 0.5$) or $\mathcal{N}(4,4)$ \\(if $ X_2 \
 \furtherreading{MOLNAR2020}
 \end{center}
 }{
-%\begin{itemize}
-% $X_2 \sim U(0,1)$ and 
-% \begin{align*}
-% X_1 \sim \begin{cases}
-% N(0, 1) \text{, if } X_2<0.5\\
-% N(4, 4), \text{else}
-% \end{cases}
-%\end{align*}
-%\item
 \textbf{Left:} For $X_2<0.5$, permuting $X_1$ (crosses) preserves marginal (but not joint) distrib. \\
 $\leadsto$ Bottom: Marginal density of $X_1$\\
 \spacer[0.25]
-%\item
 \textbf{Right:} Permuting $X_1$ within subgroups $X_2<0.5$ \& $X_2\geq 0.5$ reduces extrapolation\\
 $\leadsto$ Bottom: $X_1$-density cond. on groups
-%\item \textbf{Bottom left:} Marginal density of $X_1$
-%\item \textbf{Bottom right:} Densities of $X_1$ conditional on the groups
-%\end{itemize}
 }
-%$X_2 \sim U(0,1)$ and $X_1 \sim N(0, 1)$ if $X_2<0.5$, else $X_1 \sim N(4,4)$ (black dots)
 }
 \end{framev}
 
@@ -107,22 +92,6 @@ Let $y = x_3 + \epsilon_y$, with $\epsilon_y \sim \mathcal{N}(0, 0.1)$.
 \item $x_3 := \epsilon_3$, $x_4 := \epsilon_4$, with $\epsilon_3, \epsilon_4 \sim \mathcal{N}(0,1)$; all noise terms $\epsilon_j$ are indep.
 \item Fitting a linear model yields $\hat{f}(\xv) \approx 0.3 x_1 - 0.3 x_2 + x_3$
 \end{itemizeM}
-% \textbf{Example:} Let $y = x_3 + \epsilon_y$ with $\epsilon_y \sim N(0, 0.1)$ where $x_1 :=  \epsilon_1$, $x_2 := x_1 + \epsilon_2$ are highly correlated ($\epsilon_1 \sim N(0,1), \epsilon_2 \sim N(0, 0.01)$) and $x_3 := \epsilon_3$, $x_4 := \epsilon_4$,  with $\epsilon_3, \epsilon_4 \sim N(0,1)$. All noise terms are independent.
-% Fitting a LM yields $\fh(\xv) \approx 0.3 x_1 - 0.3 x_2 + x_3$.
-% %\begin{figure}
-% % \hfill
-% %   \includegraphics[width=0.3\linewidth]{figure_man/pfi_hexbin_pre.pdf}\hfill
-% %   \includegraphics[width=0.3\linewidth]{figure_man/pfi_hexbin_post.pdf} \hfill
-% %   \includegraphics[width=0.39\linewidth]{figure_man/pfi_extrapolation.pdf} \hfill
-% \centerline{\includegraphics[width=0.9\linewidth]{figure_man/pfi_hexbin_extrapolation.pdf}}
-% Hexbin plot of $x_1, x_2$ before permuting $x_1$ (left), after permuting $x_1$ (center), and PFI scores (right)
-% \lz
-% % \caption{Density plot for $x_1, x_2$ before permuting $x_1$ (left) and after permuting $x_1$ (center). Right: PFI including $.05$ to $.95$ quantiles.}
-% %\end{figure}
-% % 
-% $\Rightarrow$ $x_1$ and $x_2$ should be irrelevant for the prediction $\fh(\xv)$ for $\{\xv: \P(\xv) > 0\}$ as $0.3 x_1 - 0.3 x_2 \approx 0$ \\
-% $\Rightarrow$ PFI evaluates model on unrealistic obs. outside $\P(\xv)$ $\leadsto$ $x_1$ and $x_2$ are considered relevant
-% %$\Rightarrow$ Since PFI evaluates the model on unrealistic observations, the features $x_1$ and $x_2$ are nevertheless considered relevant
 \image{figure_man/pfi_hexbin_extrapolation.pdf}
 Hexbin plot of $(x_1, x_2)$ before (left) and after (center) permuting $x_1$;  
 \\PFI scores (right).
@@ -157,12 +126,10 @@ $\leadsto$ $x_1, x_2$ are misleadingly considered relevant
 
 % CFI DEFINITION
 \begin{framev}[align=top]{CFI \furtherreading{STROBL2008} \furtherreading{HOOKER2021}}
-%  {\color{blue}\textbf{with feat. values $x_S$}} and {\color{red}\textbf{with permuted feat. values $\pert{x}{}{}_S$}} 
 CFI for $X_S$ using test data $\D$:
 \begin{itemizeM}
 \item Measure the error {\color{blue}\textbf{with unperturbed features $x_S$}}.
 \item Measure the error \textbf{\color{red}with perturbed feature values $\pert{x}{}{}_S \sim \P(X_S|X_{-S})$}
-%\color{black} $\pert{x}{S}{-S}$, where $\pert{x}{S}{-S}_S \sim \P(x_S|x_{-S})$
 \item Repeat perturbing $X_S$ (e.g., $m$ times) and avg. difference of both errors:
 $$\widehat{CFI}_S = \tfrac{1}{m} \textstyle\sum\nolimits_{k = 1}^{m} \riske (\fh, {\color{red}\pert{\D}{S}{-S}_{(k)}}) - \riske (\fh, {\color{blue}\D})$$
 \end{itemizeM}
@@ -228,7 +195,6 @@ Here, $X_S$ is permuted \textit{within} each group of $X_{-S}$ to preserve $\mat
 $\Rightarrow$ CFI $= 0$
 \item Why? Under the conditional indep.
 $\P(\pert{X}{}{}_S, X_{-S}, Y) = \P(X_S, X_{-S}, Y)$
-%$\P(\pert{x}{S}{-S}, y) = \P(x,y)$
 \\
 $\leadsto$ no prediction-relevant information is destroyed by permutation of $x_S$ conditional on $x_{-S}$
 \end{itemizeM}
@@ -239,7 +205,6 @@ $\leadsto$ no prediction-relevant information is destroyed by permutation of $x_
 \item If the model does not use a feature $\Rightarrow$ CFI $= 0$
 \item Why? Then the prediction is not affected by any perturbation of the feat\\
 $\leadsto$ model performance does not change after conditional permutation
-%(and consequently the performance is invariant).
 \end{itemizeM}
 %\footnote[frame]{\fullcite{konig_relative_2021}}
 \end{framev}
@@ -257,12 +222,10 @@ Can we gain insight into whether ...
 \begin{itemizeS}
 \item If $x_j \not \indep y$ but $x_j \indep y | x_{-j}$ (e.g., $x_j$ and $x_{-j}$ share information) \\$\Rightarrow$ $CFI_j = 0$
 \item $x_j$ is not exploited by model (regardless of its usefulness for $y$) \\$\Rightarrow$ $CFI_j = 0$
-%\item If a feature is not exploited by the model, CFI is zero, irrespective of whether the feature is useful or not.
 \end{itemizeS}
 \item<3> Does the model need access to $x_j$ to achieve its prediction performance?
 \begin{itemizeS}
 \item $CFI_j \neq 0 \Rightarrow$ $x_j$ contributes unique information (meaning $x_j \not \indep y | x_{-j}$)
-%Nonzero CFI implies that the feature contributes unique information (meaning $x_S \not \indep y | x_{-S}$).
 \item Only uncovers the relationships that were exploited by the model
 \end{itemizeS}
 \end{enumerate}
@@ -278,9 +241,6 @@ Can we gain insight into whether ...
 \item $x_3 := \epsilon_3$, $x_4 := \epsilon_4$, with $\epsilon_3, \epsilon_4 \sim \mathcal{N}(0,1)$; all noise terms $\epsilon_j$ are indep.
 \item Fitting a linear model yields $\hat{f}(\xv) \approx 0.3 x_1 - 0.3 x_2 + x_3$
 \end{itemizeM}
-% \textbf{Example:} Let $y = x_3 + \epsilon_y$ with $\epsilon_Y \sim N(0, 0.1)$ where $x_1 :=  \epsilon_1$, $x_2 := x_1 + \epsilon_2$ are highly correlated ($\epsilon_1 \sim N(0,1), \epsilon_2 \sim N(0, 0.01)$) and $x_3 := \epsilon_3$, $x_4 := \epsilon_4$,  with $\epsilon_3, \epsilon_4 \sim N(0,1)$. All noise terms are independent.
-% Fitting a LM yields $\fh(\xv) \approx 0.3 x_1 - 0.3 x_2 + x_3$.%\\
-%
 \begin{figure}
 %\hfill
 \splitVCompact{0.28}{0.65}{
@@ -292,17 +252,12 @@ Can we gain insight into whether ...
 }
 \caption{Density plot for $x_1, x_2$ before permuting $x_1$ (left). PFI and CFI (right).}
 \end{figure}
-% 
-%$\Rightarrow$ $x_1$ and $x_2$ are irrelevant for the prediction for $x: \P(x) > 0$ \\
-%$\Rightarrow$ Since PFI evaluates the model on unrealistic observations, the features $x_1$ and $x_2$ are nevertheless considered relevant \\
 \begin{itemizeS}
 \item $x_1$ and $x_2$ cancel in $\fh(\xv)$ and should be irrelevant for the prediction
 \item PFI evaluates model on unrealistic obs. \\$\leadsto$ $x_1$, $x_2$ appear relevant (PFI $> 0$)
 \item CFI evaluates model on realistic obs. (due to conditional sampling) \\
 $\leadsto$ $x_1$, $x_2$ appear irrelevant (CFI $= 0$)
 \end{itemizeS}
-% $\fh(\xv)$ for $\{\xv: \P(\xv) > 0\}$ as $0.3 x_1 - 0.3 x_2 \approx 0$ \\
-%$\Rightarrow$ Since $x_1$ can be reconstructed from $x_2$ and vice versa, CFI considers $x_1$ and $x_2$ to be irrelevant
 \end{framev}
 
 % \begin{frame}{Bibliography}

--- a/slides/feature-importance/slides04-fi-sage.tex
+++ b/slides/feature-importance/slides04-fi-sage.tex
@@ -72,7 +72,7 @@ Although $x_3$ alone contributes as much to the prediction as $x_1$ and $x_2$ jo
 
 
 \begin{framev}[align=top]{SAGE Idea \furtherreading{COVERT2020}}
-\textbf{SAGE:} %Leverage game-theoretic 
+\textbf{SAGE:}
 Use Shapley values to compute a fair attribution of importance (via model performance)\\
 \spacer[0.25]
 \textbf{Idea:}
@@ -83,20 +83,12 @@ $\leadsto$ features jointly contribute to achieve a certain model performance
 \item Payoff to be fairly distributed: model performance
 \item Surplus contribution of a feature depends on the coalition of features that are already accessible by the model
 \end{itemizeM}
-%, where each feature is a player and model performance is the payoff. The surplus contribution of a feature depends on the coalition of features that are already in the room.\\
-%\pause
 \spacer[0.25]
 \textbf{Note:}
 \begin{itemizeM}
 \item Similar idea (called SFIMP) was proposed in \furtherreading{CASALICCHIO2018}
 \item Definition based on model refits was proposed in context of feature selection in \furtherreading{COHEN2007}
 \end{itemizeM}
-%$\Rightarrow$ Global feature importance technique\\
-%$\Rightarrow$ Compute approximate Shapley values $\phi_j$ using appropriate value function 
-%\lz
-%$\Rightarrow$ SAGE translates SHAP into a global feature importance technique\\
-%\lz
-%In order to compute SAGE, approximate Shapley values $\phi_j$ as for SHAP, replacing SHAP value functions with SAGE value functions.\\
 \spacer[0.25]
 %\footnote[frame]{\fullcite{NEURIPS2020_c7bf0b7c}}
 \end{framev}
@@ -109,9 +101,7 @@ To deprive information of the non-coalition features $-S$ from the model, margin
 $$
 \fh_S(x_S) = \E[\fh(x) | X_S = x_S]
 $$
-%\lz
 %\footnote[frame]{\fullcite{NEURIPS2020_c7bf0b7c}}
-%For SAGE, value functions quantify the predictive power of a coalition $S$ in terms of reduction in risk over the mean prediction.\\
 \pause
 \spacer[0.25]
 \textbf{SAGE value function:}
@@ -137,21 +127,17 @@ When computing the marginalized prediction $\fh_S(x_S)$, the ``dropped'' feature
 \item the marginal distribution $\P(x_{-S})$ $\Rightarrow$ marginal SAGE
 \item the conditional distribution $\P(x_{-S}|x_S)$ $\Rightarrow$ conditional SAGE
 \end{itemizeM}
-%\lz\pause
-%Interpretation of SAGE value functions differs, depending on whether conditional or marginal sampling is used.
 \spacer[0.25]
 \pause
 \textbf{Interpretation marginal sampling:} $v(S)$ quantifies the reliance of the model on features $x_S$
 \begin{itemizeM}
-\item %features $x_S$ not being causal for the prediction is a sufficient condition for $v(S) = 0$
-features $x_S$ not being causal for the prediction $\Rightarrow$ $v(S) = 0$
+\item features $x_S$ not being causal for the prediction $\Rightarrow$ $v(S) = 0$
 \end{itemizeM}
 \spacer[0.25]
 \pause
 \textbf{Interpretation conditional sampling}: $v(S)$ quantifies whether variables $x_S$ contain prediction-relevant information (e.g. $y \not \indep x_S$) that is (directly or indirectly) exploited by the model
 \begin{itemizeM}
-\item %features $x_S$ not being causal for the prediction is not a sufficient condition for $v(S) = 0$
-features $x_S$ not being causal for the prediction $\not \Rightarrow$ $v(S) = 0$
+\item features $x_S$ not being causal for the prediction $\not \Rightarrow$ $v(S) = 0$
 \begin{itemizeS}
 \item e.g., if $x_1$ and $x_2$ are perfectly correlated, even if only $x_1$ has a nonzero coefficient, both are considered equally important
 % (see omitted variable bias as in M-plots)
@@ -163,8 +149,6 @@ features $x_S$ not being causal for the prediction $\not \Rightarrow$ $v(S) = 0$
 
 \begin{framev}[align=top]{SAGE - marginal and cond. sampling}
 \textbf{Example:}
-%$x_1 = \epsilon_1$, $x_2 = x_1 + \epsilon_2$, $x_3 = x_2 + \epsilon_3$, $y = x_3 + \epsilon_y$ with $\epsilon_j$ independent noise terms (causal DAG: $x_1 \rightarrow x_2 \rightarrow x_3 \rightarrow y$). Assume fitting LM yields $\fh \approx 0.95 x_3 + 0.05 x_2$. 
-%
 \splitVTT[0.4]{
 \spacer[0.6]
 \begin{itemizeM}
@@ -196,8 +180,6 @@ $\Rightarrow$ Since $y \indep x_1, x_2 | x_3$, only $v(\{1,2,3\}) - v(\{1, 2\})$
 \textbf{SAGE values $\phi_j$}: fair attribution of importance
 \begin{itemizeM}
 \item can be computed by averaging the contribution of $x_j$ over all feat orderings
-%\item for feature permutation $\pi$ and the corresponding feature ordering $(x_{\pi(1)}, \dots, x_{phi(d)})$, for feature $x_j$ the coalition $S(j; \pi)$ is defined as the set of features preceding $x_j$, i.e. $S(j; \pi) := \{i : \pi(i) < \pi(j)\}$
-%\item the contribution of $j$ in an ordering $\pi$ is given as $v(j \cup S(j; \pi)) - v(S(j; \pi))$
 \item for feature permutation $\tau$, the contribution of $j$ in the set $\Stau$ is given as $v(\Stauj) - v(\Stau)$\\
 Note: $\Stau$ is the set of features preceding $j$ in permutation $\tau$
 \end{itemizeM}
@@ -285,8 +267,6 @@ $\leadsto$ zero $\phi_j$ does not imply $\xj \not \rightarrow \hat{y}$
 $\leadsto$ prediction-relevance implies nonzero $\phi_j$
 \item $x_j \indep y$ does not imply $x_j \indep y | x_S$ and consequently does not imply $v(j \cup S) - v(S) = 0$
 $\leadsto$ $\phi_j$ may be nonzero although $\xj \indep y$
-    %   \item $x_j \indep y$ in general does not imply $x_j \indep y | x_S$ and consequently does not imply that $v(j \cup S) - v(S) = 0$\\
-    %   $\leadsto$ $\phi_j$ may be nonzero although $\xj \indep y$
 \end{itemizeS}
 \item<3> model requires access to $x_j$ to achieve its prediction performance?
 \begin{itemizeS}
@@ -298,9 +278,6 @@ $\leadsto$ $\phi_j$ may be nonzero although feature has no unique contrib.
 \end{enumerate}
 \end{framev}
 
-% \begin{frame}
-%   \printbibliography
-% \end{frame}
 
 \begin{framev}[align=top]{Deep dive: Shapley axioms for SAGE}
 The Shapley axioms can be translated into properties of SAGE. The interpretation depends on whether conditional or marginal sampling is used.

--- a/slides/feature-importance/slides05-fi-loco.tex
+++ b/slides/feature-importance/slides05-fi-loco.tex
@@ -40,27 +40,12 @@ figure_man/feature-importance.png
 
 %TODO: Remove gray figure background (e.g. theme_bw())
 
-% \begin{frame}{Reminder: Feature Importance Scheme}
-% In general, feature importance methods share two components
-% \lz
-% \begin{enumerate}
-%   \item \textbf{Perturbation/Removal:} Generate predictions for which the feature of interest has been perturbed/removed.
-%   \item \textbf{Performance Comparision:} Compare performance under perturbation/removal with the original model performance.
-% \end{enumerate}
-% \lz
-% Depending on the type of perturbation/removal feature importance methods provide insight into different aspects of model and data.\\
-% \lz
-% \textbf{LOCO idea:} Simply remove the feature from the dataset and refit the model on the reduced dataset. The performance loss compared to the full model is interpreted as feature importance.\\
-
-% \end{frame}
-
 \begin{framev}[align=top]{LOCO \furtherreading{LEI2018} \furtherreading{TIBSHIRANI2018}}
 % citation of the original LOCO paper
 %
-\textbf{LOCO idea:} Remove the feature from data, refit model on reduced data, and measure the loss in performance compared to model fitted on complete data.\\ %Remove the feature from the dataset and refit the model on the reduced dataset. The performance loss compared to the full model is interpreted as feature importance.
+\textbf{LOCO idea:} Remove the feature from data, refit model on reduced data, and measure the loss in performance compared to model fitted on complete data.\\
 \pause
 \spacer[0.25]
-%\textbf{Definition:} Given train and test data $\Dtrain, \Dtest \subseteq \D$, for learner $\ind$ and model $\fh = \ind(\Dtrain)$. Then LOCO for a feature $j \in \pset$ can be computed as follows:
 \textbf{Definition:} Given train and test data $\Dtrain, \Dtest \subseteq \D$, a learner $\ind$, and model $\fh := \ind(\Dtrain)$, the LOCO importance for feat $j \in \pset$ is computed by:\\
 \spacer[0.25]
 \begin{enumerate}
@@ -84,9 +69,6 @@ $$
 \begin{framev}[align=top]{Bike Sharing Example}
 %
 \image{figure_man/bike_sharing_loco.pdf}
-%\caption{A random forest with default hyperparameters was fit on $70\%$ of the bike sharing data (training set) to optimize MSE. Then LOCO was computed for all features on the test data. The temperature is the most important feature. Without access to \texttt{temp}, the MSE increases by approx. $140,000$.}
-%
- %\textbf{Interpretation:} $\text{LOCO}_j$ quantifies how important variable $x_j$ is to the generalization performance of the learner on $\Dtrain$.\\
 %
 \begin{itemizeS}
 \item Trained random forest (default hyperparams) on 70\% of bike sharing data
@@ -129,7 +111,6 @@ Can we get insight into whether the ...
 \item $y = x_2 + x_3 + \epsilon$ with $\epsilon \sim N(0, 2)$
 \item Trained LM: $\fh(x) = -0.02 - 1.02 x_1 + 2.05 x_2 + 0.98 x_3$
 \end{itemizeM}
-%Sample $1000$ observations with $x_1, x_3 \sim N(0, 5), x_2 = x_1 + \epsilon_2$ with $\epsilon_2 \sim N(0, 0.1)$ and $y = x_2 + x_3 + \epsilon$ with $\epsilon \sim N(0, 2)$.
 \pause
 \splitVCC[0.42]{
 \image{figure_man/simulation_loco_corr.pdf}\\
@@ -137,27 +118,6 @@ Can we get insight into whether the ...
 }{
 \imageC[0.9]{figure_man/simulation_loco}
 LOCO importance from LM trained on 70\% of data, evaluated on remaining 30\%
-%LOCO importance of LM fitted on 70\% of the data computed on 30\% remaining observations
-%\begin{figure}
-%\centering
-%\hfill
- % \begin{tikzpicture}[thick, scale=1.1, every node/.style={scale=0.6, line width=0.3mm, black, fill=white}]
-%		\node[draw, circle, font=\large] (x1) at  (-.5, 2) {$X_1$};
-%		\node[draw, circle, font=\large] (x2) at  (-.5,1) {$X_2$};
-%		\node[draw, circle, font=\large] (x3) at  (.5,1) {$X_3$};
-%		\node[draw, circle, font=\large] (y) at  (0,0) {$Y$};
-%		\draw[->, black] (x1) -- (x2);
-%		\draw[->, black] (x3) -- (y);
-%		\draw[->, black] (x2) -- (y);
-%	\end{tikzpicture} 
-%\hfill
-% \includegraphics[width=\linewidth]{figure_man/simulation_loco_corr.pdf} 
-% \hfill
-% \includegraphics[width=\linewidth]{figure_man/simulation_loco}
-%\hfill
-%\end{figure}
-%Linear Gaussian data generating process with correlation matrix as depicted left.
-%A linear model was fit with $\fh(x) = -0.09 - 0.86 x_1 + 1.86 x_2 + 0.96 x_3$.\\
 }
 \spacer[0.25]
 \pause
@@ -168,7 +128,6 @@ $\Rightarrow$ We also can't infer (2), e.g., $Cor(x_2, y) = 0.68$ but $\text{LOC
 \pause
 $\Rightarrow$ We can get insight into (3): $x_2$, $x_1$ highly corr. with $\text{LOCO}_1 = \text{LOCO}_2 \approx 0$ \\
 \phantom{$\Rightarrow$} $\leadsto$ $x_2$ and $x_1$ take each others place if one of them is left out (unlike $x_3$)
-%As $x_2$ and $x_1$ are highly correlated, they can take each others place, which is not the case for $x_3$.
 \end{framev}
 
 %TODO: Why only?
@@ -185,7 +144,6 @@ Cons:
 \item Provides insight into a learner on specific data, not a specific model\\
 $+$ for algorithm-level insight\\
 $-$ for model-specific insights
-%Does not provide insight into a specific model, but rather a learner on a specific dataset
 \item Model training is a random process and LOCO estimates can be noisy\\
 $\leadsto$ Limits inference on model and data, or multiple refittings necessary?
 \item Requires re-fitting the learner for each feature\\


### PR DESCRIPTION
# Commented-Out Content Removal Report

Edited files:

- `slides/feature-importance/slides01-fi-intro.tex`
- `slides/feature-importance/slides02-fi-pfi.tex`
- `slides/feature-importance/slides02-fi-pimp.tex`
- `slides/feature-importance/slides03-fi-cfi.tex`
- `slides/feature-importance/slides04-fi-sage.tex`
- `slides/feature-importance/slides05-fi-loco.tex`

## Summary

- Removed commented-out units: **42**
- Kept candidate units: **11**
- Restored or moved provenance/reference comment blocks: **2**
- Evidence scope: current file **yes**, sibling `.tex` files **yes**

## Provenance / Attribution Audit

- Restored Fisher et al. source note from the deleted legacy PFI idea frame as commented text near `slides/feature-importance/slides02-fi-pfi.tex:43`.
- Moved the ROMANO multiple-testing full-reference comment to the active multiple-testing slide at `slides/feature-importance/slides02-fi-pimp.tex:122`.
- Deleted Altmann PIMP provenance from `slides02-fi-pfi.tex` only because the active PIMP slide already keeps the same attribution at `slides/feature-importance/slides02-fi-pimp.tex:45` and `slides/feature-importance/slides02-fi-pimp.tex:61`.
- Deleted feature-selection terminology comments only where the same `PELLET2008` notes remain near the active interpretation-goals slide in `slides/feature-importance/slides01-fi-intro.tex:313`.
- No deleted provenance or attribution lines were left without preservation.

<details>
<summary><strong>slides/feature-importance/slides01-fi-intro.tex</strong>: 11 removed, 2 kept</summary>

Evidence scope: current file **yes**, sibling files **no**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | original `slides01-fi-intro.tex:52-59` | Alternative motivation bullets and loss-based definition note. | `slides01-fi-intro.tex:41-57`; active Motivation slide states the same contrast and definition. | Same teaching point in active bullets. | `GREENWELL2020` already active nearby. |
| 2 | original `slides01-fi-intro.tex:80-84` | Old centered bike PFI/PDP figure layout. | `slides01-fi-intro.tex:59-76`; active Example slide uses the same figures. | Same visual example in current layout. | No provenance issue. |
| 3 | original `slides01-fi-intro.tex:87-98` | Old feature-importance scheme frame. | `slides01-fi-intro.tex:79-101`; active Differences slide covers removal/perturbation and performance comparison. | Same method scheme, now more specific. | No provenance issue. |
| 4 | original `slides01-fi-intro.tex:117-129` | Old LOCO/LOCI/SAGE comparison labels. | `slides01-fi-intro.tex:91-99`; active bullets cover the same comparison strategies. | Same taxonomy with cleaner wording. | No provenance issue. |
| 5 | original `slides01-fi-intro.tex:144-156` | Commented causal-goal detail under the overview slide. | `slides01-fi-intro.tex:299-309`; active later slide includes the symptom/disease example. | Same causal-vs-ground-truth warning. | No provenance issue. |
| 6 | original `slides01-fi-intro.tex:223-247` | Old interpretation-goals frame. | `slides01-fi-intro.tex:299-328`; active final goals slide covers all three questions. | Same three interpretation goals and examples. | `PELLET2008` terminology remains near active slide. |
| 7 | original `slides01-fi-intro.tex:257-297` | Duplicate TikZ copy for prediction-relevant-information example. | `slides01-fi-intro.tex:182-238`; active frame has the same diagram and explanation. | Same diagram role, active version is used. | No provenance issue. |
| 8 | original `slides01-fi-intro.tex:396-436` | Duplicate TikZ copy for requires-access example. | `slides01-fi-intro.tex:241-297`; active frame has the same diagram and explanation. | Same diagram role, active version is used. | No provenance issue. |
| 9 | original `slides01-fi-intro.tex:486-531` | Old overlay version of interpretation-goals frame. | `slides01-fi-intro.tex:299-328`; active final goals slide covers the same content. | Same goals, definitions, and random-forest note. | `PELLET2008` terminology remains near active slide. |
| 10 | original `slides01-fi-intro.tex:533-547` | Old summary frame proving distinctness by examples. | `slides01-fi-intro.tex:120-297`; active example frames demonstrate the distinctions. | Same examples now expanded as active slides. | No provenance issue. |
| 11 | original `slides01-fi-intro.tex:551-593` | Old causal-for-prediction TikZ frame. | `slides01-fi-intro.tex:120-177`; active causal example uses the same pedagogical setup. | Same overfitting/noise teaching point. | No provenance issue. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `slides01-fi-intro.tex:304-328` | Commented feature-selection terminology and alternative phrasings. | Keeps terminology/reference notes not shown actively. |
| 2 | scattered active TikZ comments | Optional compliance/test diagram fragments. | Unclear whether they are obsolete or reserved diagram variants. |

</details>

<details>
<summary><strong>slides/feature-importance/slides02-fi-pfi.tex</strong>: 11 removed, 3 kept</summary>

Evidence scope: current file **yes**, sibling files **yes**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | original `slides02-fi-pfi.tex:43-65` | Legacy PFI idea frame. | `slides02-fi-pfi.tex:46-64`; active Motivation for PFI slide covers fixed model, perturbation, and marginal permutation. | Same introductory idea. | Fisher et al. source restored at `slides02-fi-pfi.tex:43`. |
| 2 | original `slides02-fi-pfi.tex:74-116` | Old solution and population-PFI formula alternatives. | `slides02-fi-pfi.tex:46-64`; active slide has the same formula and perturbation explanation. | Same definition and rationale. | `BREIMAN2001` active at `slides02-fi-pfi.tex:67`. |
| 3 | original `slides02-fi-pfi.tex:125,139` | Old risk and subset-note phrasings. | `slides02-fi-pfi.tex:70-83`; active estimator slide defines risk and subset note. | Same notation support. | No provenance issue. |
| 4 | original `slides02-fi-pfi.tex:145-175` | Old sample-estimator frame. | `slides02-fi-pfi.tex:67-85`; active estimator slide replaces it. | Same sample estimator and example. | Obsolete TODO removed with redundant block. |
| 5 | original `slides02-fi-pfi.tex:178-224,254-275` | Old PFI demo columns and aggregation overlays. | `slides02-fi-pfi.tex:92-117`; active demo slide covers perturbation, prediction, and aggregation. | Same stepwise demo. | No provenance issue. |
| 6 | original `slides02-fi-pfi.tex:306-326` | Old extrapolation example prose and figure block. | `slides02-fi-pfi.tex:145-164`; active extrapolation slide restates the DGP and conclusion. | Same example and takeaway. | No provenance issue. |
| 7 | original `slides02-fi-pfi.tex:380-395` | Old train-vs-test captions and why text. | `slides02-fi-pfi.tex:188-208`; active frame states the observation and reason. | Same train/test lesson. | No provenance issue. |
| 8 | original `slides02-fi-pfi.tex:405` | Contraposition note. | `slides02-fi-pfi.tex:215-218`; active implication states the converse does not hold. | Same caveat. | No provenance issue. |
| 9 | original `slides02-fi-pfi.tex:421-441` | Commented PIMP overview frame. | `slides02-fi-pimp.tex:45-63`; active sibling PIMP slide covers it. | PIMP content moved to dedicated file. | Altmann attribution already kept at `slides02-fi-pimp.tex:61`. |
| 10 | original `slides02-fi-pfi.tex:443-461` | Commented PIMP algorithm frame. | `slides02-fi-pimp.tex:67-92`; active sibling algorithm slide covers it. | Same algorithm. | No provenance issue. |
| 11 | original `slides02-fi-pfi.tex:464-498` | Commented PIMP example and multiple-testing frames. | `slides02-fi-pimp.tex:96-129`; `slides02-fi-pimp.tex:121-137`. | Same example and multiple-testing digression in sibling file. | ROMANO attribution preserved in sibling. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `slides02-fi-pfi.tex:124` | Weekday contribution comment. | Adds a small detail not active in the bike example. |
| 2 | `slides02-fi-pfi.tex:188` | Commented one-sentence train/test data setup. | Inline source note attached to active example. |
| 3 | `slides02-fi-pfi.tex:136,139,223` | Short inline explanatory comments. | Source-adjacent clarifications, not standalone slide blocks. |

</details>

<details>
<summary><strong>slides/feature-importance/slides02-fi-pimp.tex</strong>: 4 removed, 2 kept</summary>

Evidence scope: current file **yes**, sibling files **no**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | original `slides02-fi-pimp.tex:52-64` | Alternative PIMP motivation and p-value phrasings. | `slides02-fi-pimp.tex:50-57`; active bullets cover randomness, null distribution, and tail probability. | Same motivation and computation. | No provenance issue. |
| 2 | original `slides02-fi-pimp.tex:88` | Non-parametric tail-probability hint. | `slides02-fi-pimp.tex:84-87`; active nested bullets give both parametric and non-parametric formulas. | Same algorithm detail. | No provenance issue. |
| 3 | original `slides02-fi-pimp.tex:114-118,131` | Old recall text and redundant prediction-relevance note. | `slides02-fi-pimp.tex:104-116`; active recall and bullets cover the same example. | Same DGP and conclusion. | No provenance issue. |
| 4 | original `slides02-fi-pimp.tex:135-147` | Old multiple-testing frame. | `slides02-fi-pimp.tex:121-137`; active frame covers FWE and Bonferroni correction. | Same digression, active wording is cleaner. | ROMANO full reference moved to `slides02-fi-pimp.tex:122`. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `slides02-fi-pimp.tex:49` | Comment about many-category bias. | Distinct caveat not active. |
| 2 | `slides02-fi-pimp.tex:109` | Long commented figure caption. | Contains extra interpretive detail about the plotted null distribution. |

</details>

<details>
<summary><strong>slides/feature-importance/slides03-fi-cfi.tex</strong>: 5 removed, 1 kept</summary>

Evidence scope: current file **yes**, sibling files **yes**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | original `slides03-fi-cfi.tex:56,76-95` | Old conditional-sampling formula and example labels. | `slides03-fi-cfi.tex:51-81`; active CFI Motivation slide covers joint preservation and marginal/conditional density labels. | Same sampling idea and figure interpretation. | `MOLNAR2020` active at `slides03-fi-cfi.tex:70`. |
| 2 | original `slides03-fi-cfi.tex:110-125` | Old PFI extrapolation recap. | `slides03-fi-cfi.tex:87-103`; active recap slide covers the same DGP and PFI conclusion. | Same PFI recap. | No provenance issue. |
| 3 | original `slides03-fi-cfi.tex:160,165` | Old CFI definition color/notation alternatives. | `slides03-fi-cfi.tex:128-136`; active CFI definition covers the same notation. | Same definition support. | No provenance issue. |
| 4 | original `slides03-fi-cfi.tex:231,242,260,265` | Old implication shorthand statements. | `slides03-fi-cfi.tex:188-229`; active implication slides cover those statements. | Same CFI implication claims. | `KNIGET2020` active at `slides03-fi-cfi.tex:188`. |
| 5 | original `slides03-fi-cfi.tex:281-305` | Old PFI-vs-CFI comparison alternatives. | `slides03-fi-cfi.tex:237-260`; active comparison frame covers the same example and conclusion. | Same comparison and takeaway. | No provenance issue. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `slides03-fi-cfi.tex:107-123` | Commented proof that conditional sampling preserves the joint plus caveat about `P(x,y)`. | Proof-level detail and caveat are not fully active. |

</details>

<details>
<summary><strong>slides/feature-importance/slides04-fi-sage.tex</strong>: 6 removed, 1 kept</summary>

Evidence scope: current file **yes**, sibling files **no**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | original `slides04-fi-sage.tex:75,86-99` | Old SAGE idea phrasings. | `slides04-fi-sage.tex:74-91`; active SAGE Idea slide covers game, players, payoff, and Shapley link. | Same motivation. | `COVERT2020`, `CASALICCHIO2018`, and `COHEN2007` remain active. |
| 2 | original `slides04-fi-sage.tex:112-114` | Old value-function explanatory comments. | `slides04-fi-sage.tex:98-122`; active Value function slide states the same risk reduction interpretation. | Same definition support. | `NEURIPS2020_c7bf0b7c` comment preserved. |
| 3 | original `slides04-fi-sage.tex:140-153` | Old sampling-interpretation comments. | `slides04-fi-sage.tex:124-141`; active slide states marginal and conditional interpretations. | Same interpretation. | No provenance issue. |
| 4 | original `slides04-fi-sage.tex:166` | Old example setup sentence. | `slides04-fi-sage.tex:150-169`; active example bullets cover DGP, DAG, and fitted LM. | Same setup. | No provenance issue. |
| 5 | original `slides04-fi-sage.tex:199-200` | Old feature-ordering notation. | `slides04-fi-sage.tex:175-188`; active slide defines contribution via `\Stau`. | Same notation concept. | No provenance issue. |
| 6 | original `slides04-fi-sage.tex:288-289` | Duplicate conditional-SAGE implication wording. | `slides04-fi-sage.tex:264-269`; active bullets cover independence not implying zero contribution. | Same caveat. | No provenance issue. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `slides04-fi-sage.tex:143` | Omitted-variable-bias / M-plot side note. | Distinct pointer not active. |

</details>

<details>
<summary><strong>slides/feature-importance/slides05-fi-loco.tex</strong>: 5 removed, 2 kept</summary>

Evidence scope: current file **yes**, sibling files **yes**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | original `slides05-fi-loco.tex:43-55` | Old reminder frame with feature-importance scheme and LOCO idea. | `slides01-fi-intro.tex:79-101`; `slides05-fi-loco.tex:43-64`. | Scheme covered in intro and LOCO idea active here. | No provenance issue. |
| 2 | original `slides05-fi-loco.tex:60,63` | Old LOCO idea/definition phrasings. | `slides05-fi-loco.tex:43-64`; active LOCO slide covers idea and definition. | Same definition. | `LEI2018` and `TIBSHIRANI2018` active at `slides05-fi-loco.tex:43`. |
| 3 | original `slides05-fi-loco.tex:87-89` | Old bike-sharing caption and interpretation. | `slides05-fi-loco.tex:69-78`; active bullets cover model, data split, MSE, and temperature result. | Same example interpretation. | No provenance issue. |
| 4 | original `slides05-fi-loco.tex:132-160` | Old correlated-example setup, TikZ DAG, and stale coefficient text. | `slides05-fi-loco.tex:103-127`; active frame covers DGP, figures, and current fitted LM. | Same example; stale coefficient superseded. | No provenance issue. |
| 5 | original `slides05-fi-loco.tex:171,188` | Old correlated-feature and learner-vs-model phrasings. | `slides05-fi-loco.tex:126-145`; active text covers both takeaways. | Same conclusions. | No provenance issue. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `slides05-fi-loco.tex:104-107` | R-style data-generation comments. | Source note for reproducing the example. |
| 2 | `slides05-fi-loco.tex:41,133` | TODO comments. | Maintenance metadata, not redundant slide content. |

</details>
