### PR TITLE
refactor (slides): remove redundant comments on shapley slides

### DIFF
--- a/slides/shapley/slides01-shapley-game-theory.tex
+++ b/slides/shapley/slides01-shapley-game-theory.tex
@@ -75,23 +75,6 @@ figure/Shapley_1.png
 % \end{frame}
 
 
-% \begin{frame}{Cooperative Games in Game Theory \furtherreading{SHAPLEY1951}}
-% \begin{itemize}[<+->]
-% %\itemsep1em
-%   \item Game theory: Study of strategic games between players, where \enquote{game} refers to interactions between \enquote{players} involving quantifiable gains and losses
-%   \item Cooperative games: For all possible players $P = \{1, \hdots, p\}$, each subset of players $\SsubP$ forms a coalition -- each coalition $S$ achieves a certain payout
-%   %\item A value function $v(S): 2^{|P|}\mapsto \R$ describes the payout (or gain) achieved by any coalition $S \subseteq P$
-%   \item Value function $v: 2^P\mapsto \R$ maps all $2^{|P|}$ possible coalitions to their payout/gain
-%   \item $v(S)$ denotes the payout of coalition $S \subseteq P$; payout of empty coalition must be 0 ($v(\emptyset) = 0$). $v(P)$ denotes the total achievable payout.
-%   %\\
-%   %\textit{Note:} The payout or gain not necessarily has a positive meaning. In the example of the prisoner's dilemma, the payout is the total number of years spent in prison.
-%   \item We denote by $\phi_j$ the individual payout of player $j \in P$, referred to later as the Shapley value. 
-%   \item As some players may contribute differently, we want to fairly divide the total achievable payout $v(P)$ among the players according to a player's individual contribution
-
-%   %\item What would be properties of a fair distribution of the payout?
-% \end{itemize}
-% \end{frame}
-
 \begin{framev}[align=top]{Cooperative Games in Game Theory \furtherreading{SHAPLEY1951}}
 \begin{itemizeM}
 \item \textbf{Game theory:} Studies strategic interactions among "players" (who act to maximize their utility), where outcomes depend on collective behavior
@@ -152,12 +135,6 @@ $\leadsto$ Assign each player $j \in P$ a fair share $\phi_j$ (\textbf{Shapley v
 \end{footnotesize}
 \spacer[0]
 }
-% \begin{itemize}
-% \item No interactions: player contributions are additive for any coalition $S$ 
-% \item Each player adds same value in all $S$
-% \item Fair payout = average marginal contrib.
-% \item Total payout splits exactly by individual contributions: \colorcircle{playerblue}{white}{3} = $\tfrac{1}{2}$, \colorcircle{playeryellow}{white}{2} = $\tfrac{1}{3}$, \colorcircle{playerred}{white}{1} = $\tfrac{1}{6}$ 
-% \end{itemize}
 \only<3>{
 \begin{itemizeM}
 \item \textbf{No interactions:} Each player contributes same fixed value to each coalition\\
@@ -184,42 +161,6 @@ $}
 
 
 
-
-% \begin{frame}{Cooperative Games - No Interactions}
-% \scriptsize
-% \begin{tabular}{ll|ll|l}
-% \toprule
-% Player & Coalition $S$ & $v(S)$ & $v(S \cup \{j\})$ & $\Delta (j, S)$ \\
-% \hline
-% \colorcircle{playerred}{white}{1}& $\emptyset$ & 0 & 1000 & 1000 \\
-% \colorcircle{playerred}{white}{1}& $\{\colorcircle{playeryellow}{white}{2}\}$ & 2000 & 3000 & 1000 \\
-% \colorcircle{playerred}{white}{1}& $\{\colorcircle{playerblue}{white}{3}\}$ & 3000 & 4000 & 1000 \\
-% \colorcircle{playerred}{white}{1} & $\{\colorcircle{playeryellow}{white}{2},\colorcircle{playerblue}{white}{3}\}$ & 5000 & 6000 & 1000 \\
-% \hline
-% \colorcircle{playeryellow}{white}{2} & $\emptyset$ & 0 & 2000 & 2000 \\
-% \colorcircle{playeryellow}{white}{2} & $\{\colorcircle{playerred}{white}{1}\}$ & 1000 & 3000 & 2000 \\
-% \colorcircle{playeryellow}{white}{2} & $\{\colorcircle{playerblue}{white}{3}\}$ & 3000 & 5000 & 2000 \\
-% \colorcircle{playeryellow}{white}{2} & $\{\colorcircle{playerred}{white}{1},\colorcircle{playerblue}{white}{3}\}$ & 4000 & 6000 & 2000 \\
-% \hline
-% \colorcircle{playerblue}{white}{3} & $\emptyset$ & 0 & 3000 & 3000 \\
-% \colorcircle{playerblue}{white}{3} & $\{\colorcircle{playerred}{white}{1}\}$ & 1000 & 4000 & 3000 \\
-% \colorcircle{playerblue}{white}{3} & $\{\colorcircle{playeryellow}{white}{2}\}$ & 2000 & 5000 & 3000 \\
-% \colorcircle{playerblue}{white}{3} & $\{\colorcircle{playerred}{white}{1},\colorcircle{playeryellow}{white}{2}\}$ & 3000 & 6000 & 3000 \\
-% \bottomrule
-% \end{tabular}
-% \end{frame}
-
-
-
-% \begin{frame}{Cooperative Games with Interactions}
-% \begin{center}
-% \includegraphics<1>[page=3, width = 0.8\textwidth]{figure/Shapley.pdf}
-
-% \only<1>{$\Rightarrow$ Unclear how to fairly distribute payouts when players interact}
-
-% \includegraphics<2>[page=4]{figure/Shapley.pdf}
-% \end{center}
-% \end{frame}
 
 \begin{framev}[align=top]{Cooperative Games - Interactions}
 %\begin{center}
@@ -262,10 +203,6 @@ $\Rightarrow$ Unclear how to fairly distribute payouts when players interact
 \end{footnotesize}
 \spacer[0]
 }
-% \begin{itemize}
-% \item Marginal contributions differ across coalitions
-% \item What is a fair payout here?
-% \end{itemize}
 \pause
 \begin{itemizeM}
 \item \textbf{With interactions:} Players contribute differently depending on coalition\\
@@ -309,25 +246,10 @@ $\leadsto$ Shapley values fairly average over all possible joining orders
 \item \textbf{Order sensitivity:} A player's marginal contribution depends on when they join $S$
 %\textbf{Overlapping skills:} Different join orders lead to different marginal contributions
 \item \textbf{Shapley value:} Averages each player’s contribution over all possible join orders\\
-% OLD
-% \begin{itemize}
-%   \item[$\leadsto$] Resolves redundancy (e.g., \colorcircle{playerblue}{white}{3}’s contribution/skill overlaps with \colorcircle{playeryellow}{white}{2}’s)
-%   \item[$\leadsto$] Accounts for order sensitivity (e.g., \colorcircle{playerred}{white}{1} brings more value if added last)
-%   \item[$\leadsto$] Ensures fairness (no player is advantaged or penalized by order of joining)% of evaluation.
-% \end{itemize}
-% NEW (removes itemize)
 $\leadsto$ Resolves redundancy (e.g., \colorcircle{playerblue}{white}{3}’s contribution/skill overlaps with \colorcircle{playeryellow}{white}{2}’s)\\
 $\leadsto$ Accounts for order sensitivity (e.g., \colorcircle{playerred}{white}{1} brings more value if added last)\\
 $\leadsto$ Ensures fairness (order of joining gives no advantage/disadvantage)
 \end{itemizeM}
-% \begin{itemize}
-%   \item \textbf{Order sensitivity:} A player's marginal contribution depends on when they join $S$
-%   \item \textbf{Shapley value:} Averages each player’s contribution over all possible join orders
-%   \begin{itemize}
-%     \item[$\leadsto$] Resolves redundancy (e.g., \colorcircle{playerblue}{white}{3} adds less if \colorcircle{playerred}{white}{1} is present)
-%     \item[$\leadsto$] Corrects for join-time advantage/disadvantage
-%   \end{itemize}
-% \end{itemize}
 \end{framev}
 
 
@@ -363,80 +285,12 @@ $\leadsto$ Ensures fairness (order of joining gives no advantage/disadvantage)
 
 
 
-% \begin{frame}{Cooperative Games with Interactions}
-% \textbf{Question:} What is a fair payout for a specific player (e.g., \enquote{yellow})?\\
-% \textbf{Idea:} Compute that player's marginal contribution across all coalitions
-
-% \begin{columns}[T, totalwidth=\linewidth]
-% \begin{column}{0.53\textwidth}
-% \includegraphics[page=4, trim=150px 120px 164px 10px, clip]{figure/Shapley.pdf}
-
-% %\includegraphics[page=4, trim=170px 15px 200px 305px, clip, width = 0.8\textwidth]{figure/Shapley.pdf}
-% %\scriptsize
-% %\hspace{-100px}
-% \begin{itemize}
-% \itemsep0em
-% %\addtolength{\itemindent}{-1cm}
-%     \item Compute coalition payouts without \enquote{yellow} and after adding \enquote{yellow}
-%     \item Take the difference to obtain marginal contribution of  \enquote{yellow}
-%     \item Average these contributions across all coalitions using weighted aggregation
-% \end{itemize}
-% \end{column}
-% \begin{column}{0.47\textwidth}
-% \pause
-% \textbf{Note:} Weights depend on coalition size; weight is highest for small and large $|S|$ and lowest in the middle
-% % \textbf{Note:} Each contribution is weighted by number of possible orders of its coalition\\
-% % $\leadsto$ More players in $S$ $\Rightarrow$ more ways to order players before adding \enquote{yellow}
-% %The more players in a coalition, the more possible orderings inside the coalition %more possibilities of ordering the players inside the coalition
-% %\includegraphics[page=15, width = \textwidth, trim=122px 10px 82px 10px, clip]{figure/Shapley.pdf}
-% \includegraphics[page=7, width = \textwidth, trim=230px 0px 25px 15px, clip]{figure/Shapley.pdf}
-% \end{column}
-% \end{columns}
-% \end{frame}
-
-% \begin{frame}{Cooperative Games without Interactions}
-% \begin{figure}
-%     \centering
-%     \includegraphics{figure/Shapley_1.png}
-% \end{figure}
-% \end{frame}
-
-% \begin{frame}{Fair Payouts are Trivial Without Interactions}
-% \begin{figure}
-%     \centering
-%     \includegraphics{figure/Shapley_2.png}
-% \end{figure}
-
-% \end{frame}
-% \begin{frame}{Cooperative Games with Interactions}
-% \begin{figure}
-%     \centering
-%     \includegraphics{figure/Shapley_3.png}
-% \end{figure}
-%\end{frame}
-
-% \begin{frame}{What is a fair payout for player \enquote{yellow}?}
-
-% \begin{figure}
-%     \centering
-%     \includegraphics{figure/Shapley_4.png}
-% \end{figure}
-
-% \end{frame}
-
-
-
 \begin{framev}[align=top]{Shapley Value - Order Definition}
-%The Shapley value was introduced as summation over sets $\SsubPnoj$, but it can be equivalently defined as a summation of all orders of players: 
-%(which explains where the factor $\frac{|S|!(|P| - |S| - 1)!}{|P|!}$ comes from):
 \textbf{The Shapley value order definition} averages the marginal contribution of a player across all possible player orderings:
 $$\phi_j = \frac{1}{|P|!} \sum_{\tau \in \Pi} (v(\Stau \cup \{j\}) - v(\Stau))$$
 \begin{itemizeM}
 \item<+-> $\Pi$: Set of all permutations (joining orders) of the players -- $|P|!$ in total
-%\item Recall the order definition: 
 \item<+-> $\Stau$: Set of players before $j$ joins, for each ordering $\tau = (\tau^{(1)}, \dots, \tau^{(p)})$\\
-%Set of players before player $j$ in order $\tau = (\tau^{(1)}, \dots, \tau^{(p)})$  where $\tau^{(i)}$ is $i$-th element \\ % j, \dots, 
-%\only<3>{\textbf{For $P = \{1,2,3\}$:} $\Pi = \{({\color{red} 1,2},3), (1,3,2), ({\color{red} 2,1},3), (2,3,1), (3,1,2), (3,2,1)\}$  \\}%
 \only<1->{\textbf{E.g.:}
 {\footnotesize
 $\Pi = \{
@@ -448,29 +302,15 @@ $\Pi = \{
 (\colorcircle{playerblue}{white}{3},\colorcircle{playeryellow}{white}{2},\colorcircle{playerred}{white}{1})
 \}$
 }
-%$\Pi = \{(1,2,3), (1,3,2), (2,1,3), (2,3,1), (3,1,2), (3,2,1)\}$
 \\}%
 \phantom{$\Rightarrow$} $\leadsto$ For joining order $\tau = (\colorcircle{playeryellow}{white}{2},\colorcircle{playerred}{white}{1},\colorcircle{playerblue}{white}{3})$ and player $j=\colorcircle{playerblue}{white}{3}$ $\Rightarrow$ $\Stau = \{\colorcircle{playeryellow}{white}{2},\colorcircle{playerred}{white}{1}\}$\\
 \phantom{$\Rightarrow$} $\leadsto$ For joining order $\tau = (\colorcircle{playerblue}{white}{3},\colorcircle{playerred}{white}{1},\colorcircle{playeryellow}{white}{2})$ and player $j=\colorcircle{playerred}{white}{1}$ $\Rightarrow$ $\Stau = \{\colorcircle{playerblue}{white}{3}\}$
-%\phantom{$\Rightarrow$} $\leadsto$ For joining order $\tau = (3,1,2)$ and player of interest $j=3$ $\Rightarrow$ $\Stau = \emptyset$
-%\item In order definition, we sum the marginal contribution twice for orders that yield set $S = \{1,2\}$\\
-%\item \textbf{Note:} Marginal contribution of orders that yield set {\color{red} $S = \{1,2\}$} is summed twice\\
-%$\leadsto$ In set definition, it has the weight $\tfrac{2! (3 - 2 - 1)!}{3!} = \tfrac{2 \cdot 0!}{6} = \tfrac{2}{6}$
-%\item<3-> \textbf{Note:} Subsets may appear in multiple orderings $\Rightarrow$ duplicated elements in sum\\
-%$\leadsto$ For \(j = 3\), joining order \((1,2,3)\) and \((2,1,3)\) yields subset \({\color{red} \Stau= \{1,2\}}\) %and are included separately in the sum
 \item<3-> Order definition allows to approximate Shapley values by sampling permutations\\
 $\leadsto$ Sample a fixed $M \ll |P|!$ random permutations and average:
 $$
 \phi_j \approx \frac{1}{M} \sum_{\tau \in \Pi_M} \left(v(\Stau \cup \{j\}) - v(\Stau)\right)
 $$
 where $\Pi_M \subset \Pi$ is the random sample of $M$ player orderings
-% Order definition allows to approximate Shapley values by sampling permutations \\
-% $\leadsto$ randomly sample a fixed number of $M$ permutations and average them:
-% %to approximate the Shapley values
-% %instead of producing all $|P|!$ permutations, a fixed number of $M< |P|!$ permutations can be sampled and averaged to approximate the Shapley values
-% $$\phi_j = \frac{1}{M} \sum_{\tau \in \Pi_M} (v(\Stau \cup \{j\}) - v(\Stau))$$
-%   where $\Pi_M \subset \Pi$ is a random subset of $\Pi$ containing only $M$ orders of players\\
-%   %$\leadsto$ $\Stau$: For permutation $\tau$, the set of players before player $j$ in order $\tau$ 
 \end{itemizeM}
 \end{framev}
 
@@ -495,10 +335,6 @@ $\{
 $\leadsto$ In $\underline{\color{black}(\colorcircle{playerred}{white}{1},\colorcircle{playeryellow}{white}{2},\colorcircle{playerblue}{white}{3})}$ and $\underline{\color{black}(\colorcircle{playeryellow}{white}{2},\colorcircle{playerred}{white}{1},\colorcircle{playerblue}{white}{3})}$, player \colorcircle{playerblue}{white}{3} joins after coal. ${\color{black} \Stau = \{\colorcircle{playerred}{white}{1},\colorcircle{playeryellow}{white}{2}\}}$
 \\
 $\Rightarrow$ Marginal contribution $v(\{\colorcircle{playerred}{white}{1},\colorcircle{playeryellow}{white}{2},\colorcircle{playerblue}{white}{3}\}) - v(\{\colorcircle{playerred}{white}{1},\colorcircle{playeryellow}{white}{2}\})$ occurs twice in $\phi_j$
-% \item<1->  \textbf{Note:} Subsets may appear in multiple orderings $\Rightarrow$ duplicated elements in sum\\
-%   $\leadsto$ For \(j = 3\), joining order \((1,2,3)\) and \((2,1,3)\) yields subset \({\color{red} \Stau= \{1,2\}}\) %and are included separately in the sum
-%   %\item<1-> Order and set definition are equivalent
-%   \textbf{For $P = \{1,2,3\}$:} $\Pi = \{({\color{red} 1,2},3), (1,3,2), ({\color{red} 2,1},3), (2,3,1), (3,1,2), (3,2,1)\}$  
 \item<1-> \textbf{Reason:} Each subset $S$ appears in $|S|!(|P| - |S| - 1)!$ orderings before $j$ joins\\
 %The number of orders which yield the same coalition $S$ is $|S|!(|P| - |S| - 1)!$\\
 $\Rightarrow$ There are $|S|!$ possible orders of players within coalition $S$\\
@@ -522,11 +358,6 @@ $\tau^{(1)}$ & \ldots & $\tau^{(|S|)}$ & $\tau^{(|S| + 1)}$ & $\tau^{(|S| + 2)}$
 
 % How to weight differences in payout
 \begin{framev}[align=top]{From Order Definition to Set Definition}
-%   \begin{center}
-%   \only<1>{\includegraphics{figure/Shapley_7.png}}%
-%   \only<2>{ \includegraphics{figure/Shapley_8.png}}%
-%   \only<3>{ \includegraphics{figure/Shapley_9.png}}%
-%   \end{center}
 \begin{center}
 \includegraphics<1>[page=5,width=0.8\textwidth]{figure/Shapley.pdf}%
 \includegraphics<2>[page=6,width=0.8\textwidth]{figure/Shapley.pdf}%
@@ -571,133 +402,8 @@ $\Rightarrow$ many permutations $\Rightarrow$ high weight
 $\Rightarrow$ lower weight
 \item Result: U-shaped weight distribution %over \( |S| \) forms a 
 \end{itemizeM}
-% \small
-% \begin{itemize}
-%   \item Joining early yields a larger weight, because it is harder to contribute when the coalition is still small.
-%   \item Joining last leads to a high weight, since it is challenging to add value to an almost-complete coalition.
-%   \item Being in the middle results in a lower weight.
-% \end{itemize}
 }
 \end{framev}
-
-% \begin{frame}{Shapley Value - Set definition}
-
-% This idea refers to the \textbf{Shapley value} which assigns a payout value to each player according to its marginal contribution in all possible coalitions.
-% % which  provide a unique solution for the payout attribution problem.
-  
-% \begin{itemize}[<+->]
-%   %\item Shapley values were proposed by Lloyd Shapley in 1951 for cooperative games (game theory).
-%   % given axioms of efficiency, symmetry, dummy and additivity.
-%   %\item The \textbf{Shapley value} of player $j$ assigns a payout value according to the marginal contribution of each player in all possible coalitions\\
-%   %$\leadsto$ %To compute the Shapley payout for a player $j$, we 
-%   \item Let $v(\Scupj) - v(S)$ be the marginal contribution of player $j$ to coalition $S$\\
-%   $\leadsto$ measures how much a player $j$ increases the value of a coalition $S$
-%   \item Average marginal contributions for all possible coalitions $\SsubPnoj$ \\
-%   $\leadsto$ order of how players join the coalition matters $\Rightarrow$ different weights depending on size of $S$\\
-%   %$\leadsto$ marginal contributions are weighted differently
-%   \item Shapley value via \textbf{set definition} (weighting via multinomial coefficient): 
-%   $$\phi_j = \sum_{\SsubPnoj} \frac{|S|!(|P| - |S| - 1)!}{|P|!}(v(\Scupj) - v(S))$$
-    
-%   %\item Shapley values are the \texthetit{only} solution for the attribution with the specified axioms.
-% %   \item Equivalent Shapley value definition via \textbf{orders}: $$\phi_j = \frac{1}{|P|!} \sum_{\tau \in \Pi} (v(\Stau \cup \{j\}) - v(\Stau))$$
-% %     $\leadsto$ $\Pi$: All possible $|P|!$ orders/permutations of players\\
-% %     $\leadsto$ $\Stau$: The set of players before player $j$ in order $\tau = (\tau^{(1)}, \dots, \tau^{(p)})$ % j, \dots, 
-% \end{itemize}
-
-% \end{frame}
-
-% \begin{frame}{Shapley Value - Multinomial coefficient}
-% \[
-% \frac{|S|!(|P| - |S| - 1)!}{|P|!}
-% \]
-%   The coefficient tells us the probability that, when randomly arranging all $|P|$ players, the exact set $S$ appears before player $j$, and the remaining players appear afterward.
-% \centerline{
-%   \begin{tabular}{|c|c|c|c|c|c|c|}
-%     \multicolumn{3}{c}{\enspace\raisebox{-3.3ex}[0pt][2.6ex]{$ \overbrace{\vphantom{-}\hspace{9em}}^{|S|! \text{ permutations}}$}} &
-%     \multicolumn{1}{c}{\enspace\raisebox{-3.3ex}[0pt][1.1ex]{$ \overbrace{\vphantom{-}\hspace{3em}}^{\text{player } j}$}} &
-%     \multicolumn{3}{c}{\enspace\raisebox{-3.3ex}[0pt][2.6ex]{$ \overbrace{\vphantom{-}\hspace{9em}}^{(|P| - |S| - 1)! \text{ permutations}}$}}\\
-%     \hline
-%     $\tau^{(1)}$ & \ldots & $\tau^{(|S|)}$ & $\tau^{(|S| + 1)}$ & $\tau^{(|S| + 2)}$ & \ldots & $\tau^{(|P|)}$ \\
-%     \hline
-%   \end{tabular}}
-
-% \pause
-% \begin{figure}[h!]
-%     \centering
-%     % code for the figure (https://colab.research.google.com/drive/1kOEZkT2jgjgaK9OFRbnfx8-_C8z7t8v3?usp=sharing)
-%     \begin{minipage}[b]{0.4\textwidth}
-%         \includegraphics[width=\textwidth]{figure_man/multinom_coef_over_size.png}
-%     \end{minipage}
-%     \hspace{0.05\textwidth} 
-%     \begin{minipage}[b]{0.5\textwidth}
-%         \small
-%         \begin{itemize}
-%           \item Joining early yields a larger weight, because it is harder to contribute when the coalition is still small.
-%           \item Joining last leads to a high weight, since it is challenging to add value to an almost-complete coalition.
-%           \item Being in the middle results in a lower weight.
-%         \end{itemize}
-%     \end{minipage}
-% \end{figure}
-% \end{frame}
-
-% \begin{frame}{How to Weight Differences in Payout?}
-
-% \begin{itemize}
-%     %\itemsep2em
-%     %\item Form a coalition one player at a time -- each player receives its contribution to the total payout, i.e., the increase in total payout when a player joins a coalition
-%     % \item The Shapley value is the players' average contribution over all possible formations of coalitions\\
-%     % $\leadsto$ order of how players join the coalition matters\\
-%     % $\leadsto$ marginal contributions are weighted
-%     %\item Each contribution is weighted proportionally to the number of possible orders of its coalition -- the more players in a coalition, the more possibilities of ordering the players inside the coalition
-%     \item Shapley value via \textbf{set definition} (weighting via multinomial coefficient): 
-%     $$\phi_j = \sum_{\SsubPnoj} \frac{|S|!(|P| - |S| - 1)!}{|P|!}(v(\Scupj) - v(S))$$
-%     \item Shapley value via \textbf{order definition}: $$\phi_j = \frac{1}{|P|!} \sum_{\tau \in \Pi} (v(\Stau \cup \{j\}) - v(\Stau))$$
-    
-%     with $\Pi$ being all possible $|P|!$ orders/permutations of players and $\Stau$ being the set of players before player $j$ in order $\tau$ 
-    
-%     %$\phi_j = \frac{1}{|P|!} \sum_{\tau \in \Pi} (v(S_j(\tau) \cup \{j\}) - v(S_j(\tau)))$
-% \end{itemize}
-
-% \end{frame}
-
-% \begin{frame}{How to Weight Differences in Payout?}
-
-% \begin{figure}
-%     \centering
-%     \includegraphics{figure/Shapley_5.png}
-% \end{figure}
-
-% \end{frame}
-
-
-
-% \begin{frame}{From Game Theory To Machine Learning}
-
-% \begin{figure}
-%     \centering
-%     \includegraphics{figure/Shapley_5.png}
-% \end{figure}
-
-% \end{frame}
-
-% \begin{frame}{Shapley Values}
-
-%   Shapley values provide a unique solution to the attribution problem while satisfying all axioms:
-%     \vspace{0.25cm}
-% \begin{itemize}
-%   \itemsep1em
-%   \item Shapley values were proposed by Lloyd Shapley in 1951.
-%   \item The Shapley value assigns a value to each player according to the marginal contribution of each player in all possible coalitions.
-%   \item $\phi_j = \sum_{\SsubPnoj} \frac{|S|!(|P| - |S| - 1)!}{|P|!}(v(\Scupj) - v(S))$
-%   \item $v(\Scupj) - v(S)$ is the marginal contribution of player $j$ to coalition $S$.
-%   \item To compute the Shapley payout for a player, we average, for all possible coalitions, how much the player would increase the value of the coalition (=marginal contribution).
-%   \item Shapley values are the \textit{only} solution for the attribution with the specified axioms.
-% \end{itemize}
-
-% \footnote{Shapley, Lloyd S. (August 21, 1951). "Notes on the n-Person Game -- II: The Value of an n-Person Game" (PDF). Santa Monica, Calif.: RAND Corporation.}
-
-% \end{frame}
-
 
 \begin{framev}[align=top]{Axioms of Fair Payouts}
 \textbf{What makes a payout fair?} The Shapley value provides a fair payout $\phi_j$ for each player $j \in P$ and uniquely satisfies the following axioms for any value function $v$:\\
@@ -725,28 +431,6 @@ $\leadsto$ Payout of combined game = payout of the two separate games
 \end{framev}
 
 
-
-
-% \begin{frame}{Axioms of Fair Payouts}
-%  Why is this a fair payout solution?
-%  \\
-%  One possibility to define fair payouts are the following axioms for a given value function $v$:
-%   \vspace{0.25cm}
-%   \begin{itemize}[<+->]
-%   \itemsep1em
-%     \item \textbf{Efficiency}: Player contributions add up to the total payout of the game:
-%       $\sum\nolimits_{j=1}^p\phi_j = v(P)$
-%     % symmetry - "any" confused me a bit since we actually look into coalitions that do not include both j and k. Maybe we can state this more as "for any coalition it make no difference whether we add $j$ or $k$"
-%     \item \textbf{Symmetry}: For any players $j,k \in P$ who contribute the same to any coalition $S$ get the same payout: \\ 
-%       If $v(\Scupj) = v(\Scupk)$ for all $\SsubP \setminus\{j,k\}$, then $\phi_j=\phi_k$
-%     \item \textbf{Dummy/Null Player}: Payout is 0 for players who do not contribute to the value of any coalition: \\
-%       If $v(\Scupj)=v(S)\quad  \forall \quad \SsubP \setminus \{j\}$, then $\phi_j=0$
-%     \item \textbf{Additivity}: For games with value functions $v_1, v_2$, their combined value function $v(S) = v_1(S) + v_2(S)$ implies that the payout $\phi_{j,v}$ is $\phi_{j,v_1} + \phi_{j, v_2}$
-%   \end{itemize}
-%   \vspace{0.5cm}
-  
-
-% \end{frame}
 
 
 % \begin{frame}{Banzhaf Value}

--- a/slides/shapley/slides02-shapley-ml.tex
+++ b/slides/shapley/slides02-shapley-ml.tex
@@ -38,21 +38,10 @@ figure_man/bike-sharing03.png
 
 
 
-% \begin{frame}{From Game Theory To Machine Learning}
-
-% \begin{figure}
-%     \centering
-%     \includegraphics{figure/Shapley_6.png}
-% \end{figure}
-
-% \end{frame}
-
 \begin{framev}[align=center]{From Game Theory to Machine Learning}
 \splitVTT[0.55]{
 \spacer[0.6]
 \begin{itemizeS}
-%\item A model prediction is the outcome of multiple features acting together
-%\item How should we attribute this outcome fairly to individual features?
 \item Model prediction depends on feature interactions for a specific observation
 \item \textbf{Goal:} Decompose prediction into \textbf{individual feature contributions}
 \item \textbf{Idea:} Treat features as players jointly producing a prediction
@@ -120,36 +109,7 @@ arrow/.style = {-stealth, gray, semithick}
 }
 \end{itemizeS}
 \end{framev}
-% \begin{frame}{Shapley Values}
-%   We can use Shapley values to explain individual predictions $\fh(\xv)$ of a machine learning model $\fh$:
-% \begin{itemize}
-%   \item Players $\hat{=}$ feature values of $i$-th observation $x_j, j \in \pset$.
-%   \item Features cooperate to produce a prediction $\fh(x_1, x_2, \ldots, x_p)$.
-%   \item The value function / payout of coalition $S$ for observation $\xv$ is
-%     $$v(S) =  \fh_{S} (\xv_S) - \E_{\xv}(\fh(\xv)),$$ 
-%     where $\xv_S = \{x_j\}_{j \in S}$ and $\fh_S: \Xspace_S \mapsto \Yspace$.
-% \item The marginal prediction $\fh_S$ is defined as $\fh_{S}(\xv_S) := \int_{X_{-S}} \fh(\xv_S, X_{-S})d \P_{X_{-S}}$
-% \item We have already seen the marginal prediction in action in the PDP.
-% \item The subtraction of $\E_{\xv}(\fh(\xv))$ is necessary so that $v$ is a value function with $v(\emptyset) = 0$.
-% \item By using the marginal prediction, we have defined what it means for features to be \enquote{missing} for the prediction: We remove it by integrating over its distribution.
-% \end{itemize}
-% \begin{center}
-% \vspace{-0.3cm}
-% \includegraphics[width=0.6\textwidth]{figure_man/shapley_valuefct}
-% \end{center}
-
-% \begin{itemize}
-%  \item Shapley values tell us what the payout of each feature is, i.e., how each feature contributes to the overall prediction of a specific observation.
-%     \item The Shapley value is the average marginal contribution of a feature towards the prediction \textbf{across all possible feature coalitions}.
-%     \item The sum of Shapley values over all features yields the difference between the average prediction of all data points (baseline) and the selected individual prediction.
-%   \end{itemize}
-% \end{frame}
-
-
-
 \begin{framev}[align=top]{Shapley Value - Definition \furtherreading{SHAPLEY1953} \furtherreading{STRUMBELJ2014}}
-%Using the order definition, the Shapley value for feature $j$ and a given observation $\xv$ is computed by:
-%Shapley value $\phi_j$ of feature $j$ for observation $\xv$ via \textbf{order definition}:
 \textbf{Order definition:} Shapley value $\phi_j(\xv)$ quantifies contribution of $x_j$ via
 $$
 \phi_j(\xv) = \frac{1}{|P|!} \sum_{\tau \in \Pi} \underbrace{\fh_{\Stauj}(\xv_{\Stauj}) - \fh_{\Stau}(\xv_{\Stau})}_{\Delta(j, \Stau)~\text{marginal contribution of feature $j$}}
@@ -158,15 +118,10 @@ $$ %S \subseteq P\setminus \{j\}
 \item \textbf{Interpretation:} $\phi_j(\xv)$ quantifies how much feature $x_j$ contributes to the difference between $\fh(\xv)$ and the mean prediction $\fh_\emptyset$\\
 %$x_j$ contributed $\phi_j$ to difference between $\fh(\xv)$ and mean prediction\\
 $\leadsto$ Marginal contributions and Shapley values can be negative
-%$x_j$ contributed $\phi_j$ to prediction $\fh(\xv)$ compared to average prediction
-% of Shapley value $\phi_j$ for feature $j$ and observation $\xv$:\\
-%Feature value $x_j$ contributed amount $\phi_j$ to prediction $\fh(\xv)$ compared to the average prediction
 \item \textbf{Exact computation of $\phi_j$:} Using PD function
 %$\fh_{S}(\xv_S) =  \frac{1}{n} \sum_{i=1}^n \fh_S^{(i)}(\xv_S) = \frac{1}{n} \sum_{i=1}^n \fh(\xv_S, \xv_{-S}^{(i)})$ 
 $\fh_S(\xv_S) = \frac{1}{n} \sum_{i=1}^n \fh(\xv_S, \xv_{-S}^{(i)})$
 yields
-%for any set of features $S$ can be used which yields
-%$$ \phi_j(\xv) = \frac{1}{|P|! \cdot n} \sum_{\tau \in \Pi} \sum_{i = 1}^n \fh_{\Smj}^{(i)}(\xv_{\Smj}) -  \fh_{\Sm }^{(i)}(\xv_{\Sm}) $$
 $$
 \phi_j(\xv) = \frac{1}{|P|!} \sum_{\tau \in \Pi} \frac{1}{n} \sum_{i = 1}^n
 \fh(\xv_{\Stauj}, \xv_{\minusStauj}^{(i)}) - \fh(\xv_{\Stau}, \xv_{-\Stau}^{(i)})
@@ -181,21 +136,6 @@ $\leadsto$ Exact computation requires $|P|! \cdot n$ marginal contribution terms
 %Strumbelj, Erik, Igor Kononenko, Erik Strumbelj, and Igor Kononenko. 2014. $"$Explaining prediction models and individual predictions with feature contributions.$"$
 \end{framev}
 
-
-% \begin{frame}{Estimation: A practical problem}
-%   \begin{itemize}[<+->]
-%   %\itemsep1em
-%       \item Exact Shapley value computation is problematic for high-dimensional feature spaces\\
-%       $\leadsto$ For 10 features, there are already $|P|! = 10! \approx 3.6$ million possible orders of features
-%       \item Additional problem due to estimation of the marginal prediction $\fh_{\Stau}$: Averaging over the entire data set for each coalition $\Stau$ introduced by $\tau$ can be very expensive for large data sets
-%       \item Solution to both problems is sampling:
-%       Instead of averaging over $|P|! \cdot n$ terms, we approximate it using a limited amount of $M$ random samples of $\tau$ to build coalitions $\Stau$
-%       %We calculate the Shapley value over $M$ samples -- for each sample, we sample one order of features and one data point to replace missing features
-%       \item $M$ is a tradeoff between accuracy of the Shapley value and computational costs\\
-%       $\leadsto$ The higher $M$, the closer to the exact Shapley values, but the more costly the computation
-%       %- the higher $M$, the closer we get to the true Shapley values, but the more costly the computation becomes
-%   \end{itemize}
-% \end{frame}
 
 \begin{framev}[align=top]{Estimation: A Practical Problem}
 \begin{itemize}[<+->]
@@ -217,34 +157,14 @@ $\leadsto$ Higher cost, but better fidelity to the exact value
 \newcommand{\xk}{\mathbf{x}^{(k)}}
 
 \begin{framev}[align=top]{Approximation Algorithm \furtherreading{STRUMBELJ2014}}
-%Estimation of $\phi_j$ for observation $\xv$ of model $\fh$ fitted on data $\D$ using sample size $M$:
 Estimate Shapley value $\phi_j$ of observation $\xv$ for feature $j$:
-%\vspace{0.25cm}
 \begin{enumerate}[<+->]
 \item[$\bullet$] \textbf{Input:} $\xv$ obs. of interest, $j$ feat. of interest, $\fh$ model, $\D$ data, $M$ iterations
 \item For $m = 1, \ldots, M$ \textbf{do}:
 \begin{enumerate}
 \item Sample random permut. $\tau = (\tau^{(1)}, \ldots, \tau^{(p)}) \in \Pi$ of feature indices% = (\tau^{(1)}, \ldots, \tau^{(p)})
-%\item Select random data point $\xv^{(k)} \in X$.
-%\item Let $\Sm := \Sm$ be the set of features before $j$ of order $\tau$ forming a coalition
-%\item Determine coalition $\Sm := \Stau$, i.e., the set of feat. before feat. $j$ in order $\tau$
 \item Let coalition $\Sm := \Stau$ be the set of features preceding $j$ in $\tau$
 \item Sample random data point {\color{blue} $\mathbf{z}^{(m)} \in \D$} (so-called background data)%\\
-%$\leadsto$ used to marginalize over
-%\item Order feature values in $\xv$ according to $\tau$: $\xv_{\tau} = (x_{\tau^{(1)}}, \ldots, x_{\tau^{(j)}}, \ldots, x_{\tau^{(p)}})$
-%\item Order feature values in $\mathbf{z}^{(m)}$ according to $\tau$: $\mathbf{z}_{\tau}^{(m)} = (z_{\tau^{(1)}}^{(m)}, \ldots, z_{\tau^{(j)}}^{(m)}, \ldots, z_{\tau^{(p)}}^{(m)})$
-% \item Construct two artificial obs. by replacing feature values from $\xv$ with $\mathbf{z}^{(m)}$:
-%   \begin{itemize}
-%   \setlength\itemsep{.5em}
-%     \item % 
-%     $ \xjp  = (\underbrace{x_{\tau^{(1)}}, \ldots, x_{\tau^{(|\Sm|)}}, x_{j}}_{\xv_{\Smj}}, \underbrace{z_{\tau^{(|\Sm|+2)}}^{(m)} , \ldots, z_{\tau^{(p)}}^{(m)}}_{\mathbf{z}^{(m)}_{\minusSmj}} )$
-%     takes features $\Smj$ from $\xv$
-%     %(with value of feature $j$ from $\xv$)
-%     \item % \xjm =
-%     $ \xjm = (\underbrace{x_{\tau^{(1)}}, \ldots, x_{\tau^{(|\Sm|)}}}_{\xv_{\Sm}}, \underbrace{z_{j}^{(m)} , z_{\tau^{(|\Sm|+2)}}^{(m)} , \ldots, z_{\tau^{(p)}}^{(m)}}_{\mathbf{z}^{(m)}_{-\Sm}} )$
-%     takes features $\quad$  $\Sm$ from $\xv$ (takes $\{j\}$ randomly)
-%     %(without value of feature $j$ from $\xv$)
-%   \end{itemize}
 \item Construct two hybrid obs. by combining values from $\xv$ and {\color{blue} $\mathbf{z}^{(m)}$}:
 \begin{itemizeS}
 \item $
@@ -259,30 +179,14 @@ $\\
 $\leadsto$ includes $\xv_{\Sm}$ (features in $\Sm$ excl. $x_j$ from $\xv$), rest from {\color{blue} $\mathbf{z}^{(m)}$}
 \end{itemizeS}
 \item Compute marginal contribution $\Delta(j, \Sm) = \fh(\xjp) - \fh(\xjm)$ %\\
-%$\leadsto$ $\fh_{\Sm}(\xv_{\Sm})$ is approximated by $\fh(\xv_{-j}^{(m)})$ and  $\fh_{\Smj}(\xv_{\Smj})$ by  $\fh(\xv_{+j}^{(m)})$ over $M$ iters.
-%$\hat =$ A random sample from the marginal contribution of feature $j$ to coalition $\Sm$
 \end{enumerate}
 \item Compute Shapley value $\phi_j = \frac{1}{M}\sum_{m=1}^M \Delta(j, \Sm)$ %= \frac{1}{M} \sum_{m = 1}^M   \fh(\xjp ) -  \fh(\xjm ) $
 \item[$\leadsto$] Over $M$ iterations, the PD functions $\fh_{\Sm}(\xv_{\Sm})$ and $\fh_{\Smj}(\xv_{\Smj})$ are approximated by $\fh(\xjm)$ and $\fh(\xjp)$, where features not in the coalition (to be marginalized) are imputed with vals from random data points {\color{blue} $\mathbf{z}^{(m)}$}
 \end{enumerate}
-%\pause
-%Each $\phi_j^m$ is a random sample from the marginal contribution of feature $j$ for a sampled coalition introduced by $\tau$.
-   
-   %$$ \phi_j(\xv) = \frac{1}{|P|! \cdot n} \sum_{\tau \in \Pi} \sum_{i = 1}^n  \fh(\xv_{\Smj}, \xv_{\minusSmj}^{(i)}) - \fh(\xv_{\Sm}, \xv_{- \Sm}^{(i)})  $$
-   
-   % \vspace{0.25cm}
-    %\tiny{Strumbelj, Erik, Igor Kononenko, Erik Strumbelj, and Igor Kononenko. 2014. $"$Explaining prediction models and individual predictions with feature contributions.$"$}
 \end{framev}
 
 \begin{framev}[align=top]{Shapley value approx. - Illustration}
 \begin{exampleblock}{Definition}
-% \[
-% \tikzmark{phi}\phi_{\tikzmark{j}j}(%\tikzmark{v}\fh,
-% \tikzmark{x}\xv)=\frac{1}{M}\tikzmark{M}\sum_{m=1}^M \left[
-% \fh_{\Sm \tikzmark{SJ}\cup j}
-% \left(\xv_{\Sm \tikzmark{SJ}\cup j}\right)-
-% \fh_{\tikzmark{S}\Sm}\left(\xv_{\tikzmark{S}\Sm}\right)\right]
-% \]
 $$
 \tikzmark{phi}\phi_{\tikzmark{j}j}(%\tikzmark{v}\fh,
 \tikzmark{x}\xv)=\frac{1}{M}\tikzmark{M}\sum_{m=1}^M \left[
@@ -295,36 +199,12 @@ overlay,
 expl/.style={draw=blue,fill=white,rounded corners,text width=3.7cm},
 arrow/.style={blue,ultra thick,->,>=latex}
 ]
-%%%% Explain Formula I
-% \draw<2-3> [draw=white, fill=white, opacity=0]
-%       (5.8,0) -- (11,0) -- (11,2) -- (5.8,2) --cycle;
-% \node<1>[expl] 
-%   (phiex) 
-%   at (6,2cm)
-%   {Shapley value of feat. $j$};
-% \node<2>[expl] 
-%   (jex) 
-%   at (2,0cm)
-%   {for feature $j$};
-% \node<3>[expl] 
-%   (vex) 
-%   at (5,-0.7cm)
-%   {$\fh$: pred. function};
 \node<1>[expl] 
 (xex) 
 at (4,2cm)
 {$\xv$: obs. of interest};
-% \draw<1>[arrow]
-%   (phiex.south) to[out=270,in=90] ([xshift= 1ex, yshift=1.5ex]{pic cs:phi});  
-% \draw<2>[arrow]
-%   (jex.north) to[out=90,in=270] ([yshift=-0.5ex]{pic cs:j});  
-% \draw<3>[arrow]
-%   (vex.east) to[out=0,in=270] ([xshift= 1ex, yshift=-0.5ex]{pic cs:v});  
 \draw<1>[arrow]
 (xex.south) to[out=270,in=90] ([xshift= 0.5ex, yshift=1.5ex]{pic cs:x}); 
-%%%% Explain Formula II
-% \draw<3-5> [draw=white, fill=white, opacity=0.6]
-%       (4,0) -- (6.8,0) -- (6.8,2) -- (4,2) --cycle;
 \node<1>[expl] 
 (Sex) 
 at (9,2cm)
@@ -364,27 +244,7 @@ at (8,2cm)
 \begin{itemizeM}
 \begin{onlyenv}<1>
 \spacer[2.5]
-% \item The Shapley value assigns a value to each feature $j$ according to the marginal contribution of each player in all possible coalitions
 \end{onlyenv}
-%\invisible<2>{\item The Shapley value assigns a value to each feature $j$ according to the marginal contribution of each player in all possible coalitions}
-%\begin{onlyenv}<3>
-%\item A value function $v(S): 2^{|P|}\mapsto \R$ describes the payout (or gain) achieved by any coalition $\forall S \subseteq P$. The value of the empty coalition must be zero: $v(\emptyset) = 0$.
-%\item The payout of coalition $S$ for observation $\xv$ is 
-%$$v(\xv_S) =  \fh_{S} (\xv_S) - \E (\fh(\xv))$$ 
-%i.e., the difference of the marginal prediction of $\xv_S$ and the average prediction.
-%\end{onlyenv}
-%\begin{onlyenv}<4>
-%\item Example observation from bike sharing data
-%\end{onlyenv}
-% Part II
-%\begin{onlyenv}<5>
-%\item $\Sm$ is a randomly selected set of features: $\Sm \subseteq P \setminus j$ where $P$ denotes the quantity of all features in $X$
-%\item Let $x_{\Sm}$ be a random chosen subset of features in $x_S$ that is hold fix
-%\end{onlyenv}
-%   \begin{onlyenv}<6>
-%\item Let $S_{\lnot m}$ denote the subset of $P$ that is not in $\Sm$.
-%\item Draw the values of all other features $x_{S_{\lnot m}}$ randomly from the set of available values of the regarding feature to calculate $v(x_{\Sm})$
-%\end{onlyenv}
 \begin{onlyenv}<2>
 \item $\Delta(j, \Sm) = \fh(\xjp) - \fh(\xjm)$ is marginal contribution of feature $j$ to coalition $\Sm$
 \item Here: Feature \textit{year} contributes +700 bike rentals if it joins coalition $\Sm = \{temp, hum\}$ %compared to the expected prediction conditioned on features in coalition $\Sm$ (while other features were taken from a random obs.)
@@ -396,14 +256,8 @@ at (8,2cm)
 \end{onlyenv}
 \end{itemizeM}
 \vfill
-%\vspace*{30pt}
 \begin{center}
-%\includegraphics<3>[width=0.5\textwidth]{figure_man/shapley_valuefct}
 % Link https://docs.google.com/presentation/d/14FZZ4zk7IBZv6XnQA0wDVfCDhmjzf4np5uVj7KrIxXg/edit#slide=id.p
-%\includegraphics<4>[page=1, width=1\textwidth]{figure_man/data_shapley}
-%\includegraphics<5>[page=2, width=1\textwidth]{figure_man/data_shapley}
-%\includegraphics<6>[page=3, width=1\textwidth]{figure_man/data_shapley}
-%\includegraphics<7>[page=4, width=1\textwidth]{figure_man/data_shapley}
 \includegraphics<1>[page=13, width=1\textwidth]{figure_man/data_shapley}
 \includegraphics<2>[page=14, width=1\textwidth]{figure_man/data_shapley}
 \includegraphics<3>[page=15, width=1\textwidth]{figure_man/data_shapley}
@@ -413,25 +267,6 @@ at (8,2cm)
 
 
 
-
-% \begin{frame}{Revisited: Axioms for Fair Attributions}
-%   We take the general axioms for Shapley Values and apply it to predictions:
-%   \vspace{0.25cm}
-%   \begin{itemize}[<+->]
-%   \itemsep1em
-%     \item \textbf{Efficiency}: Shapley values add up to the (centered) prediction: %. 
-%     %That means, unlike, e.g., LIME, we get a dense attribution, and not a sparse one.
-%     $\sum\nolimits_{j=1}^p\phi_j=\fh(\xv)-\E_{\xv}(\fh(X))$
-%     \item \textbf{Symmetry}: If $x_j$, $x_k$ contribute the same, they receive the same payout\\
-%     $\leadsto$ interaction effects between features are fairly divided \\
-%       $\fh_{S\cup\{j\}}(\xv_{\Scupj}) = \fh_{\Scupk}(\xv_{\Scupk})$ for all $S \subseteq P\setminus\{j,k\}$ then $\phi_j=\phi_k$
-%     \item \textbf{Dummy / Null Player}: Shapley value of a feature that does not influence the prediction is zero $\leadsto$ if a feature was not selected by the model (e.g., tree or LASSO), its Shapley value is zero  \\
-%       $\fh_{\Scupj}(\xv_{\Scupj})=\fhS(\xv_S)$ for all $S \subseteq P$ then $\phi_j=0$
-%     \item \textbf{Additivity}:  For a prediction with combined payouts, the
-%       payout is the sum of payouts: $\phi_j(v_1) + \phi_j(v_2)$\\
-%       $\leadsto$ Shapley values for model ensembles can be combined
-%   \end{itemize}
-% \end{frame}
 
 \begin{framev}[align=top]{Revisited: Axioms for Fair Attributions}
 We adapt the classic Shapley axioms to the setting of model predictions:
@@ -502,11 +337,6 @@ $\leadsto$ Enables combining Shapley values for model ensembles
 \begin{framev}[align=top]{Bike Sharing Dataset}
 \imageC[0.6]{figure/shapley-bike.pdf}%{figure_man/bike-sharing03.png}%
 
-% \begin{itemize}
-%     \item Shapley values of observation $i = 200$ from the bike sharing data
-%     \item Difference between model prediction of this observation and the average prediction of the data is fairly distributed among the features (i.e., $4434 - 4507 \approx -73 $)
-%     \item Feature value temp = 28.5 has the most positive effect, with a contribution (increase of prediction) of about +400
-% \end{itemize}
 \begin{itemizeM}%[<+->]
 \item Shapley decomposition for a single prediction in bike sharing dataset %(observation $i = 200$)
 \item Model pred.: $\fh(\xv^{(200)}) = \textbf{4434.86}$ vs. dataset avg.: $\E_\xv[\fh(\xv)] = \textbf{4507.67}$
@@ -527,28 +357,6 @@ $\leadsto$ Model captures lower bike demand in 2011 compared to 2012
 %  \end{itemize}
 %     \tiny{Lundberg, Scott M., and Su-In Lee. "A Unified Approach to Interpreting Model Predictions." Advances in Neural Information Processing Systems 30 (2017): 4765-4774.}
 %     \tiny{Lundberg, Scott M., Gabriel G. Erion, and Su-In Lee. "Consistent individualized feature attribution for tree ensembles." arXiv preprint arXiv:1802.03888 (2018).}
-% \end{frame}
-
-% \begin{frame}{ADVANTAGES AND DISADVANTAGES}
-% 	\textbf{Advantages:}
-% 	\begin{itemize}
-% 	 \item \textbf{Solid theoretical foundation} in game theory
-%         \item Prediction is \textbf{fairly distributed} among the feature values $\leadsto$ easy to interpret for a user
-%         \item \textbf{Contrastive explanations} that compare the prediction with the average prediction
-% 	\end{itemize}
-% \vspace{0.25cm}
-% 	\textbf{Disadvantages:}
-% 	\begin{itemize}
-% 		\item Without sampling, Shapley values need a lot of computing time to
-% 		inspect all possible coalitions
-% 		%\item The Shapley value of a feature value can be easily misinterpreted:
-% 		%It is not the difference of the predicted value after removing the
-% 		%feature from the model training; it is the contribution of a feature
-% 		%value to the difference between the actual prediction and the mean
-% 		%prediction, given the current set of features
-% 		\item Like many other IML methods, Shapley values suffer from the
-% 		inclusion of unrealistic data observations when features are correlated
-% 	\end{itemize}
 % \end{frame}
 
 \begin{framev}[align=top]{Advantages and Disadvantages}

--- a/slides/shapley/slides03-shap.tex
+++ b/slides/shapley/slides03-shap.tex
@@ -49,60 +49,12 @@ figure_man/exSHAP.png
 % 
 
 
-% \begin{frame}{Shapley Values in ML - A short Recap}
-  
-%   \textbf{Question:} How much does a feat. $j$ contribute to the prediction of a single obs. \\
-%   \textbf{Idea:} Use Shapley values from cooperative game theory \\
-%   \pause
-%   \textbf{Procedure:} 
-%   \begin{itemize}
-%     \item Compare ``reduced prediction function'' of feature coalition $S$ with $\Scupj$ 
-%     \item Iterate over possible coalitions to calculate marginal contribution of feature $j$ to sample $\xv$
-% \end{itemize}
-
-% $$\phi_j 
-% %= \frac{1}{|P|!} \sum_{\tau \in \Pi} (v(\Stauj) - v(\Stau)) 
-% = \frac{1}{p!} \sum_{\tau \in \Pi}  \underbrace{\fh_{\Stauj}(\xv_{\Stauj}) - \fh_{\Stau}(\xv_{\Stau})}_{\text{marginal contribution of feature $j$}} $$
-
-% \pause
-% \textbf{Remember:}
-
-% \begin{itemize}
-%     \item $\fh$ is the prediction function, $p$ denotes the number of features
-%     \item Non-existent feat. in a coalition are replaced by values of random feat. values 
-%     \item Recall $\Stau$ defines the coalition as the set of players before player $j$ in order $\tau = (\tau^{(1)}, \dots, \tau^{(p)})$% states from the feature
-    
-%   \centerline{
-%   \begin{tabular}{|c|c|c|c|c|c|c|}
-%     %\multicolumn{3}{c}{\enspace\raisebox{-3.3ex}[0pt][2.6ex]{$ \overbrace{\vphantom{-}\hspace{9em}}^{|S|! \text{ permutations}}$}} &
-%     %\multicolumn{1}{c}{} &
-%     %\multicolumn{3}{c}{\enspace\raisebox{-3.3ex}[0pt][2.6ex]{$ \overbrace{\vphantom{-}\hspace{9em}}^{(|P| - |S| - 1)! \text{ permutations}}$}}\\
-%     \hline
-%     $\tau^{(1)}$ & \ldots & $\tau^{(|S|)}$ & $\tau^{(|S| + 1)}$ & $\tau^{(|S| + 2)}$ & \ldots & $\tau^{(p)}$ \\
-%     \hline
-%     \multicolumn{3}{c}{\enspace\raisebox{1.3ex}[0pt][2.6ex]{$ \underbrace{\vphantom{-}\hspace{9em}}^{}$}} &
-%     \multicolumn{1}{c}{\enspace\raisebox{1.3ex}[0pt][2.6ex]{$ \underbrace{\vphantom{-}\hspace{4em}}^{}$}} &
-%     \multicolumn{3}{c}{\enspace\raisebox{1.3ex}[0pt][2.6ex]{$ \underbrace{\vphantom{-}\hspace{9em}}^{}$}}\\
-%     \multicolumn{3}{c}{$S_j^\tau:$ Players before player $j$} & \multicolumn{1}{c}{player $j$} & \multicolumn{3}{c}{Players after player $j$} \\
-%   \end{tabular}}
-% \end{itemize}
-
-% \end{frame}
-
-
 \begin{framev}[align=top]{Shapley Values in ML - A Short Recap}
-% \textbf{Question:} How much does $x_j$ contribute to prediction of a specific obs. $\xv$?
-% 
-% \textbf{Idea:} Use Shapley values to compute fair attributions.
-% 
-% \pause
 \textbf{Shapley values (order definition):} Average over marginal contributions across all permutations of feature indices $\tau \in \Pi$:
 $$
 \phi_j(\xv) = \frac{1}{p!} \sum_{\tau \in \Pi} 
 \underbrace{\fh_{\Stauj}(\xv_{\Stauj}) - \fh_{\Stau}(\xv_{\Stau})}_{\text{marginal contribution of feature $j$}}
 $$
-%\pause
-%\textbf{Procedure:}
 \begin{itemizeM}
 \item For each permutation $\tau$, determine coalition $\Stau$: features before $j$ in $\tau$
 \item In $\fh_S$, features not in $S$ are marginalized (e.g., randomly imputed)
@@ -117,83 +69,7 @@ $$
 \phi_j(\xv) = 
 \sum_{S \subseteq \{1,\dots,p\} \setminus \{j\}} \frac{|S|!(p - |S| - 1)!}{p!} \left[\fh_{S \cup \{j\}}(\xv_{S \cup \{j\}}) - \fh_S(\xv_S)\right].
 $$
-% 
-% \pause
-% \textbf{Notes:}
-% \begin{itemize}
-%   \item $\fh$: prediction function; $p$: number of features
-%   \item Features not in the coalition are replaced via marginalization (e.g., random imputations of feature values)
-% \end{itemize}
-% 
-% \vspace{0.4em}
-% \centerline{
-% \begin{tabular}{|c|c|c|c|c|c|c|}
-%   \hline
-%   $\tau^{(1)}$ & $\cdots$ & $\tau^{(|S|)}$ & $\tau^{(|S|+1)}$ & $\tau^{(|S|+2)}$ & $\cdots$ & $\tau^{(p)}$ \\
-%   \hline
-%   \multicolumn{3}{c}{$\underbrace{\hspace{9em}}_{\Stau}$} & 
-%   \multicolumn{1}{c}{$\underbrace{\hspace{4em}}_{j}$} & 
-%   \multicolumn{3}{c}{$\underbrace{\hspace{9em}}_{\text{Remaining features}}$}
-% \end{tabular}
-% }
-
 \end{framev}
-
-% 
-% \begin{frame}{Shapley Values in ML - A short Recap}
-%   
-%   \textbf{Example:} Random forest trained on bike share data using only humidity (hum), temperature (temp), windspeed (ws)
-% \begin{columns}[T, onlytextwidth]
-% \begin{column}{0.58\textwidth}
-% 
-%   \begin{itemize}
-%       \item Observation $\xv$ with prediction $\fh(\xv) = \color{orange}{2573}$
-%       \item Mean prediction $\E(\fh) = \color{blue}{4515}$
-%   \end{itemize}
-%   
-%   \medskip
-%   
-%   
-%   \textbf{Exact Shapley value for hum:} 
-%       {\centering
-%       \scriptsize
-%       \begin{tabular}{c|c|c|c|c}
-%    $S$    &  $\Scupj$  & $\fh_S$ &  $\fh_{\Scupj}$  & weight\\\hline
-%      $\varnothing$&    hum  & \color{blue}{4515} & 4635 & $2/6$\\
-%        temp &  temp, hum & 3087 & 3060& $1/6$\\
-%        ws &  ws, hum & 4359  & 4450 & $1/6$\\
-%        temp, ws & temp, ws, hum & 2623 & \color{orange}{2573} & $2/6$
-%       \end{tabular}
-%       }
-% \end{column}
-% \begin{column}{0.42\textwidth}
-% %\vspace{-1cm}
-% \includegraphics[width=\linewidth]{figure/shapley2shap.pdf}
-% \end{column}
-% \end{columns}
-% 
-% $$\Rightarrow
-% \phi_{hum} = \tfrac{2}{6} (4635-4515) + \tfrac{1}{6} (3060-3087) + \tfrac{1}{6} (4450-4359) + \tfrac{2}{6} (2573-2623) = 34
-% $$
-% $\Rightarrow$ Analogously $\phi_{\text{temp}} = -1654$, $\phi_{\text{ws}} = -322$
-% % \begin{align*}
-% %  v(P) &= \fh(\xv) - \E(\fh) = \phi_{\text{hum}} + \phi_{\text{temp}} + \phi_{\text{ws}} \\
-% %  &= {\color{orange} 2573} - {\color{blue} 4515} = 34 - 1654 - 322 = -1942
-% %  \end{align*}
-% 
-% \medskip
-% 
-% \textbf{Interpretation:} \texttt{hum} raises prediction by 34, \texttt{temp} and \texttt{ws} lower it by 1654 and 322, explaining the deviation from the mean
-% 
-% %\textbf{Recall:} Shapley values explain how features shift prediction from baseline $\E(\fh)$:
-% % \begin{align*}
-% % v(P) &= \fh(\xv) - \E(\fh) = \phi_{\text{hum}} + \phi_{\text{temp}} + \phi_{\text{ws}} \\
-% % &= {\color{orange} 2573} - {\color{blue} 4515} = 34 - 1654 - 322 = -1942
-% % \end{align*}
-% 
-% \end{frame}
-
-
 
 \begin{framev}[align=top]{Shapley Values in ML - Example}
 \textbf{Example (Bike sharing data):}
@@ -216,50 +92,12 @@ temp, ws & temp, ws, hum & 2623 & \color{orange}{2573} & $2/6$
 \item[$\Rightarrow$] {\small $\phi_{\text{hum}}(\xv) = \tfrac{2}{6}(4635-4515) + \tfrac{1}{6}(3060-3087) + \tfrac{1}{6}(4450-4359) + \tfrac{2}{6}(2573-2623) = 34$}
 \item[$\Rightarrow$] {\small Analogously $\phi_{\text{temp}}(\xv) = -1654$, $\phi_{\text{ws}}(\xv) = -322$}
 \end{itemizeM}
-% \begin{align*}
-%  v(P) &= \fh(\xv) - \E(\fh) = \phi_{\text{hum}} + \phi_{\text{temp}} + \phi_{\text{ws}} \\
-%  &= {\color{orange} 2573} - {\color{blue} 4515} = 34 - 1654 - 322 = -1942
-%  \end{align*}
 \end{framev}
-
-% 
-% \begin{frame}{From Shapley to SHAP}
-% \textbf{Example continued}: Same calculation can be done for temperature and windspeed:
-% \begin{itemize}
-%     \item $\phi_{temp} = \ldots = -1654$
-%     \item $\phi_{ws} = \ldots = -322$
-% \end{itemize}
-% 
-% \textbf{Remember}: Shapley values explain difference between actual and average pred.:
-% \begin{eqnarray*}
-% \color{orange}{2573} \color{black}- \color{blue}{4515} \color{black} &= 34 - 1654 - 322 &= - 1942\\
-% \fh(\xv) - \E(\fh) &= \phi_{hum} + \phi_{temp} + \phi_{ws}&\\
-% \end{eqnarray*}
-% \begin{columns}[T]
-% \begin{column}{0.5\textwidth}
-% $\leadsto$ can be rewritten as
-% $$
-% \fh(\xv) = \underbrace{\E(\fh)}_{\phi_0} + \phi_{hum} + \phi_{temp} + \phi_{ws}
-% $$
-% $\leadsto$ Additive decomposition: baseline $\phi_0$ + per-feature contributions $\phi_j$
-% %N.B.: This reminds us of a LM with weights $\phi_j$ multiplied by a binary feature value indicating weather a feature is included in a considered coalition.
-% \end{column}
-% \begin{column}{0.5\textwidth}
-% \vspace{-1cm}
-% \begin{figure}
-%     \centering
-%     \includegraphics[width=0.9\columnwidth]{figure/shapley2shap.pdf}
-% \end{figure}
-% \end{column}
-% \end{columns}
-% \end{frame}
 
 \begin{framev}[align=top]{From Shapley Values to SHAP}
 \splitVTT[0.51]{
 %\textbf{Example (cont.):} Shapley values for other features $\phi_{\text{temp}} = -1654$, $\phi_{\text{ws}} = -322$
 %\medskip
-% \textbf{Interpretation:} \texttt{hum} raises prediction by 34, \texttt{temp} and \texttt{ws} lower it by 1654 and 322, explaining the deviation from the mean
-% \medskip
 \textbf{Shapley value interpretation (for $\xv$):}
 \begin{itemizeM}
 \item \texttt{hum} $(+34)$ pushes pred. \emph{above} baseline (= average prediction).
@@ -267,12 +105,6 @@ temp, ws & temp, ws, hum & 2623 & \color{orange}{2573} & $2/6$
 \item Together, they explain full deviation from average prediction.
 \end{itemizeM}
 %\medskip
-% \textbf{Recall:} Shapley values explain how features shift prediction from baseline $\E(\fh)$:
-% \footnotesize
-% \begin{align*}
-%  \fh(\xv) - \E_{\xv}[\fh(\xv)] &= \phi_{\text{hum}}(\xv) + \phi_{\text{temp}}(\xv)  + \phi_{\text{ws}}(\xv) \\
-%  {\color{orange} 2573} - {\color{blue} 4515} &= 34 - 1654 - 322 = -1942
-% \end{align*}
 }{
 \spacer[0]
 %\vspace{-1cm}
@@ -297,159 +129,11 @@ $$
 $\leadsto$ Like a LM evaluated at $\xv$: global intercept $\phi_0$ plus per-feature contribs $\phi_j(\xv)$.\\
 \spacer[0.25]
 %\vspace{0.4em}
-% \textbf{SHAP:} Express prediction of $\xv$ as additive decomposition of Shapley values
-% \[
-% \fh(\xv) = \underbrace{\E(\fh)}_{\phi_0} + \sum_j \phi_j
-% \]
-% $\leadsto$ Analogous to linear models: intercept $\phi_0$ + per-feature contributions $\phi_j$
-
-% \textbf{SHAP takeaway:}  
-% \[
-% \fh(\xv)=\underbrace{\E_{\xv}[\fh(\xv)]}_{\phi_0}
-%       +\sum_{j=1}^{p}\phi_j(\xv)
-%       \quad\text{with each }\phi_j(\xv)\text{ the \emph{Shapley value} of feature }j.
-% \]
-
-%\(\leadsto\) Like a linear model evaluated at \(\xv\): global intercept \(\phi_0\) plus instance-specific feature contributions \(\phi_j(\xv)\).
-
 \textbf{SHAP Motivation:}
 Can we efficiently estimate this Shapley-based additive decomp. of $\fh(\xv)$ via a surrogate model (while preserving Shapley axioms)?
-%Additive explanation model: intercept $\phi_0$ plus per-feature effects $\phi_j$ (analogous to a linear model)
-%Reminds of linear models: $\phi_j$ as effect of feature $j$ and intercept $\phi_0$ 
 \end{framev}
 
 
-
-% 
-% \begin{frame}{From Shapley Values to the SHAP}
-% 
-% SHAP defines an \textbf{additive local surrogate model} \(g(\mathbf{z}^{\prime})\) based on a binary \textbf{simplified input} \(\mathbf{z}^{\prime} = (z^{\prime}_1, \dots, z^{\prime}_p)^\top \in \{0,1\}^p\), where:
-% \[
-% g(\mathbf{z}^{\prime}) = \phi_0 + \sum_{j=1}^p \phi_j z^{\prime}_j
-% \]
-% \begin{itemize}
-%   \item \(z^{\prime}_j = 1\): feature \(j\) is "observed" (i.e., present in coalition)
-%   \item \(z^{\prime}_j = 0\): feature \(j\) is "absent" and replaced via (conditional) imputation
-%   \item SHAP seeks \(\phi_j\) values such that Shapley axioms hold %$\Rightarrow$ guarantees fairness, consistency, and efficiency.
-% \end{itemize}
-% \end{frame}
-% % 
-% % \begin{frame}{From Shapley to SHAP Model}
-% % 
-% % SHAP defines an additive feature attribution model (local surrogate model) \(g(\mathbf{z}^{\prime})\) based on a simplified feature vector \(\mathbf{z}^{\prime}\in\{0,1\}^p\) indicating whether a feature value was replaced by random imputation:
-% % \[
-% %  g(\mathbf{z}^{\prime})=\phi_0+\sum_{j=1}^p\phi_j z^{\prime}_j
-% % \]
-% % \begin{itemize}
-% %   \item $z^{\prime}_j=1$ feature present; $z^{\prime}_j = 0$ replaced by random imputation.
-% %   \item Find coefficients \(\phi_j\) such that Shapley axioms hold \(\Rightarrow\) SHAP.
-% % \end{itemize}
-% % \end{frame}
-% 
-% 
-% \begin{frame}{SHAP Definition \furtherreading{LUNDBERG2017}}
-% \textbf{Aim}: 
-% %Find an additive combination that explains the prediction of an observation $\xv$ by computing the contribution of each feature to the prediction using a (more efficient) estimation procedure. \\\medskip
-% Explain a prediction $\fh(\xv)$ by decomposing it into additive contributions from individual features using a surrogate model and efficient Shapley estimation.
-% 
-% \medskip
-% 
-% \only<1-5>{\textbf{SHAP Setup}
-% \begin{itemize}
-%     % \item Simplified (binary) coalition feat. space $\mathbf{Z}^\prime \in \{0,1\}^{K \times p}$ with $K$ rows and $p$ cols.
-%     % \item Rows are referred to as $\mathbf{z}^{\prime (k)} = \{z^{\prime (k)}_1, \ldots, z^{\prime (k)}_p\}$ with $k \in \{1,\ldots, K\}$ (indexes $k$-th coalition)
-%     % \item Cols are referred to as $\mathbf{z}_j$ with $j \in \{1, \ldots, p\}$ being the index of the original feat.
-%      \item Simplified (binary) coalition feat. space $\mathbf{Z}^\prime \in \{0,1\}^{K \times p}$ with $K$ rows and $p$ cols.
-%     \item Each row $\mathbf{z}^{\prime (k)} = (z_1^{\prime(k)}, \ldots, z_p^{\prime(k)})$ represents a coalition (subset of features).
-%     \item Each column $\mathbf{z}_j$ indicates if feature $j$ is part of a coalition.
-% \end{itemize}
-% }
-% 
-% \medskip
-% 
-% \only<1>{
-% \textbf{Example -- Coalition Space for 3 Features}: 
-% \vspace{-0.2cm}
-% \begin{table}[]
-%     \centering
-%     \footnotesize
-%      \begin{tabular}{l |c|ccc}
-%   Coalition  & $\mathbf{z}^{\prime (k)}$ &  hum & temp & ws \\
-%   \hline 
-%   $\varnothing$ & $\mathbf{z}^{\prime (1)}$ & 0 & 0 & 0  \\
-%   hum & $\mathbf{z}^{\prime (2)}$ & 1 & 0 & 0  \\
-%   temp &  $\mathbf{z}^{\prime (3)}$ & 0 & 1 & 0  \\
-%   ws &   $\mathbf{z}^{\prime (4)}$ & 0 & 0 & 1  \\
-%   hum, temp & $\mathbf{z}^{\prime (5)}$ & 1 & 1 & 0  \\
-%   temp, ws & $\mathbf{z}^{\prime (6)}$ & 0 & 1 & 1  \\
-%   hum, ws &   $\mathbf{z}^{\prime (7)}$ & 1 & 0 & 1  \\
-%   hum, temp, ws & $\mathbf{z}^{\prime (8)}$ & 1 & 1 & 1  \\
-%   \end{tabular}
-% \end{table}
-% }
-% \only<2->{
-% %\vspace{0.5cm}
-% \begin{exampleblock}{}
-% \[
-% g\left(\tikzmark{zp} \mathbf{z}^{\prime (k)}\right)=
-% \tikzmark{ph0}\phi_{0}+\sum_{j=1}^{p}
-% \tikzmark{phj} \phi_{j} z_{j}^{\prime (k)}
-% \]
-% \begin{tikzpicture}[
-%   remember picture,
-%   overlay,
-%   expl/.style={draw=blue,fill=white,rounded corners,text width=3cm},
-%   arrow/.style={blue,ultra thick,->,>=latex}
-% ]
-% \node<2-4>[expl] 
-%   (zex) 
-%   at (2,1.5cm)
-%   {$\mathbf{z}^{\prime (k)}$: \textbf{Coalition} \\ simplified features};
-% \node<3-4>[expl] 
-%   (ph0ex) 
-%   at (4,-.5cm)
-%   {$\phi_0$: \textbf{Null Output} \\ Average Model Baseline ($\E(\fh))$};
-% \node<4>[expl] 
-%   (phjex) 
-%   at (10,0cm)
-%   {$\phi_j$: \textbf{Attribution} \\ How much does feature $j$ change the output for coalition $k$};
-% 
-% \draw<2-4>[arrow]
-%   (zex.east) to[out=0,in=120] ([xshift= 1ex, yshift=2.3ex]{pic cs:zp});  
-% \draw<3-4>[arrow]
-%   (ph0ex.east) to[out=0,in=270] ([xshift= 1ex, yshift=-0.8ex]{pic cs:ph0});  
-% \draw<4>[arrow]
-%   (phjex.west) to[out=180,in=270] ([xshift= 1ex, yshift=-1ex]{pic cs:phj});
-%  \node<5>[expl] 
-%   (zex)  
-%   at (2,1cm)
-%   {$g(\mathbf{z}^{\prime (k)})$: \textbf{Marginal Contribution} \\ Contribution of coalition $\mathbf{z}^{\prime (k)}$ to the prediction};
-%   \draw<5>[arrow]
-%   (zex.east) to[out=0,in=140] ([xshift= 1ex, yshift=2.3ex]{pic cs:zp});  
-% \node<5>[expl] 
-%   (phjsh) 
-%   at (10,1.5cm)
-%   {$\phi_j$: \textbf{Shapley Values}};
-% \draw<5>[arrow]
-%   (phjsh.west) to[out=180,in=50] ([xshift= 1ex, yshift=2ex]{pic cs:phj}); 
-% \draw<5> [
-%     thick,
-%     decoration={
-%         brace,
-%         mirror,
-%         raise=0.5cm
-%     },
-%     decorate
-% ] (5.7,0.7) -- (8.2,0.7)
-% node[pos=0.5,below=15pt,black]{\textbf{Additive Feature Attribution}};
-% \end{tikzpicture}
-% \end{exampleblock}
-% \begin{onlyenv}<5>
-% \vspace{1cm}
-% \textbf{Next:} How do we estimate the Shapley values $\phi_j$ efficiently?
-% \end{onlyenv}}
-% 
-% \end{frame}
 
 \begin{framev}[align=top]{SHAP Framework \furtherreading{LUNDBERG2017}}
 \textbf{SHAP} expresses the prediction of $\xv$ as a sum of contribs from each feature:
@@ -478,96 +162,10 @@ $$
 \end{framev}
 
 
-% \begin{frame}{SHAP Framework \furtherreading{LUNDBERG2017}}
-
-% \textbf{SHAP} expresses the prediction of $\xv$ as a sum of contributions from each feature:
-
-% \[
-% g(\zv') = \phi_0 + \sum_{j=1}^p \phi_j z'_j
-% \]
-
-% \begin{itemize}
-%   \item $\zv' \in \{0,1\}^p$: simplified binary input referring to a coalition (coalition vector)
-%   \item \(z'_j = 1\): feature $j$ is "present" $\Rightarrow$ use $x_j$ in the model evaluation
-%   \item \(z'_j = 0\): feature $j$ is "absent" $\Rightarrow$ marginalize $x_j$ (average over its possible values)\\
-%   $\leadsto$ \textit{Note: In practice (e.g., KernelSHAP), marginalization is approximated via random imputations from background data.}
-% \end{itemize}
-
-% \vspace{0.5em}
-% \textbf{Key idea:} Construct a surrogate model $g(\zv')$ such that it satisfies the Shapley value axioms and recovers $\fh(\xv)$:
-% \[
-% \fh(\xv) = g(\mathbf{1}) = \phi_0 + \sum_{j=1}^p \phi_j
-% \]
-
-
-% \end{frame}
-
-
-% \begin{frame}{SHAP Framework \furtherreading{LUNDBERG2017}}
-
-% \textbf{SHAP} defines a surrogate \(g(\zv')\) over binary vectors \(\zv' \in \{0,1\}^p\) (simplified features):
-
-% \[
-% g(\zv') = \phi_0 + \sum_{j=1}^p \phi_j z'_j
-% \]
-
-% \begin{itemize}
-
-%   \item \textbf{Fixed:} \(\xv\) is the instance being explained (i.e., SHAP explains \(\fh(\xv)\))
-%   \item \textbf{Coalitions:} \(\zv'\) encodes which features of \(\xv\) are "observed" in coalition:
-%     \begin{itemize}
-%       \item \(z'_j = 1\): feature \(j\) is included $\Rightarrow$ use \(x_j\)
-%       \item \(z'_j = 0\): feature \(j\) is excluded $\Rightarrow$ \(x_j\) is marginalized out
-%       %random imputation when evaluating \(\fh\)
-%     \end{itemize}
-% \item Each $\zv'$ represents a \textbf{feature coalition} used to approximate $\fh(\xv)$\\
-% %Each \(\zv'\) represents a \textbf{coalition}, i.e., a subset of features considered "known" for the prediction at \(\xv\)
-%   %\item Many different \(\zv'\) are used for the same \(\xv\), to simulate all possible feature subsets and compute marginal contributions.
-%   $\leadsto$ Many \(\zv'\) are constructed from \(\xv\), defining a subset of "observed" features\\
-%   $\leadsto$ Used to estimate marginal contributions and compute Shapley values
-%   \item SHAP computes \(\phi_j\) such that \(g(\zv')\) satisfies Shapley axioms and recovers \(\fh(\xv)\)
-%   %SHAP chooses the \(\phi_j\) such that \(g(\zv')\) approximates \(\fh(\xv)\) in a way that satisfies the Shapley axioms.
-% \end{itemize}
-
-
-%  \end{frame}
-
 \begin{framev}[align=top]{SHAP Framework \furtherreading{LUNDBERG2017}}
 %\textbf{Goal:} Explain a prediction \(\fh(\xv)\) by decomposing it into additive feature contributions using a local surrogate model derived from Shapley values.
 \textbf{SHAP}
 defines an additive surrogate $g(\zv')$ over a binary input $\zv' \in \{0,1\}^p$:
-% \only<1>{
-% \[
-% g(\zv') = \phi_0 + \sum_{j=1}^p \phi_j z'_j
-% \]
-% \begin{itemize}
-%   \item \(z'_j = 1\): feature \(j\) is "observed" (included in coalition)
-%   \item \(z'_j = 0\): feature \(j\) is "absent" and replaced via (conditional) imputation
-%   \item \(\phi_j\): contribution of feature \(j\) to \(\fh(\xv)\), satisfying Shapley axioms
-% \end{itemize}
-
-% \medskip
-
-% \textbf{Coalition space:} each row \(\zv'^{(k)} \in \{0,1\}^p\) refers to a coalition
-
-% \begin{table}[]
-%     \centering
-%     \footnotesize
-%      \begin{tabular}{l |c|ccc}
-%   Coalition  & $\zv'^{(k)}$ &  hum & temp & ws \\
-%   \hline 
-%   $\varnothing$ & $\zv'^{(1)}$ & 0 & 0 & 0  \\
-%   hum & $\zv'^{(2)}$ & 1 & 0 & 0  \\
-%   temp &  $\zv'^{(3)}$ & 0 & 1 & 0  \\
-%   ws &   $\zv'^{(4)}$ & 0 & 0 & 1  \\
-%   hum, temp & $\zv'^{(5)}$ & 1 & 1 & 0  \\
-%   temp, ws & $\zv'^{(6)}$ & 0 & 1 & 1  \\
-%   hum, ws &   $\zv'^{(7)}$ & 1 & 0 & 1  \\
-%   hum, temp, ws & $\zv'^{(8)}$ & 1 & 1 & 1  \\
-%   \end{tabular}
-% \end{table}
-% }
-
 \only<1->{
 \begin{exampleblock}{}
 $$

--- a/slides/shapley/slides04-kernel-shap.tex
+++ b/slides/shapley/slides04-kernel-shap.tex
@@ -95,40 +95,6 @@ figure_man/exSHAP.png
 
 
 
-% \begin{frame}{Kernel SHAP in 5 Steps}
-
-% \textbf{Goal:} Estimate Shapley values for a fixed instance \(\xv\) without model restrictions.
-
-% \medskip
-% \begin{enumerate}
-%   \item \textbf{Sample coalitions}  
-%         Draw \(K\) binary masks  
-%         \(\zv'^{(k)}\!\in\!\{0,1\}^p\) (\(k=1,\dots,K\)); each mask marks a subset of “known” features.
-
-%   \item \textbf{Create coalition inputs \& predict}  
-%         Build \(\tilde{\xv}^{(k)}\) by  
-%         \(\tilde{x}^{(k)}_j = x_j\) if \(z'^{(k)}_j=1\); otherwise impute.  
-%         Evaluate the model: \(y^{(k)} = \fh\!\bigl(\tilde{\xv}^{(k)}\bigr)\).
-
-%   \item \textbf{Assign kernel weights}  
-%         \[
-%           \pi_x(\zv') = \frac{p-1}{\binom{p}{|\zv'|}\,|\zv'|\,(p-|\zv'|)}
-%         \]
-
-%   \item \textbf{Fit weighted surrogate}  
-%         Weighted least squares for  
-%         \(g(\zv') = \phi_0 + \sum_{j=1}^p \phi_j z'_j\):
-%         \[
-%           \min_{\phi}\sum_{k=1}^K \bigl[y^{(k)} - g(\zv'^{(k)})\bigr]^2\,\pi_x(\zv'^{(k)})
-%         \]
-
-%   \item \textbf{Return Shapley estimates}  
-%         Coefficients \(\phi_j(\xv)\) (and \(\phi_0\)) are the Kernel-SHAP attributions.
-% \end{enumerate}
-
-% \end{frame}
-
-
 \begin{framev}[fs=small,align=top]{Kernel SHAP - In 5 Steps}
 \textbf{Step 1: Sample coalition vectors}
 \begin{itemizeM}
@@ -254,13 +220,6 @@ $\vdots$ & \multicolumn{3}{c}{$\cdots$} & $\cdots$ \\
 \end{small}
 \end{table}
 
-% \[
-% \textstyle
-% \overbrace{\frac{1}{B}\sum_{b=1}^{B}\hat{f}(h_{\xv, \xv'^{(b)}}(\mathbf{z}'))}^{\text{Monte-Carlo average}}
-% \;\;\longrightarrow\;\;
-% \mathbb{E}_{\mathbf{X}_{-S}}\bigl[f(\mathbf{x}_S,\mathbf{X}_{-S})\bigr]
-% \]
-
 \begin{itemizeM}
 \item Typically, many background samples $\xv'^{(1)}, \dots, \xv'^{(B)}$ are used to approximate the marginal expectation required for KernelSHAP via Monte-Carlo average:
 $$ \textstyle \mathbb{E}_{\mathbf{X}_{-S}}\bigl[f(\mathbf{x}_S,\mathbf{X}_{-S})\bigr] \approx
@@ -285,121 +244,9 @@ $$ \textstyle \mathbb{E}_{\mathbf{X}_{-S}}\bigl[f(\mathbf{x}_S,\mathbf{X}_{-S})\
 
 
 
-% \begin{frame}{Kernel SHAP - In 5 Steps}
-
-
-% \textbf{Step 2: Map coalition vectors to original feature space and predict}
-% \begin{itemize}
-%    % \item $$\hat{f}: \hat{f}\left(h_{x}\left(z_{k}^{\prime}\right)\right)$$
-%    \item $\mathbf{z}^{\prime (k)}$ is 1 if features are are part of the $k$-th coalition, 0 if they are absent
-%    \item To calculate predictions for these coalitions, we need to define a function which maps the binary feature space back to the original feature space
-% \end{itemize}
-
-
-% \begin{tikzpicture}
-% \centering
-
-% \fontsize{8}{12}
-
-% \node (tab1) {%
-%        \begin{tabular}{l |cccc}
-%   $\xv^{coalition}$ &  hum & temp & ws \\
-%   \hline 
-%   $\xv^{\{\varnothing\}}$ & $\varnothing$ & $\varnothing$ &$\varnothing$  \\
-%    $\xv^{\{hum\}}$ & 51.6 & $\varnothing$ & $\varnothing$  \\
-%     $\xv^{\{temp\}}$ & $\varnothing$ & 5.1 & $\varnothing$  \\
-%      $\xv^{\{ws\}}$ & $\varnothing$ & $\varnothing$ & 17.0  \\
-%      $\xv^{\{hum, temp\}}$ & 51.6 & 5.1 & $\varnothing$  \\
-%      $\xv^{\{temp, ws\}}$ &$\varnothing$ & 5.1 & 17.0  \\
-%      $\xv^{\{hum, ws\}}$ & 51.6 & $\varnothing$ & 17.0  \\
-%   $\xv^{\{hum, temp, ws\}}$ &51.6 & 5.1 & 17.0   \\
-  
- 
-%   \end{tabular}};
-
-% \node [left=of tab1] (tab2) {%
-%      \begin{tabular}{l |c|ccc}
-%   Coalition & $\mathbf{z}^{\prime (k)}$ &  hum & temp & ws \\
-%   \hline 
-%   $\varnothing$ & $\mathbf{z}^{\prime (1)}$ & 0 & 0 & 0  \\
-%   hum & $\mathbf{z}^{\prime (2)}$ & 1 & 0 & 0  \\
-%   temp &  $\mathbf{z}^{\prime (3)}$ & 0 & 1 & 0  \\
-%   ws &   $\mathbf{z}^{\prime (4)}$ & 0 & 0 & 1  \\
-%   hum, temp & $\mathbf{z}^{\prime (5)}$ & 1 & 1 & 0  \\
-%   temp, ws & $\mathbf{z}^{\prime (6)}$ & 0 & 1 & 1  \\
-%   hum, ws &   $\mathbf{z}^{\prime (7)}$ & 1 & 0 & 1  \\
-%   hum, temp, ws & $\mathbf{z}^{\prime (8)}$ & 1 & 1 & 1  \\
-   
- 
-%   \end{tabular}};
-% \draw[->]
-% (tab2.north) to[out=10,in=170] node[below]{} (tab1.north) ;
-% \end{tikzpicture}
-
-% \end{frame}
-
-
-% \begin{frame}{Kernel SHAP - In 5 Steps}
-
-
-% \textbf{Step 2: Map coalition vectors to original feature space and predict}
-% \begin{itemize}
-%    % \item $$\hat{f}: \hat{f}\left(h_{x}\left(z_{k}^{\prime}\right)\right)$$
-%     \item Define 
-% $h_x\left(\mathbf{z}^{\prime (k)}\right)=\mathbf{z}^{(k)} \text { where } h_x:\{0,1\}^{p} \rightarrow \R^{p}$
-%  maps 1’s to feature values of observation $\xv$ for features part of the $k$-th coalition and 0's to feature values of a \color{orange}{randomly sampled observation} \color{black}for features absent in the $k$-th coalition
-%   % \item Absent feature values are replaced by feature values of a \color{orange}{random observation} \color{black} of the dataset (permuted) $\leadsto$ permute feature values several times
-%   (feature values are permuted multiple times) 
-%    \item Predict with ML model on this dataset $\hat{f}: \hat{f}\left(h_{x}\left(\mathbf{z}^{\prime (k)}\right)\right)$
-% \end{itemize}
-
-
-% \begin{tikzpicture}
-% \centering
-
-% \fontsize{7}{12}
-
-% \node (tab1) {%
-%        \begin{tabular}{l |ccc | c}
-%   $\mathbf{z}^{(k)}$ &  hum & temp & ws & $\hat{f}\left(h_{x}\left(\mathbf{z}^{\prime (k)}\right)\right)$\\
-%   \hline 
-%   $\mathbf{z}^{(1)}$ & \color{orange}{64.3} & \color{orange}{28.0} & \color{orange}{14.5} & 6211 \\
-%    $\mathbf{z}^{(2)}$ & 51.6 & \color{orange}{28.0} & \color{orange}{14.5} & 5586  \\
-%     $\mathbf{z}^{(3)}$ & \color{orange}{64.3} & 5.1 & \color{orange}{14.5}  & 3295\\
-%      $\mathbf{z}^{(4)}$ & \color{orange}{64.3} & \color{orange}{28.0} & 17.0 &5762 \\
-%      $\mathbf{z}^{(5)}$ & 51.6 & 5.1 & \color{orange}{14.5}  & 2616\\
-%      $\mathbf{z}^{(6)}$ &\color{orange}{64.3} & 5.1 & 17.0  & 2900\\
-%      $\mathbf{z}^{(7)}$ & 51.6 & \color{orange}{28.0} & 17.0 & 5411 \\
-%   $\mathbf{z}^{(8)}$ &51.6 & 5.1 & 17.0 & 2573  \\
-  
- 
-%   \end{tabular}};
-
-% \node [left=of tab1] (tab2) {%
-%      \begin{tabular}{l |c|ccc}
-%   Coalition & $\mathbf{z}^{\prime (k)}$ &  hum & temp & ws \\
-%   \hline 
-%   $\varnothing$ & $\mathbf{z}^{\prime (1)}$ & 0 & 0 & 0  \\
-%   hum & $\mathbf{z}^{\prime (2)}$ & 1 & 0 & 0  \\
-%   temp &  $\mathbf{z}^{\prime (3)}$ & 0 & 1 & 0  \\
-%   ws &   $\mathbf{z}^{\prime (4)}$ & 0 & 0 & 1  \\
-%   hum, temp & $\mathbf{z}^{\prime (5)}$ & 1 & 1 & 0  \\
-%   temp, ws & $\mathbf{z}^{\prime (6)}$ & 0 & 1 & 1  \\
-%   hum, ws &   $\mathbf{z}^{\prime (7)}$ & 1 & 0 & 1  \\
-%   hum, temp, ws & $\mathbf{z}^{\prime (8)}$ & 1 & 1 & 1  \\
-  
-%   \end{tabular}};
-% \draw[->]
-% (tab2.north) to[out=10,in=170] node[below]{$h_x(\mathbf{z}^{\prime (k)})$} (tab1.north) ;
-% \end{tikzpicture}
-
-% \end{frame}
-
 \begin{framev}[fs=small,align=top]{Kernel shap - in 5 steps}
 \textbf{Step 3: Compute kernel weights for surrogate model}\\
 \spacer[0.25]
-%\textbf{Intuition}: We learn most about individual features if we can study their effects in isolation or at maximal interaction:
-%Small coalitions (few 1’s) and large coalitions (i.e. many 1’s) get the largest weights\\NB: the figure is independent from the running example
 \begin{onlyenv}<1>
 \textbf{Intuition:}  
 We learn most about a feature’s effect when (recall multinomial coefficient in Shapley value's set definition):
@@ -453,17 +300,6 @@ at (6,-1cm)
 \end{onlyenv}
 
 
-% \begin{onlyenv}<3>
-
-% $$\pi_{x}\left(z^{\prime}\right)=\frac{(M-1)}{\left(\begin{array}{c} M \\\left|z^{\prime}\right|\end{array}\right)\left|z^{\prime}\right|\left(M-\left|z^{\prime}\right|\right)}$$
-
-% \begin{itemize}
-%     \item If a coalition consists of a single feature, we can learn about this feature’s isolated main effect on the prediction
-%     \item If a coalition consists of all but one feature, we can learn about this feature’s total effect (main effect plus feature interactions)
-%     \item If a coalition consists of half the features, we learn little about an individual feature’s contribution, as there are many possible coalitions with half of the features
-% \end{itemize}
-% \end{onlyenv}
-
 % \begin{onlyenv}<4>
 % \vspace{1cm}
 % \textbf{Limited Budget $K$}: Can we be a bit smarter about the sampling of coalitions, than just randomly drawing?
@@ -493,8 +329,6 @@ $$\pi_{x}\left(\mathbf{z}^{\prime}\right)=\frac{(p-1)}{\left(\begin{array}{c} p 
 $\leadsto$ These coalition vectors are not used as obs. for the linear regression\\
 $\leadsto$ Instead constraints are used to ensure \emph{local accuracy} and \emph{missingness}
 \end{itemizeM}
-% $\leadsto$ all the finite weights being equal to the same value (0.33) is the result of coalition size being equal to 3. In general the weight distribution is not uniform. 
-% \\$\leadsto$ weights for empty and full set are infinity (since they result in division by 0 when calculating $\pi_{x}\left(\mathbf{z}^{\prime}\right)$) and not used as observations for the linear regression\\ $\leadsto$ instead constraints are used such that properties (local accuracy and missingness) are satisfied
 }
 
 \begin{table}
@@ -514,119 +348,6 @@ hum, temp, ws & $\mathbf{z}^{\prime (8)}$ & 1 & 1 & 1 & $\infty$ \\
 \end{table}
 % \medskip
 \end{framev}
-
-%\begin{frame}{Coalition Mapping}
-%We define a coalition $z^{\prime}$, by describing a function 
-
-%$$
-%h\left(z^{\prime}\right)=z \text { where } h:\{0,1\}^{M} \rightarrow \mathbb{R}^{p}
-%$$
-
-
-%\begin{onlyenv}<1>
-%\vspace{1cm}
-%\begin{itemize}
-%    \item Coalition $z^{\prime} \in \{0, 1\}^M$ is the  vector, indicating if feature $j$ contributes to the prediction 
-%    \item $h(\cdot)$ represent a function that maps 1’s to the corresponding value from the observation x that we want to explain: $h(\cdot)$ connects our coalition vector to the underlying data 
-%\end{itemize}
-%\end{onlyenv}
-
-%\begin{onlyenv}<2->
-%\begin{tikzpicture}
-%\centering
-
-%\node<2> (tab1) {%
-%  \begin{tabular}{l |cccc}
-%  observation & temp & hum & ws & yr\\
-%  \hline 
-%  $x_{ex}$ & 24.7 & 58.5 & 13.96 & 2011\\
- % \\
- % \\
-  %\end{tabular}};
-%\node<3-> (tab1) {%
-%  \begin{tabular}{l |cccc}
-%  observation & temp & hum & ws & yr\\
-%  \hline 
-%  $x_{ex}$ & 24.7 & 58.5 & 13.96 & 2011\\
-%  $z_{temp, yr}$ & 24.7 & $\varnothing$ & $\varnothing$ & 2011\\
-%  $z_{yr}$ & $\varnothing$ & $\varnothing$ & $\varnothing$ & 2011\\
-%  \end{tabular}};
-%\node<2> [left=of tab1] (tab2) {%
-%  \begin{tabular}{l |cccc}
-%  Coalition & temp & hum & ws & yr\\
-%  \hline 
-%  $x^{\prime}$ & 1 & 1 & 1 & 1 \\
-%  \\
-%  \\
-%  \end{tabular}};
-%\node<3-> [left=of tab1] (tab2) {%
-%  \begin{tabular}{l |cccc}
-%  Coalition & temp & hum & ws & yr\\
-%  \hline 
-%  $x^{\prime}$ & 1 & 1 & 1 & 1 \\
-%  $z^{\prime}_{temp, yr}$ & 1 & 0 & 0 %& 1 \\
-%  $z^{\prime}_{yr}$ & 0 & 0 & 0 & 1 %\\
-%  \end{tabular}};
-%\draw<2->[->]
-%(tab2.north) to[out=30,in=150] node[below]{$h(\cdot)$} (tab1.north) ;
-%\end{tikzpicture}
-%\end{onlyenv}
-%\begin{onlyenv}<3->
-%\begin{itemize}
-%    \item $h(\cdot)$ maps 1’s to the %corresponding value from the observation x that we want to explain
-%    \item<4> it maps 0’s to the values of another observation that we sample from the data
-%    \item<4>  we equate “feature value is absent” with “feature value is replaced by random feature value from data”
-%\end{itemize}
-%\end{onlyenv}
-%\end{frame}
-
-
-% \begin{frame}{Kernel shap - in 5 steps}
-% \textbf{Step 4: Fit a weighted linear model}\\\medskip
-% \textbf{Aim}: Estimate a weighted linear model with Shapley values being the coefficients $\phi_j$
-% $$
-% g\left(\mathbf{z}^{\prime (k)}\right)=
-% \phi_{0}+\sum_{j=1}^{p}
-%  \phi_{j} z_{j}^{\prime (k)} \only<2>{\leadsto g\left(\mathbf{z}^{\prime (k)}\right)=
-% 4515 +
-%  34 \cdot z_{1}^{\prime (k)} - 1654 \cdot z_{2}^{\prime (k)} - 323 \cdot z_{3}^{\prime (k)} }
-% $$
-
-
-% \only<1>{
-% and minimize by WLS using the weights $\pi_{x}$ of step 3
-%     $$L\left(\hat{f}, g, \pi_{x}\right)=\sum_{k = 1}^K\left[\hat{f}\left(h_{x}\left(\mathbf{z}^{\prime (k)}\right)\right)-g\left(\mathbf{z}^{\prime (k)}\right)\right]^{2} \pi_{x}\left(\mathbf{z}^{\prime (k)}\right)$$
-
-% with $\phi_0 = \E(\fh)$ and $\phi_p = \fh(x) - \sum_{j=0}^{p-1} \phi_j$ we receive a $p-1$ dimensional linear regression problem
-% }
-
-% \only<2>{
-% \begin{table}[]
-%     \centering
-%         \begin{tabular}{l |ccc|c|c}
-%   $\mathbf{z}^{\prime (k)}$ &  hum & temp & ws & weight & $\fh$\\
-%   \hline 
-%    $\mathbf{z}^{\prime (2)}$ & 1 & 0 & 0 & 0.33 & 4635\\
-%     $\mathbf{z}^{\prime (3)}$ & 0 & 1 & 0 & 0.33 & 3087\\
-%      $\mathbf{z}^{\prime (4)}$ & 0 & 0 & 1 & 0.33 & 4359\\
-%      $\mathbf{z}^{\prime (5)}$ & 1 & 1 & 0 & 0.33 & 3060\\
-%      $\mathbf{z}^{\prime (6)}$ & 0 & 1 & 1 &0.33 & 2623\\
-%      $\mathbf{z}^{\prime (7)}$ & 1 & 0 & 1 & 0.33 & 4450\\
-%       \multicolumn{1}{c}{} & \multicolumn{3}{c}{\upbracefill}&\multicolumn{1}{c}{} &\multicolumn{1}{c}{\upbracefill}\\[-1ex]
-%     \multicolumn{1}{c}{} & \multicolumn{3}{c}{$\scriptstyle input$}&\multicolumn{1}{c}{} &  \multicolumn{1}{c}{$\scriptstyle output$}\\
-  
- 
-%   \end{tabular}
-% \end{table}
-% }
-
-
-  
-% \end{frame}
-
-
-
-
 
 \begin{framev}[align=top]{Kernel shap - in 5 steps}
 \textbf{Step 4: Fit a weighted linear model}\\
@@ -705,78 +426,5 @@ g(\mathbf{z}^{\prime (8)}) &= \fh(h_x(\mathbf{z}^{\prime (8)}) ) = 4515 + 34 \cd
 \includegraphics[trim={10 17 5 5},clip,width=0.48\linewidth]{figure/shapley2shap.pdf}
 \end{center}
 \end{framev}
-%\begin{frame}{Marginal Contribution}
-
-%\begin{itemize}
-%    \begin{onlyenv}<1>
-%    \item Consider coalition $z^{\prime}$ as indicator function for our shapley values $\phi$
-%    \end{onlyenv}
-%    \begin{onlyenv}<2>
-%    \item This connects the coalition vector $z^{\prime}$ to the respective marginal contribution
-%    \end{onlyenv}
-%    \begin{onlyenv}<3>
-%    \item To estimate the marginal contribution, we can transfer the coalition to the data space by $h(z^{\prime})$
-%    \end{onlyenv}
-%    \begin{onlyenv}<4->
-%    \item $\fh(h(z^{\prime}))$ connects the coalitions directly to the marginal distribution.
-%    \end{onlyenv}
-%\end{itemize}
-
-%\vspace{1cm}
-
-%\begin{tikzpicture}
-%\centering
-
-%\node<1-2> (tab1) {%
-%  \begin{tabular}{l |cccc}
-%  Coalition & temp & hum & ws & yr\\
-%  \hline 
-%  $x^{\prime}$ & 1 & 1 & 1 & 1 \\
-%  $z^{\prime}_{temp, yr}$ & 1 & 0 & 0 & 1 \\
-%  $z^{\prime}_{yr}$ & 0 & 0 & 0 & 1 \\
-%  \end{tabular}};
-%\node<2-> [right=of tab1] (tab2) {%
-%\begin{tabular}{l | cccc}
-%  & temp & hum & ws & yr\\
-%  \hline 
-%  $g(x^{\prime})$ & $\phi_{temp}$ + & $\phi_{hum}$ + & $\phi_{ws}$ + & $\phi_{yr}$ \\
-%  $g(z^{\prime}_{temp, yr})$ & $\phi_{temp}$ + &  &  & $\phi_{yr}$\\
-%   $g(z^{\prime}_{yr})$ & &  &  & $\phi_{yr}$ \\
-%  \end{tabular}};
-%\node<3-> [left=of tab2] (tab) {%
-%  \begin{tabular}{l |cccc}
-%  observation & temp & hum & ws & yr\\
-%  \hline 
-%  $x_{ex}$ & 24.7 & 58.5 & 13.96 & %2011\\
-%  $z_{temp, yr}$ & 24.7 & %$\varnothing$ & $\varnothing$ & %2011\\
-%  $z_{yr}$ & $\varnothing$ & %$\varnothing$ & $\varnothing$ & 2011\\
-%  \end{tabular}};
-%\draw<2>[->]
-%(tab1.south) to[out=320,in=200] node[above]{$\sum \mathbb{I}_{[z^{\prime}_i == 1]} \phi_i$} (tab2.south) ;
-%\draw<3->[->]
-%(tab2.south) to[out=200,in=330] node[above]{$\fh(h(z^{\prime}))$} (tab1.south) ;
-%\end{tikzpicture}
-
-%\begin{onlyenv}<4>
-%\begin{equation}
-%\begin{array}{lllc}
-  
-%  g(x^{\prime}) &= \phi_{temp} + \phi_{hum} + \phi_{ws} + &\phi_{yr} &= 6825\\
-%  g(z^{\prime}_{temp, yr}) &= \phi_{temp} + &\phi_{yr} &= 6134\\
-%   g(z^{\prime}_{yr}) &= &\phi_{yr} &= 4325\\
-%\end{array}
-%\end{equation}
-%\end{onlyenv}
-
-%\begin{onlyenv}<5>
-%\vspace{0.5cm}
-
-%\textbf{Notice:}\\ We created a coalition data set $Z^{\prime}$ here by sampling multiple coalitions from observation $\xv$ that is evaluable with the prediction function $\fh$
-%\end{onlyenv}
-
-%\end{frame}
-
-
-
 \endlecture
 \end{document}

--- a/slides/shapley/slides05-shap-global.tex
+++ b/slides/shapley/slides05-shap-global.tex
@@ -100,51 +100,6 @@ Combines feature importance with feature effects
 \imageC[0.5]{figure_man/global_shap_jitter.pdf}
 \end{framev}
 
-% \begin{frame}{Dependence Plot}
-
-% \begin{onlyenv}<1>
-% \begin{itemize}
-%     \item Visualize the marginal contribution of a feature similar to the PDP 
-%     \item Plot a point with the feature value on the x-axis and the corresponding Shapley value on the y-axis
-% \end{itemize}
-
-% \end{onlyenv}
-
-% \begin{onlyenv}<2>
-% \textbf{Interpretation:}\\
-% \begin{itemize}
-%     \item Increasing temperatures induce increasing bike rentals until $25^\circ\text{C}$
-%     \item If it gets too hot, the bike rentals decrease
-% \end{itemize}
-% \end{onlyenv}
-
-% % \begin{onlyenv}<3>
-% % \textbf{Interpretation:}\\
-% % \begin{itemize}
-% %     \item We can colour the observations by a second feature to detect interactions
-% %     \item Visibly the temperatures interaction with the season is very strong
-% %     \item In summer, when temperatures rise, we see an increase in the model's SHAP values, indicating more bike rentals. By contrast, winter's lower temperatures translate into negative SHAP contributions, suggesting fewer rentals.
-% % \end{itemize}
-% % \end{onlyenv}
-
-
-% \btVFill
-% \begin{onlyenv}<1-2>
-% \begin{figure}
-%     \centering
-%     \includegraphics[width=0.5\columnwidth]{figure_man/global_shap_depend.pdf}
-% \end{figure}
-% \end{onlyenv}
-
-% % \begin{onlyenv}<3>
-% % \begin{figure}
-% %     \centering
-% %     \includegraphics[width=0.5\columnwidth]{figure_man/global_shap_depend_season.pdf}
-% % \end{figure}
-% % \end{onlyenv}
-% \end{frame}
-
-
 \begin{framev}[align=top]{Dependence Plot: Effect + Interaction}
 \textbf{Interpretation of SHAP Dependence Plot (Feature = Temperature)}
 \begin{itemizeM}
@@ -184,10 +139,6 @@ $\leadsto$ Visual diagnostics: feat. importance; summary and dependence plots
 \item Efficient for tree-based models via TreeSHAP\\
 (See \furtherreading{LUNDBERG2018} and for intuitive explanation \furtherreading{SUKUMAR})
 \item Unifies feature attribution under a consistent additive framework
-% \item All the advantages of Shapley values
-% \item Unify the field of interpretable machine learning in the class of additive feature attribution methods
-% \item Has a fast implementation for tree-based models
-% \item Various global interpretation methods
 \item Can be used for images \furtherreading{SHAP} and text \furtherreading{SHAP}
 \end{itemizeM}
 \spacer[0.25]
@@ -196,12 +147,6 @@ $\leadsto$ Visual diagnostics: feat. importance; summary and dependence plots
 \item KernelSHAP is inefficient for large datasets or complex models
 \item Ignores feature dependencies in marginal sampling (interventional SHAP)
 \item Conditional sampling (observational SHAP) is difficult in practice (would require estimating a conditional distribution)
-% \item Disadvantages of Shapley values also apply to SHAP
-% \begin{itemize}
-%     \item Shapley values can be misinterpreted and access to data is needed to compute them for new data (not if TreeSHAP is used)
-% \end{itemize}
-% \item KernelSHAP is slow (TreeSHAP can be used as a faster alternative for tree-based models  -- and for an intuitive explanation  \furtherreading{SUKUMAR})
-% \item KernelSHAP ignores feature dependence 
 % \item TreeSHAP can produce unintuitive feature attributions
 % \item It is possible to create intentionally misleading interpretations with SHAP, which can hide biases \furtherreading{SLACK2020}
 \end{itemizeM}


### PR DESCRIPTION
# Commented-Out Content Removal Report

Edited files:

- `slides/shapley/slides01-shapley-game-theory.tex`
- `slides/shapley/slides02-shapley-ml.tex`
- `slides/shapley/slides03-shap.tex`
- `slides/shapley/slides04-kernel-shap.tex`
- `slides/shapley/slides05-shap-global.tex`
- `slides/shapley/slides06-resources-and-software.tex`

## Summary

- Removed commented-out units: **42**
- Kept candidate units: **16**
- Restored or moved provenance/reference comment blocks: **0**
- Evidence scope: current file **yes**, sibling `.tex` files **yes**

## Provenance / Attribution Audit

- No deleted unit required moving provenance or attribution comments.
- Existing provenance was preserved where relevant: title figure license in `slides01-shapley-game-theory.tex`, the active multinomial-coefficient figure source comment in `slides01-shapley-game-theory.tex`, and the `data_shapley` Google Slides link in `slides02-shapley-ml.tex`.
- Reference-heavy or distinct commented blocks were kept rather than partially deleted when no active slide preserved the same reference context.

<details>
<summary><strong>slides01-shapley-game-theory.tex</strong>: 15 removed, 7 kept</summary>

Evidence scope: current file **yes**, sibling files **yes**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | `slides01-shapley-game-theory.tex:78-93` | Old cooperative-games definition frame. | `slides01-shapley-game-theory.tex:78-101`; active frame defines game theory, coalitions, value function, marginal contribution, and fair payout goal. | Same teaching setup is active with cleaner structure. | Citation already active in frame title. |
| 2 | `slides01-shapley-game-theory.tex:155-160` | Old no-interactions summary bullets. | `slides01-shapley-game-theory.tex:135-151` | Active bullets state constant marginal contributions and proportional fair payout. | No separate provenance. |
| 3 | `slides01-shapley-game-theory.tex:188-210` | Old no-interactions table frame. | `slides01-shapley-game-theory.tex:113-132` | Active table contains the same coalition payouts and marginal contributions. | No separate provenance. |
| 4 | `slides01-shapley-game-theory.tex:214-222` | Old interactions figure frame. | `slides01-shapley-game-theory.tex:165-170` | Active frame uses the same interaction figure role and takeaway. | No separate provenance. |
| 5 | `slides01-shapley-game-theory.tex:265-268` | Old interaction prompt bullets. | `slides01-shapley-game-theory.tex:203-216` | Active bullets explain varying marginal contributions and unfair simple averaging. | No separate provenance. |
| 6 | `slides01-shapley-game-theory.tex:312-330` | Old order-sensitivity/Shapley-value alternatives. | `slides01-shapley-game-theory.tex:246-252` | Active bullets preserve redundancy, order sensitivity, and fairness points. | No separate provenance. |
| 7 | `slides01-shapley-game-theory.tex:339-360` | Old order-example and alternate illustration comments. | `slides01-shapley-game-theory.tex:255-279` | Active illustration frame already explains joining orders and averaging marginal contributions. | No separate provenance. |
| 8 | `slides01-shapley-game-theory.tex:366-423` | Old player-yellow interaction and old figure-only frames. | `slides01-shapley-game-theory.tex:174-216`; `slides01-shapley-game-theory.tex:330-385` | Active interaction and set-definition frames cover marginal contributions, weighting, and fair payout. | No separate provenance. |
| 9 | `slides01-shapley-game-theory.tex:430-473` | Old order/set-definition explanatory comments and sampled-permutation formula. | `slides01-shapley-game-theory.tex:288-326`; `slides01-shapley-game-theory.tex:330-370` | Active frames cover order definition, sampling approximation, and duplicate subset weighting. | No separate provenance. |
| 10 | `slides01-shapley-game-theory.tex:498-501` | Old duplicate-subset note. | `slides01-shapley-game-theory.tex:343-349` | Active example explicitly shows duplicate subset occurrence. | No separate provenance. |
| 11 | `slides01-shapley-game-theory.tex:525-529` | Old `Shapley_7-9` figure alternatives. | `slides01-shapley-game-theory.tex:333-336` | Active frame uses the corresponding `Shapley.pdf` pages. | No separate provenance. |
| 12 | `slides01-shapley-game-theory.tex:574-579` | Old weight-intuition bullets. | `slides01-shapley-game-theory.tex:403-415` | Active bullets state high first/last weights and lower middle weights. | No separate provenance. |
| 13 | `slides01-shapley-game-theory.tex:585-695` | Old set-definition, multinomial, weighting, transition, and Shapley-value frames. | `slides01-shapley-game-theory.tex:388-418`; `slides01-shapley-game-theory.tex:420-443` | Active set-definition and axioms frames preserve the same formulas, coefficient intuition, and uniqueness/fairness message. | Shapley citation is preserved via active `\furtherreading{SHAPLEY1951}`. |
| 14 | `slides01-shapley-game-theory.tex:730-746` | Old axioms frame. | `slides01-shapley-game-theory.tex:420-443` | Active frame defines efficiency, symmetry, dummy, and additivity. | No separate provenance. |
| 15 | `slides01-shapley-game-theory.tex:430-460` | Remaining inline order-definition duplicate notes. | `slides01-shapley-game-theory.tex:288-326`; `slides01-shapley-game-theory.tex:330-370` | Active order/set-definition frames now cover these explanations directly. | No separate provenance. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `slides01-shapley-game-theory.tex:55-56` | Title figure license and URL. | Provenance metadata, not redundant slide content. |
| 2 | `slides01-shapley-game-theory.tex:59-75` | Old general game-theory/prisoner's-dilemma frame. | Prisoner's-dilemma example is not fully active. |
| 3 | `slides01-shapley-game-theory.tex:448-505` | Banzhaf value frame. | Banzhaf comparison is distinct from active Shapley content. |
| 4 | `slides01-shapley-game-theory.tex:508-531` | Proof-of-axioms sketches. | Active axioms frame states axioms but does not prove them. |
| 5 | `slides01-shapley-game-theory.tex:534-541` | Linearity corollary frame. | Corollary detail is not active. |
| 6 | `slides01-shapley-game-theory.tex:545-566` | Applications frame and references. | Broader application examples and citations are distinct. |
| 7 | `slides01-shapley-game-theory.tex:121` | Figure source comment. | Provenance metadata retained near active figure. |

</details>

<details>
<summary><strong>slides02-shapley-ml.tex</strong>: 10 removed, 4 kept</summary>

Evidence scope: current file **yes**, sibling files **yes**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | `slides02-shapley-ml.tex:43-46` | Old game-to-ML transition figure frame. | `slides02-shapley-ml.tex:41-55` | Active transition frame uses the same visual and concept. | No separate provenance. |
| 2 | `slides02-shapley-ml.tex:54-55` | Old prediction-as-feature-cooperation bullets. | `slides02-shapley-ml.tex:45-50` | Active bullets restate feature interactions, feature contributions, and fair credit. | No separate provenance. |
| 3 | `slides02-shapley-ml.tex:123-146` | Old Shapley-values-in-ML frame. | `slides02-shapley-ml.tex:58-109`; `slides02-shapley-ml.tex:112-137` | Active frames cover players-as-features, value function, marginal prediction, and baseline decomposition. | No separate provenance. |
| 4 | `slides02-shapley-ml.tex:151-169` | Old definition lead-ins, interpretation, and exact formula variants. | `slides02-shapley-ml.tex:112-137` | Active definition frame includes the order formula, interpretation, and exact PD computation. | No separate provenance. |
| 5 | `slides02-shapley-ml.tex:185-198` | Old estimation-problem frame. | `slides02-shapley-ml.tex:140-154` | Active frame covers factorial complexity, marginalization cost, sampling, and accuracy/cost tradeoff. | No separate provenance. |
| 6 | `slides02-shapley-ml.tex:228-269` | Old approximation-algorithm alternatives and artificial-observation construction. | `slides02-shapley-ml.tex:159-211` | Active algorithm covers permutation sampling, background data, hybrid observations, and marginal contribution. | No separate provenance. |
| 7 | `slides02-shapley-ml.tex:279-327` | Old formula-annotation overlay comments. | `slides02-shapley-ml.tex:214-266` | Active illustration annotates the updated formula and contribution terms. | No separate provenance. |
| 8 | `slides02-shapley-ml.tex:369-406` | Old illustration explanatory overlays and obsolete image includes. | `slides02-shapley-ml.tex:252-266`; `slides02-shapley-ml.tex:269-295` | Active illustration and axioms frames cover the same value-function and marginal-contribution explanations. | Google Slides link preserved at `slides02-shapley-ml.tex:268`. |
| 9 | `slides02-shapley-ml.tex:417-434` | Old fair-attribution axioms frame. | `slides02-shapley-ml.tex:271-297` | Active frame adapts the same four axioms to prediction attributions. | No separate provenance. |
| 10 | `slides02-shapley-ml.tex:505-552` | Old bike-example bullets and advantages/disadvantages frame. | `slides02-shapley-ml.tex:337-359`; `slides02-shapley-ml.tex:362-377` | Active slides cover the same bike decomposition and pros/cons. | No separate provenance. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `slides02-shapley-ml.tex:131-136` | Commented tiny Shapley/Strumbelj citations. | Reference metadata kept. |
| 2 | `slides02-shapley-ml.tex:303-333` | Additional estimation trick frames. | Manual high-weight coalition inclusion is not active. |
| 3 | `slides02-shapley-ml.tex:268` | `data_shapley` Google Slides link. | Provenance for figure material. |
| 4 | `slides02-shapley-ml.tex:352-359` | Versions of Shapley value with Lundberg citations. | Reference-rich comparison is not fully active in this file. |

</details>

<details>
<summary><strong>slides03-shap.tex</strong>: 7 removed, 1 kept</summary>

Evidence scope: current file **yes**, sibling files **yes**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | `slides03-shap.tex:54-88` | Old Shapley-in-ML recap frame. | `slides03-shap.tex:52-71` | Active recap includes order and set definitions plus marginal-contribution interpretation. | No separate provenance. |
| 2 | `slides03-shap.tex:94-138` | Old inline recap question, procedure, notes, and order table. | `slides03-shap.tex:52-71` | Active bullets cover coalition construction, marginalization, and averaging. | No separate provenance. |
| 3 | `slides03-shap.tex:142-222` | Old bike-data exact-Shapley example and duplicate equation. | `slides03-shap.tex:74-94` | Active example keeps the same values, table, and hum/temp/ws Shapley results. | No separate provenance. |
| 4 | `slides03-shap.tex:225-318` | Old From-Shapley-to-SHAP frame and additive-decomposition notes. | `slides03-shap.tex:97-135` | Active frame covers interpretation, additive decomposition, baseline, and SHAP motivation. | No separate provenance. |
| 5 | `slides03-shap.tex:323-452` | Old SHAP definition and animated surrogate explanation. | `slides03-shap.tex:138-162`; `slides03-shap.tex:165-205` | Active SHAP framework frames cover binary coalition inputs, surrogate model, baseline, and feature attributions. | Citation already active via `\furtherreading{LUNDBERG2017}`. |
| 6 | `slides03-shap.tex:481-533` | Old SHAP framework alternatives. | `slides03-shap.tex:138-162`; `slides03-shap.tex:165-205` | Active alternatives cover the same simplified input and coalition semantics. | Citation already active in frame title. |
| 7 | `slides03-shap.tex:536-569` | Old hidden first overlay with formula and coalition table. | `slides03-shap.tex:165-205` | Active SHAP surrogate frame now explains the formula and coalition vector role. | No separate provenance. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `slides03-shap.tex:210-239` | Old 4-feature `exSHAP` example. | Specific example is not clearly duplicated by active content. |

</details>

<details>
<summary><strong>slides04-kernel-shap.tex</strong>: 7 removed, 2 kept</summary>

Evidence scope: current file **yes**, sibling files **yes**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | `slides04-kernel-shap.tex:98-129` | Old detailed Kernel SHAP five-step frame. | `slides04-kernel-shap.tex:68-94` | Active overview frame lists the same five steps. | No separate provenance. |
| 2 | `slides04-kernel-shap.tex:257-262` | Old Monte Carlo average display. | `slides04-kernel-shap.tex:220-227` | Active Step 2 frame states the same Monte Carlo approximation formula. | No separate provenance. |
| 3 | `slides04-kernel-shap.tex:288-396` | Old Step 2 mapping and prediction frames. | `slides04-kernel-shap.tex:98-145`; `slides04-kernel-shap.tex:148-201` | Active Step 1/2 frames include coalition tables, mapping, background sample values, and predictions. | No separate provenance. |
| 4 | `slides04-kernel-shap.tex:401-465`; `slides04-kernel-shap.tex:496-497` | Old Step 3 intuition, duplicate kernel-weight notes, and finite/infinite-weight comments. | `slides04-kernel-shap.tex:248-312`; `slides04-kernel-shap.tex:316-346` | Active Step 3 frames cover high weights for small/large coalitions, kernel formula, and infinite boundary weights. | No separate provenance. |
| 5 | `slides04-kernel-shap.tex:518-581` | Old coalition-mapping frame. | `slides04-kernel-shap.tex:148-201`; `slides04-kernel-shap.tex:204-241` | Active Step 2 frames cover binary-to-data mapping and background replacement. | No separate provenance. |
| 6 | `slides04-kernel-shap.tex:584-621` | Old weighted-linear-model frame. | `slides04-kernel-shap.tex:353-414` | Active Step 4 frame includes WLS objective, constraints, numeric surrogate, and table. | No separate provenance. |
| 7 | `slides04-kernel-shap.tex:710-775` | Old marginal-contribution mapping frame. | `slides04-kernel-shap.tex:353-414`; `slides04-kernel-shap.tex:417-425` | Active Step 4/5 frames cover surrogate coefficients, mapping, and returned SHAP values. | No separate provenance. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `slides04-kernel-shap.tex:39-66` | Old 4-feature `exSHAP` example. | Specific example is not clearly duplicated by active Kernel SHAP steps. |
| 2 | `slides04-kernel-shap.tex:303-310` | Limited-budget high-weight coalition sampling comments. | Sampling-budget strategy is more detailed than active content. |

</details>

<details>
<summary><strong>slides05-shap-global.tex</strong>: 3 removed, 2 kept</summary>

Evidence scope: current file **yes**, sibling files **no**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| 1 | `slides05-shap-global.tex:103-145` | Old dependence-plot frame. | `slides05-shap-global.tex:103-130` | Active frame explains x/y axes, marginal effect, high-temperature behavior, and season interaction. | No separate provenance. |
| 2 | `slides05-shap-global.tex:187-190` | Old duplicate advantages bullets. | `slides05-shap-global.tex:134-143` | Active discussion covers local accuracy, global diagnostics, TreeSHAP, and additive unification. | No separate provenance. |
| 3 | `slides05-shap-global.tex:199-204` | Old duplicate disadvantages bullets. | `slides05-shap-global.tex:147-149` | Active discussion covers KernelSHAP inefficiency and feature-dependence limitations. | No separate provenance. |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| 1 | `slides05-shap-global.tex:150` | TreeSHAP can produce unintuitive attributions. | Distinct caution not active. |
| 2 | `slides05-shap-global.tex:151` | SHAP can be used for misleading interpretations. | Distinct adversarial-use caveat not active. |

</details>

<details>
<summary><strong>slides06-resources-and-software.tex</strong>: 0 removed, 0 kept</summary>

Evidence scope: current file **yes**, sibling files **no**

### Removed

| # | Removed from | Removed content | Active duplicate evidence | Justification | Provenance/reference |
|---|---|---|---|---|---|
| - | - | No redundant commented-out slide content found. | - | - | - |

### Kept

| # | Location | Kept content | Reason |
|---|---|---|---|
| - | - | No notable commented-out slide candidates. | - |

</details>
